### PR TITLE
Fix missing dependency for yaml parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'boto3==1.36.0',
         'google-auth==2.37.0',
         'elasticsearch==8.17.0',
+        'pyyaml==6.0.2',
         'pygpt-net>=0.1.0'
     ],
     extras_require={


### PR DESCRIPTION
## Summary
- add `pyyaml` to `setup.py` so `huey.config` can load YAML files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f766daa4832ba7f9819779fe12f5