### PR TITLE
Add Tkinter license acceptance GUI

### DIFF
--- a/src/license_gui.py
+++ b/src/license_gui.py
@@ -1,0 +1,50 @@
+import tkinter as tk
+from pathlib import Path
+from tkinter import messagebox, scrolledtext
+
+from .config_manager import ConfigManager
+
+
+def accept_license(config_path: str | Path) -> None:
+    """Set the ``license.accepted`` flag in the given config file."""
+    manager = ConfigManager(str(config_path))
+    manager.set_setting("license.accepted", True)
+
+
+def show_license_gui(config_path: str | Path = "config/pygpt_net/config.json") -> None:
+    """Display a simple license agreement dialog."""
+    manager = ConfigManager(str(config_path))
+    if manager.get_setting("license.accepted"):
+        return
+
+    root = tk.Tk()
+    root.title("License Agreement")
+
+    text = scrolledtext.ScrolledText(root, width=80, height=20, wrap=tk.WORD)
+    try:
+        license_text = Path("docs/LICENSE").read_text(encoding="utf-8")
+    except Exception:
+        license_text = "License file not found."
+    text.insert(tk.END, license_text)
+    text.config(state=tk.DISABLED)
+    text.pack(padx=10, pady=10)
+
+    def on_accept() -> None:
+        accept_license(config_path)
+        messagebox.showinfo("License", "License accepted")
+        root.destroy()
+
+    def on_decline() -> None:
+        messagebox.showwarning("License", "You must accept the license to proceed")
+        root.destroy()
+
+    btn_frame = tk.Frame(root)
+    btn_frame.pack(pady=10)
+    tk.Button(btn_frame, text="Accept", command=on_accept).pack(side=tk.LEFT, padx=5)
+    tk.Button(btn_frame, text="Decline", command=on_decline).pack(side=tk.LEFT, padx=5)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    show_license_gui()

--- a/tests/test_license_gui.py
+++ b/tests/test_license_gui.py
@@ -1,0 +1,26 @@
+import json
+import os
+import unittest
+from pathlib import Path
+
+from src.license_gui import accept_license
+
+
+class TestLicenseGui(unittest.TestCase):
+    def test_accept_license_updates_config(self):
+        temp_path = Path("/tmp/test_config.json")
+        data = {"license.accepted": False}
+        with temp_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        accept_license(temp_path)
+
+        with temp_path.open(encoding="utf-8") as f:
+            updated = json.load(f)
+
+        self.assertTrue(updated.get("license.accepted"))
+        os.remove(temp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create `license_gui` module for showing a simple license dialog using Tkinter
- add unit test verifying license acceptance updates config

## Testing
- `flake8 huey tests src/license_gui.py`
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_684224fd5cf4832b87899d9617d88c04