### PR TITLE
Add cross-platform installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ pip install -r requirements.txt
 python py/main.py
 ```
 
+You can also use the provided cross-platform installer, which automatically
+detects your operating system and invokes the appropriate setup script:
+
+```bash
+python installer.py
+```
+
 ---
 
 ## 🔬 Test Hardware

--- a/installer.py
+++ b/installer.py
@@ -1,0 +1,29 @@
+import os
+import platform
+import subprocess
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+LINUX_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Debian13", "install.sh")
+WINDOWS_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Windows11", "01-FULL.bat")
+
+
+def run_installer():
+    system = platform.system()
+    try:
+        if system == "Linux":
+            subprocess.run(["bash", LINUX_INSTALL], check=True)
+        elif system == "Windows":
+            subprocess.run(["cmd", "/c", WINDOWS_INSTALL], check=True)
+        else:
+            print(f"Unsupported operating system: {system}")
+            return 1
+    except subprocess.CalledProcessError as exc:
+        print(f"Installer failed with return code {exc.returncode}")
+        return exc.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_installer())


### PR DESCRIPTION
## Summary
- add `installer.py` to run the correct setup script on Linux or Windows
- document the installer usage in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_68410aa10270832b933343745ff6dbaf