### PR TITLE
Add macOS setup script and installer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ detects your operating system and invokes the appropriate setup script:
 python installer.py
 ```
 
+### macOS Installation
+
+Running the installer on macOS executes `setup/macOS/install.sh`. This script
+ensures Homebrew is available, installs Git, Python 3, Docker, and sets up the
+project's Python virtual environment automatically.
+
 ### Windows 10 & 11 Installation
 
 Ensure that **Python 3** is available on your system (download from
@@ -118,8 +124,9 @@ python installer.py
 ```
 
 This launches `setup/Windows11/01-FULL.bat`, which installs Chocolatey, Git,
-Docker Desktop, and other required tools. The batch script supports both Windows
-10 and Windows 11.
+Docker Desktop, and other required tools on Windows. On macOS the installer
+invokes `setup/macOS/install.sh` to configure Homebrew and the Python
+environment. The batch script supports both Windows 10 and Windows 11.
 
 ### Directory Structure
 

--- a/installer.py
+++ b/installer.py
@@ -6,6 +6,7 @@ import sys
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 LINUX_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Debian13", "install.sh")
+MAC_INSTALL = os.path.join(SCRIPT_DIR, "setup", "macOS", "install.sh")
 WINDOWS_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Windows11", "01-FULL.bat")
 
 
@@ -14,6 +15,8 @@ def run_installer():
     try:
         if system == "Linux":
             subprocess.run(["bash", LINUX_INSTALL], check=True)
+        elif system == "Darwin":
+            subprocess.run(["bash", MAC_INSTALL], check=True)
         elif system == "Windows":
             subprocess.run(["cmd", "/c", WINDOWS_INSTALL], check=True)
         else:

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+VENV_DIR="venv"
+
+function command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+function install_homebrew() {
+    if ! command_exists brew; then
+        echo "Homebrew not found. Installing..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    else
+        echo "Homebrew already installed."
+    fi
+}
+
+function install_packages() {
+    echo "Installing required packages..."
+    brew update
+    brew install git python docker || true
+}
+
+function setup_python_env() {
+    echo "Creating virtual environment..."
+    python3 -m venv "$VENV_DIR"
+    echo "Activating virtual environment..."
+    source "$VENV_DIR/bin/activate"
+    echo "Upgrading pip..."
+    pip install --upgrade pip
+    echo "Installing dependencies..."
+    pip install -r requirements.txt
+}
+
+install_homebrew
+install_packages
+setup_python_env
+
+echo "Installation completed successfully."


### PR DESCRIPTION
## Summary
- add a macOS installation script under `setup/macOS`
- extend `installer.py` to run the new script on macOS
- document macOS installation and update installer description in README

## Testing
- `pip install pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cd8edf44832bb4d533efeb0efb0a