### PR TITLE
Customize PyGPT GUI defaults

### DIFF
--- a/repo/pygpt-MHP/README.md
+++ b/repo/pygpt-MHP/README.md
@@ -3046,7 +3046,7 @@ The configuration is stored in JSON files for easy manual modification outside o
 These configuration files are located in the user's work directory within the following subdirectory:
 
 ``` ini
-{HOME_DIR}/.config/pygpt-net/
+{PROJECT_DIR}/
 ```
 
 ## Manual configuration
@@ -3054,7 +3054,7 @@ These configuration files are located in the user's work directory within the fo
 You can manually edit the configuration files in this directory (this is your work directory):
 
 ``` ini
-{HOME_DIR}/.config/pygpt-net/
+{PROJECT_DIR}/
 ```
 
 - `assistants.json` - stores the list of assistants.
@@ -3114,7 +3114,7 @@ This allows you to overwrite language files or CSS styles in a very simple way -
 
 
 ``` ini
-{HOME_DIR}/.config/pygpt-net/
+{PROJECT_DIR}/
 ```
 
 - `locale` - a directory for locales in `.ini` format.
@@ -3385,7 +3385,7 @@ In `Settings -> Developer` dialog, you can enable the `Show debug menu` option t
 By default, all errors and exceptions are logged to the file:
 
 ```ini
-{HOME_DIR}/.config/pygpt-net/app.log
+{PROJECT_DIR}/app.log
 ```
 
 To increase the logging level (`ERROR` level is default), run the application with `--debug` argument:

--- a/repo/pygpt-MHP/src/pygpt_net/config.py
+++ b/repo/pygpt-MHP/src/pygpt_net/config.py
@@ -104,7 +104,7 @@ class Config:
 
         :return: base workdir path
         """
-        path = os.path.join(Path.home(), '.config', Config.CONFIG_DIR)
+        path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
         if "PYGPT_WORKDIR" in os.environ and os.environ["PYGPT_WORKDIR"] != "":
             print("FORCE using workdir: {}".format(os.environ["PYGPT_WORKDIR"]))
             # convert relative path to absolute path if needed

--- a/repo/pygpt-MHP/src/pygpt_net/controller/theme/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/theme/__init__.py
@@ -173,13 +173,13 @@ class Theme:
 
     def apply(
             self,
-            theme: str = 'dark_teal.xml',
+            theme: str = 'dark_purple.xml',
             custom: Optional[str] = None
     ):
         """
         Update material theme and apply custom CSS
 
-        :param theme: material theme filename (e.g. dark_teal.xml)
+        :param theme: material theme filename (e.g. dark_purple.xml)
         :param custom: additional custom stylesheet filename (e.g. style.css)
         """
         inverse = False

--- a/repo/pygpt-MHP/src/pygpt_net/data/config/config.json
+++ b/repo/pygpt-MHP/src/pygpt_net/data/config/config.json
@@ -355,7 +355,7 @@
       }
   },
   "temperature": 1.0,
-  "theme": "dark_cyan",
+  "theme": "dark_purple",
   "theme.markdown": true,
   "theme.style": "chatgpt",
   "top_p": 1.0,

--- a/repo/pygpt-MHP/src/pygpt_net/data/win32/pygpt.aip
+++ b/repo/pygpt-MHP/src/pygpt_net/data/win32/pygpt.aip
@@ -342,7 +342,7 @@
     <ROW File="dark_pink.xml" Component_="dark_amber.xml" FileName="DARK_P~1.XML|dark_pink.xml" Attributes="0" SourcePath="..\..\dist\Windows\qt_material\themes\dark_pink.xml" SelfReg="false"/>
     <ROW File="dark_purple.xml" Component_="dark_amber.xml" FileName="DARK_P~2.XML|dark_purple.xml" Attributes="0" SourcePath="..\..\dist\Windows\qt_material\themes\dark_purple.xml" SelfReg="false"/>
     <ROW File="dark_red.xml" Component_="dark_amber.xml" FileName="dark_red.xml" Attributes="0" SourcePath="..\..\dist\Windows\qt_material\themes\dark_red.xml" SelfReg="false"/>
-    <ROW File="dark_teal.xml" Component_="dark_amber.xml" FileName="DARK_T~1.XML|dark_teal.xml" Attributes="0" SourcePath="..\..\dist\Windows\qt_material\themes\dark_teal.xml" SelfReg="false"/>
+    <ROW File="dark_purple.xml" Component_="dark_amber.xml" FileName="DARK_T~1.XML|dark_purple.xml" Attributes="0" SourcePath="..\..\dist\Windows\qt_material\themes\dark_purple.xml" SelfReg="false"/>
     <ROW File="dark_yellow.xml" Component_="dark_amber.xml" FileName="DARK_Y~1.XML|dark_yellow.xml" Attributes="0" SourcePath="..\..\dist\Windows\qt_material\themes\dark_yellow.xml" SelfReg="false"/>
     <ROW File="light_amber.xml" Component_="dark_amber.xml" FileName="LIGHT_~1.XML|light_amber.xml" Attributes="0" SourcePath="..\..\dist\Windows\qt_material\themes\light_amber.xml" SelfReg="false"/>
     <ROW File="light_blue.xml" Component_="dark_amber.xml" FileName="LIGHT_~2.XML|light_blue.xml" Attributes="0" SourcePath="..\..\dist\Windows\qt_material\themes\light_blue.xml" SelfReg="false"/>

--- a/repo/pygpt-MHP/src/pygpt_net/provider/core/config/patch.py
+++ b/repo/pygpt-MHP/src/pygpt_net/provider/core/config/patch.py
@@ -69,7 +69,7 @@ class Patch:
                     if key in data:
                         del data[key]
                 if 'theme' not in data:
-                    data['theme'] = "dark_teal"
+                    data['theme'] = "dark_purple"
                 updated = True
 
             # < 0.9.4
@@ -90,7 +90,7 @@ class Patch:
             # < 2.0.0
             if old < parse_version("2.0.0"):
                 print("Migrating config from < 2.0.0...")
-                data['theme'] = 'dark_teal'  # force, because removed light themes!
+                data['theme'] = 'dark_purple'  # force, because removed light themes!
                 if 'cmd' not in data:
                     data['cmd'] = True
                 if 'stream' not in data:

--- a/repo/pygpt-MHP/tests/controller/theme/test_theme_common.py
+++ b/repo/pygpt-MHP/tests/controller/theme/test_theme_common.py
@@ -17,20 +17,20 @@ from pygpt_net.controller import Theme
 
 def test_get_extra_css(mock_window):
     """Test get extra css"""
-    mock_window.core.config.data['theme'] = 'dark_teal'
+    mock_window.core.config.data['theme'] = 'dark_purple'
     theme = Theme(mock_window)
     with patch('os.path.exists') as os_path_exists, \
         patch('os.path.join') as os_path_join:
         os_path_exists.return_value=True
         os_path_join.return_value='test'
-        assert theme.common.get_extra_css('dark_teal') == 'style.dark.css'
+        assert theme.common.get_extra_css('dark_purple') == 'style.dark.css'
 
 
 def test_translate(mock_window):
-    name = 'dark_teal'
+    name = 'dark_purple'
     theme = Theme(mock_window)
     mock_window.core.config.data['lang'] = 'en'
-    assert theme.common.translate(name) == 'Dark: Teal'  # must have EN lang in config to pass!!!!!!!!
+    assert theme.common.translate(name) == 'Dark: Purple'  # must have EN lang in config to pass!!!!!!!!
 
 
 def test_get_themes_list(mock_window):


### PR DESCRIPTION
## Summary
- use project root as default workdir
- default theme is now dark purple
- update migration patch for new theme
- adjust Windows packaging file
- fix related tests and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684228e12200832b87be46b047774983