### PR TITLE
Add container management scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ operating system to invoke the appropriate setup script:
 python installer.py
 ```
 
+### Docker and Kubernetes Utilities
+
+The `scripts/` directory contains helper scripts for container management:
+
+```bash
+./scripts/docker_setup.sh    # build image and start compose stack
+./scripts/docker_cleanup.sh  # stop containers and prune resources
+./scripts/k8s_setup.sh       # apply manifests in k8s/
+./scripts/k8s_cleanup.sh     # remove Kubernetes resources
+```
+
+
 ### macOS Installation
 
 Running the installer on macOS executes `setup/macOS/install.sh`. This script

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monkey-head
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: monkey-head
+  template:
+    metadata:
+      labels:
+        app: monkey-head
+    spec:
+      containers:
+      - name: monkey-head
+        image: monkey-head-project:latest
+        ports:
+        - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monkey-head
+spec:
+  selector:
+    app: monkey-head
+  ports:
+  - port: 8000
+    targetPort: 8000
+  type: ClusterIP

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: monkey-head
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: monkey-head
+  template:
+    metadata:
+      labels:
+        app: monkey-head
+    spec:
+      containers:
+      - name: monkey-head
+        image: monkey-head-project:latest
+        ports:
+        - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: monkey-head
+spec:
+  selector:
+    app: monkey-head
+  ports:
+  - port: 8000
+    targetPort: 8000
+  type: ClusterIP

--- a/scripts/docker_cleanup.sh
+++ b/scripts/docker_cleanup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Stop and remove compose services
+if [ -f docker-compose.yml ]; then
+    docker-compose down
+fi
+
+# Remove dangling images
+docker image prune -f
+# Remove unused volumes
+docker volume prune -f

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Build Docker image
+docker build -t monkey-head-project:latest .
+
+# Start services using docker-compose
+if [ -f docker-compose.yml ]; then
+    docker-compose up -d
+fi
+
+docker ps

--- a/scripts/k8s_cleanup.sh
+++ b/scripts/k8s_cleanup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+K8S_DIR="k8s"
+
+if [ ! -d "$K8S_DIR" ]; then
+    echo "Kubernetes manifests not found in $K8S_DIR" >&2
+    exit 1
+fi
+
+kubectl delete -f "$K8S_DIR"/ || true

--- a/scripts/k8s_setup.sh
+++ b/scripts/k8s_setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+K8S_DIR="k8s"
+
+if [ ! -d "$K8S_DIR" ]; then
+    echo "Kubernetes manifests not found in $K8S_DIR" >&2
+    exit 1
+fi
+
+kubectl apply -f "$K8S_DIR"/
+
+kubectl get pods
+kubectl get services


### PR DESCRIPTION
## Summary
- add helper scripts for docker and Kubernetes
- provide sample Kubernetes deployment manifest
- document usage of new scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842269e2d60832b948be3f9db659344