### PR TITLE
Ensure repo submodules initialized by installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,14 @@ python3 -m venv venv
 source venv/bin/activate  # Linux/macOS
 venv\Scripts\activate     # Windows
 pip install -r requirements.txt
+git submodule update --init --recursive
+pip install -e repo/pygpt-MHP
 python src/main.py
 ```
 
 ### Submodule
 
-This project uses the [pygpt-MHP](https://github.com/DylanLRPollock/pygpt-MHP) submodule located in `repo/pygpt-MHP`. It provides advanced GPT-based capabilities leveraged by GenCore. Clone the repository with `--recurse-submodules` or run `git submodule update --init --recursive` after cloning to ensure it is available.
+This project uses the [pygpt-MHP](https://github.com/DylanLRPollock/pygpt-MHP) submodule located in `repo/pygpt-MHP`. It provides advanced GPT-based capabilities leveraged by GenCore. Clone the repository with `--recurse-submodules` or run `git submodule update --init --recursive` after cloning to ensure it is available. The installer performs this step automatically and installs the package with `pip install -e repo/pygpt-MHP`.
 
 ### Running Tests
 
@@ -108,7 +110,8 @@ pytest tests
 ```
 
 You can also use the provided cross-platform installer, which automatically
-detects your operating system and invokes the appropriate setup script:
+initializes git submodules, installs the `pygpt-MHP` package, and detects your
+operating system to invoke the appropriate setup script:
 
 ```bash
 python installer.py

--- a/installer.py
+++ b/installer.py
@@ -10,9 +10,19 @@ MAC_INSTALL = os.path.join(SCRIPT_DIR, "setup", "macOS", "install.sh")
 WINDOWS_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Windows11", "01-FULL.bat")
 
 
+def update_submodules() -> None:
+    """Ensure git submodules are initialized."""
+    try:
+        subprocess.run(["git", "submodule", "update", "--init", "--recursive"], check=True)
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to update submodules: {exc.returncode}")
+        raise
+
+
 def run_installer():
     system = platform.system()
     try:
+        update_submodules()
         if system == "Linux":
             subprocess.run(["bash", LINUX_INSTALL], check=True)
         elif system == "Darwin":

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -41,12 +41,20 @@ function setup_python_env {
     pip install --upgrade pip || error_exit "Failed to upgrade pip."
     echo "Installing dependencies..."
     pip install -r requirements.txt || error_exit "Failed to install dependencies."
+    echo "Installing local pygpt-MHP package..."
+    pip install -e repo/pygpt-MHP || error_exit "Failed to install pygpt-MHP."
+}
+
+function update_submodules {
+    echo "Initializing git submodules..."
+    git submodule update --init --recursive || error_exit "Failed to update submodules."
 }
 
 ensure_root
 update_system
 install_common_tools
 install_additional_tools
+update_submodules
 setup_python_env
 
 echo "Installation completed successfully."

--- a/setup/Windows11/01-FULL.bat
+++ b/setup/Windows11/01-FULL.bat
@@ -103,20 +103,24 @@ goto :eof
 echo Cloning repository...
 if not exist "%USERPROFILE%\Source" mkdir "%USERPROFILE%\Source"
 cd "%USERPROFILE%\Source"
-git clone https://github.com/your/repo.git
+git clone --recurse-submodules https://github.com/DylanLRPollock/Monkey-Head-Project.git
 call :checkError "Git Clone"
+cd Monkey-Head-Project
+git submodule update --init --recursive
 goto :eof
 
 :: Function to set up Python environment
 :setupPythonEnv
 echo Setting up Python environment...
-cd "%USERPROFILE%\Source\repo"
+cd "%USERPROFILE%\Source\Monkey-Head-Project"
 python -m venv venv
 call :checkError "Python Virtual Environment Setup"
 venv\Scripts\activate
 call :checkError "Activate Python Virtual Environment"
 pip install -r requirements.txt
 call :checkError "Install Python Requirements"
+pip install -e repo\pygpt-MHP
+call :checkError "Install pygpt-MHP"
 goto :eof
 
 :: Function to configure Git

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -32,10 +32,18 @@ function setup_python_env() {
     pip install --upgrade pip
     echo "Installing dependencies..."
     pip install -r requirements.txt
+    echo "Installing local pygpt-MHP package..."
+    pip install -e repo/pygpt-MHP
+}
+
+function update_submodules() {
+    echo "Initializing git submodules..."
+    git submodule update --init --recursive
 }
 
 install_homebrew
 install_packages
+update_submodules
 setup_python_env
 
 echo "Installation completed successfully."


### PR DESCRIPTION
## Summary
- add git submodule initialization and local package install to install scripts
- initialize submodules automatically in `installer.py`
- document manual setup of submodules and package install
- clarify installer behavior in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6842194e1eb4832b81a01dbd64d71cab