### PR TITLE
Fix python version and setup paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,15 @@
 FROM debian:trixie
 
 # Install system dependencies and Python 3.12
-RUN apt update && apt install -y \
-    python3.12 \
-    python3.12-venv \
-    python3.12-dev \
-    python3-pip \
-    build-essential \
+RUN apt update && apt install -y 
+    python3.12 
+    python3.12-venv 
+    python3.12-dev 
+    python3-pip 
+    build-essential 
+    portaudio19-dev 
+    libasound2 
+    libasound2-dev 
     && rm -rf /var/lib/apt/lists/*
 
 # Set environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       args:
-        PYTHON_VERSION: "3.11"
+        PYTHON_VERSION: "3.12"
         DEBIAN_VERSION: "trixie"
     volumes:
       - .:/workspace

--- a/py/setup.py
+++ b/py/setup.py
@@ -32,7 +32,9 @@ def mini_setup():
     clear_screen()
     print("[GenCore]: Running 'mini' setup...")
     subprocess.run(["python", "-m", "pip", "install", "--upgrade", "pip"])
-    subprocess.run(["python", "-m", "pip", "install", "python3.11-slim", "python3.11-venv"])
+    subprocess.run(["apt-get", "update"])
+    subprocess.run(["apt-get", "install", "-y", "portaudio19-dev", "libasound2", "libasound2-dev"])
+    subprocess.run(["python", "-m", "pip", "install", "python3.12-slim", "python3.12-venv"])
     print("[GenCore]: 'Mini' setup completed.")
 
 def cleanup_files():

--- a/repo/pygpt-MHP/.readthedocs.yaml
+++ b/repo/pygpt-MHP/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3489,3 +3489,4 @@ youtube-transcript-api==0.6.3 ; python_version >= "3.10" and python_version < "3
 zipp==3.21.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4 \
     --hash=sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931
+pygpt-net>=0.1.0

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,13 @@ except FileNotFoundError:
 
 setup(
     name='MonkeyHeadProject',
-    version='1.0.0',
+    version='1.0.1',
     description='A project integrating diverse functionalities including ML, web frameworks, and more.',
     long_description=long_description,
     long_description_content_type='text/markdown',
     author='Dylan L.R. Pollock',
     author_email='admin@dlrp.ca',
-    url='https://github.com/DylanLRPollokc/Monkey-Head-Project',
+    url='https://github.com/DylanLRPollock/Monkey-Head-Project',
     packages=find_packages(),
     install_requires=[
         'requests==2.32.3',
@@ -64,9 +64,9 @@ setup(
             'pytest==7.4.0'
         ]
     },
-    python_requires='>=3.11',
+    python_requires='>=3.12',
     classifiers=[
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: Microsoft :: Windows',
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -74,7 +74,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'monkeyhead=monkeyhead.cli:main'
+            'monkeyhead=huey.cli:run_cli'
         ]
     },
 )


### PR DESCRIPTION
## Summary
- rename `dockerfile` to `Dockerfile`
- use Python 3.12 in docker compose
- install Python 3.12 slim packages in setup helper
- install audio build deps in Dockerfile and setup helper
- update supported Python version in setup.py and entry point
- update docs build config
- add pygpt-net to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6841021c6b0c832bb39d6e57f0aa758f