### PR TITLE
Fix CLI config flag

### DIFF
--- a/huey/cli.py
+++ b/huey/cli.py
@@ -3,20 +3,34 @@
 import argparse
 from .main import main as huey_main
 
+
 def parse_arguments():
     """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(description='Huey Project Command-Line Interface')
-    parser.add_argument('--config', type=str, help='Path to configuration file', default='config.yaml')
-    parser.add_argument('--verbose', action='store_true', help='Enable verbose output')
+    parser = argparse.ArgumentParser(
+        description='Huey Project Command-Line Interface'
+    )
+    parser.add_argument(
+        '--config',
+        type=str,
+        help='Path to configuration file',
+        default='config.yaml'
+    )
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Enable verbose output'
+    )
     return parser.parse_args()
+
 
 def run_cli():
     """Run the CLI application."""
     args = parse_arguments()
     if args.verbose:
         print("Verbose mode enabled.")
-    # Pass the config file path to main (modify main to accept config path if necessary)
-    huey_main()
+    # Pass the config file path to main
+    huey_main(config_file=args.config)
+
 
 if __name__ == '__main__':
     run_cli()

--- a/huey/main.py
+++ b/huey/main.py
@@ -5,11 +5,17 @@ from .utils import setup_logging, calculate_sum, validate_input
 from .config import load_config
 from .exceptions import InvalidInputError
 
-def main():
-    """Main function for the Huey project."""
+def main(config_file: str = "config.yaml"):
+    """Main function for the Huey project.
+
+    Parameters
+    ----------
+    config_file: str, optional
+        Path to the configuration YAML file. Defaults to ``"config.yaml"``.
+    """
     try:
         # Load configuration
-        config = load_config()
+        config = load_config(config_file)
         # Set up logging with configuration
         setup_logging(config)
         logging.info("Huey application started.")


### PR DESCRIPTION
## Summary
- allow passing a config path to `huey.main`
- plumb the `--config` CLI option through to `main`

## Testing
- `pytest tests/test_main.py::TestMain::test_main_runs -q`
- `pytest tests/test_utils.py::TestUtils::test_calculate_sum -q`
- `pytest tests/test_utils.py tests/test_main.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68409b5b8dc0832b826ca4736311faed