### PR TITLE
Update pygpt-MHP version

### DIFF
--- a/repo/pygpt-MHP/CHANGELOG.md
+++ b/repo/pygpt-MHP/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## 2.5.10 (2025-03-06)
+
+- Added a new model: Claude 3.7 Sonnet.
+- Fixed the context switch issue when the column changed and the tab is not a chat tab.
+- LlamaIndex upgraded to 0.12.22.
+- LlamaIndex LLMs upgraded to recent versions.
+
+## 2.5.9 (2025-03-05)
+
+- Improved formatting of HTML code in the output.
+- Disabled automatic indentation parsing as code blocks.
+- Disabled automatic scrolling of the notepad when opening a tab.
+
 ## 2.5.8 (2025-03-02)
 
 - Added a new mode: Research (Perplexity) powered by: https://perplexity.ai - beta.

--- a/repo/pygpt-MHP/PyGPT_Linux_PAD_File.xml
+++ b/repo/pygpt-MHP/PyGPT_Linux_PAD_File.xml
@@ -2,13 +2,13 @@
 <PAD>
 <PAD_Version>4.0</PAD_Version>
 <Program_Name>PyGPT - Desktop AI Assistant</Program_Name>
-<Program_Version>2.5.8</Program_Version>
+<Program_Version>2.5.10</Program_Version>
 <Program_Release_Month>03</Program_Release_Month>
-<Program_Release_Day>02</Program_Release_Day>
+<Program_Release_Day>06</Program_Release_Day>
 <Program_Release_Year>2025</Program_Release_Year>
 <Program_Cost_Dollars>0</Program_Cost_Dollars>
 <Program_Type>Open Source</Program_Type>
-<Download_URL>https://pygpt.net/download/2.5.8/pygpt-2.5.8.zip</Download_URL>
+<Download_URL>https://pygpt.net/download/2.5.10/pygpt-2.5.10.zip</Download_URL>
 <Application_OS_Support>Linux 64 bit</Application_OS_Support>
 <Program_Specific_Category>Generative AI Tools</Program_Specific_Category>
 <Program_Language>English, Polish</Program_Language>

--- a/repo/pygpt-MHP/PyGPT_Windows_PAD_File.xml
+++ b/repo/pygpt-MHP/PyGPT_Windows_PAD_File.xml
@@ -2,13 +2,13 @@
 <PAD>
 <PAD_Version>4.0</PAD_Version>
 <Program_Name>PyGPT - Desktop AI Assistant</Program_Name>
-<Program_Version>2.5.8</Program_Version>
+<Program_Version>2.5.10</Program_Version>
 <Program_Release_Month>03</Program_Release_Month>
-<Program_Release_Day>02</Program_Release_Day>
+<Program_Release_Day>06</Program_Release_Day>
 <Program_Release_Year>2025</Program_Release_Year>
 <Program_Cost_Dollars>0</Program_Cost_Dollars>
 <Program_Type>Open Source</Program_Type>
-<Download_URL>https://pygpt.net/download/2.5.8/pygpt-2.5.8.msi</Download_URL>
+<Download_URL>https://pygpt.net/download/2.5.10/pygpt-2.5.10.msi</Download_URL>
 <Application_OS_Support>Windows 10 64 bit, Windows 11 64 bit</Application_OS_Support>
 <Program_Specific_Category>Generative AI Tools</Program_Specific_Category>
 <Program_Language>English, Polish</Program_Language>

--- a/repo/pygpt-MHP/README.md
+++ b/repo/pygpt-MHP/README.md
@@ -2,7 +2,7 @@
 
 [![pygpt](https://snapcraft.io/pygpt/badge.svg)](https://snapcraft.io/pygpt)
 
-Release: **2.5.8** | build: **2025.03.02** | Python: **>=3.10, <3.13**
+Release: **2.5.10** | build: **2025.03.06** | Python: **>=3.10, <3.13**
 
 > Official website: https://pygpt.net | Documentation: https://pygpt.readthedocs.io
 > 
@@ -3971,6 +3971,19 @@ may consume additional tokens that are not displayed in the main window.
 # CHANGELOG
 
 ## Recent changes:
+
+**2.5.10 (2025-03-06)**
+
+- Added a new model: Claude 3.7 Sonnet.
+- Fixed the context switch issue when the column changed and the tab is not a chat tab.
+- LlamaIndex upgraded to 0.12.22.
+- LlamaIndex LLMs upgraded to recent versions.
+
+**2.5.9 (2025-03-05)**
+
+- Improved formatting of HTML code in the output.
+- Disabled automatic indentation parsing as code blocks.
+- Disabled automatic scrolling of the notepad when opening a tab.
 
 **2.5.8 (2025-03-02)**
 

--- a/repo/pygpt-MHP/pyproject.toml
+++ b/repo/pygpt-MHP/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pygpt-net"
-version = "2.5.8"
+version = "2.5.10"
 description = "Desktop AI Assistant powered by models: OpenAI o1, GPT-4o, GPT-4, GPT-4 Vision, GPT-3.5, DALL-E 3, Llama 3, Mistral, Gemini, Claude, DeepSeek, Bielik, and other models supported by Langchain, Llama Index, and Ollama. Features include chatbot, text completion, image generation, vision analysis, speech-to-text, internet access, file handling, command execution and more."
 authors = ["Marcin Szczyglinski <info@pygpt.net>"]
 license = "MIT"

--- a/repo/pygpt-MHP/version.rc
+++ b/repo/pygpt-MHP/version.rc
@@ -16,12 +16,12 @@ StringFileInfo(
     u'040904B0',
     [StringStruct(u'CompanyName', u'pygpt.net'),
     StringStruct(u'FileDescription', u'Desktop AI Assistant powered by o1, GPT-4, GPT-3 and DALL-E 3: assistant, chatbot, text completion, image generation, vision and more.'),
-    StringStruct(u'FileVersion', u'2.5.8'),
+    StringStruct(u'FileVersion', u'2.5.10'),
     StringStruct(u'InternalName', u'pygpt'),
     StringStruct(u'LegalCopyright', u'(c) 2025 pygpt.net, Marcin Szczygliński'),
     StringStruct(u'OriginalFilename', u'pygpt.exe'),
     StringStruct(u'ProductName', u'pygpt.net'),
-    StringStruct(u'ProductVersion', u'2.5.8')])
+    StringStruct(u'ProductVersion', u'2.5.10')])
   ]), 
 VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
   ]


### PR DESCRIPTION
## Summary
- update pygpt-MHP metadata to release 2.5.10
- bump changelog and README entries
- adjust PAD files and version resources

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841fc3dfa34832bafbcd9b851ee648e