### PR TITLE
Fix missing imports for flake8

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,3 +1,7 @@
+from .config_manager import ConfigManager
+from .file_manager import FileManager
+
+
 class CLI:
     def __init__(self):
         self.config_manager = ConfigManager("config.json")

--- a/src/core/system_checks.py
+++ b/src/core/system_checks.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import subprocess
 

--- a/src/file_manager.py
+++ b/src/file_manager.py
@@ -1,5 +1,7 @@
 import shutil
 
+from .error_handler import ErrorHandler
+
 
 class FileManager:
     def move_file(self, src, dst):

--- a/src/services/container_management.py
+++ b/src/services/container_management.py
@@ -1,6 +1,8 @@
 import logging
+import os
 import subprocess
-from system_checks import check_error
+
+from core.system_checks import check_error
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/formatter_temp.py
+++ b/src/utils/formatter_temp.py
@@ -3,6 +3,7 @@ import sys
 import glob
 import atexit
 import logging
+import json
 from concurrent.futures import ThreadPoolExecutor
 from nltk.tokenize import sent_tokenize
 


### PR DESCRIPTION
## Summary
- add missing imports for CLI module
- register ErrorHandler import in FileManager
- fix container management imports
- include json dependency in formatter
- remove unused import from system checks

## Testing
- `pytest -q`
- `flake8 src tests`

------
https://chatgpt.com/codex/tasks/task_e_68421bb5c7b8832b96e4d563d3efe007