### PR TITLE
Implement TODOs and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Create one with `python -m venv venv` and install dependencies using
 When adding new modules, format the code with `black` and run
 `flake8` and `pytest` before opening a pull request.
 
+### Recent Updates
+
+- Preset placeholders now show the preset name instead of the file ID for better readability.
+
 ---
 
 ## 🔬 Test Hardware

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 We're thrilled you're interested in contributing to the Monkey Head Project! This document provides comprehensive guidelines for contributing to our groundbreaking AI/OS initiative. Your contributions are invaluable to us, and we appreciate your commitment to making the Monkey Head Project better.
 
 ## Code of Conduct
-Please review our [Code of Conduct](link_to_code_of_conduct), which outlines our expectations for participant behavior. By participating, you are expected to uphold this code to ensure a welcoming and productive environment for everyone.
+Please review our [Code of Conduct](https://github.com/DylanLRPollock/Monkey-Head-Project/blob/main/CODE_OF_CONDUCT.md), which outlines our expectations for participant behavior. By participating, you are expected to uphold this code to ensure a welcoming and productive environment for everyone.
 
 ## How to Contribute
 We welcome various types of contributions, including coding, documentation improvements, bug reports, and feature suggestions. Here’s how you can get started:

--- a/repo/pygpt-MHP/src/pygpt_net/controller/config/placeholder.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/config/placeholder.py
@@ -252,10 +252,11 @@ class Placeholder:
         presets = self.window.core.presets.get_all()
         data = []
         data.append({'_': '---'})
-        for id in presets:
+        for id, preset in presets.items():
             if id.startswith("current."):  # ignore "current" preset
                 continue
-            data.append({id: id})  # TODO: name
+            name = getattr(preset, "name", id)
+            data.append({id: name})
         return data
 
     def get_models(self) -> List[Dict[str, str]]:

--- a/repo/pygpt-MHP/src/pygpt_net/controller/ctx/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/ctx/__init__.py
@@ -705,12 +705,15 @@ class Ctx:
 
     def selection_change(self):
         """Select ctx on list change"""
-        # TODO: implement this
-        # idx = self.window.ui.nodes['ctx.list'].currentIndex().row()
-        # self.select(idx)
+        if self.context_change_locked():
+            self.window.ui.nodes['ctx.list'].lockSelection()
+            return
+
         selected_idx = self.window.ui.nodes['ctx.list'].currentIndex()
         if selected_idx.isValid():
-            id = self.window.core.ctx.get_id_by_idx(selected_idx.row())
+            ctx_id = self.window.core.ctx.get_id_by_idx(selected_idx.row())
+            self.select_by_id(ctx_id)
+
         self.window.ui.nodes['ctx.list'].lockSelection()
 
     def search_string_change(self, text: str):

--- a/repo/pygpt-MHP/src/pygpt_net/controller/files/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/files/__init__.py
@@ -36,8 +36,13 @@ class Files:
 
     def selection_change(self):
         """Select on list change"""
-        # TODO: implement this
-        pass
+        explorer = self.window.ui.nodes.get('output_files')
+        if explorer is None:
+            return
+        indexes = explorer.treeView.selectedIndexes()
+        if indexes:
+            path = explorer.model.filePath(indexes[0])
+            explorer.path_label.setText(path)
 
     def delete_recursive(
             self,

--- a/repo/pygpt-MHP/src/pygpt_net/controller/presets/editor.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/presets/editor.py
@@ -184,8 +184,18 @@ class Editor:
 
     def show_hide_by_mode(self):
         """Show or hide fields by mode"""
-        # TODO: implement this!
-        return
+        mode = self.window.core.config.get('mode')
+        for key in self.options:
+            visible = True
+            if mode in self.hidden_by_mode and key in self.hidden_by_mode[mode]:
+                visible = False
+
+            if key in self.window.ui.config[self.id]:
+                self.window.ui.config[self.id][key].setVisible(visible)
+
+            label = 'preset.' + key + '.label'
+            if label in self.window.ui.nodes:
+                self.window.ui.nodes[label].setVisible(visible)
         mode = self.window.core.config.get('mode')
         for key in self.options:
             if mode in self.hidden_by_mode:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -14,6 +14,14 @@ class TestMemory(unittest.TestCase):
         self.assertEqual(history[1]["role"], "assistant")
         self.assertEqual(history[1]["content"], "hello")
 
+    def test_get_returns_copy(self):
+        mem = Memory()
+        mem.add_user_message("hi")
+        history = mem.get_messages()
+        history.append({"role": "assistant", "content": "changed"})
+        # internal history should not change
+        self.assertEqual(len(mem.get_messages()), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,51 @@
+import unittest
+import os
+import sys
+import importlib.util
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+MODULE_PATH = os.path.join(
+    ROOT,
+    'repo',
+    'pygpt-MHP',
+    'src',
+    'pygpt_net',
+    'controller',
+    'config',
+    'placeholder.py',
+)
+
+sys.path.append(os.path.join(ROOT, 'repo', 'pygpt-MHP', 'src'))
+
+spec = importlib.util.spec_from_file_location('placeholder_module', MODULE_PATH)
+placeholder_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(placeholder_module)
+Placeholder = placeholder_module.Placeholder
+from pygpt_net.item.preset import PresetItem
+
+class DummyWindow:
+    def __init__(self, presets):
+        class DummyPresets:
+            def __init__(self, data):
+                self._data = data
+            def get_all(self):
+                return self._data
+        class DummyCore:
+            def __init__(self, presets):
+                self.presets = DummyPresets(presets)
+        self.core = DummyCore(presets)
+
+class TestPlaceholder(unittest.TestCase):
+    def test_get_presets_returns_names(self):
+        preset = PresetItem()
+        preset.name = "Example"
+        preset.filename = "example.json"
+        presets = {preset.filename: preset}
+        placeholder = Placeholder(DummyWindow(presets))
+        result = placeholder.get_presets()
+        self.assertIn({"_": "---"}, result)
+        self.assertIn({"example.json": "Example"}, result)
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- display preset names in placeholders
- implement context list selection change
- update files controller to show selected path
- show/hide preset editor fields based on mode
- document recent updates and fix contributing link
- add regression tests for memory and placeholders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f7252988832b908a1533b88cfc65