### PR TITLE
Add project header to shell scripts

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/bin/build.sh` from the pygpt-MHP repo.

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/bin/clean.sh` from the pygpt-MHP repo.

--- a/bin/resources.sh
+++ b/bin/resources.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/bin/resources.sh` from the pygpt-MHP repo.

--- a/bin/sort_locale.sh
+++ b/bin/sort_locale.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/bin/sort_locale.sh` from the pygpt-MHP repo.

--- a/docs/build-en.sh
+++ b/docs/build-en.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/docs/build-en.sh` from the pygpt-MHP repo.

--- a/docs/build-pl.sh
+++ b/docs/build-pl.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/docs/build-pl.sh` from the pygpt-MHP repo.

--- a/docs/rebuild-lang.sh
+++ b/docs/rebuild-lang.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/docs/rebuild-lang.sh` from the pygpt-MHP repo.

--- a/docs/rst_to_md.sh
+++ b/docs/rst_to_md.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/docs/rst_to_md.sh` from the pygpt-MHP repo.

--- a/docs/update.sh
+++ b/docs/update.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/docs/update.sh` from the pygpt-MHP repo.

--- a/install.sh
+++ b/install.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/install.sh` from the pygpt-MHP repo.

--- a/repo/pygpt-MHP/bin/build.sh
+++ b/repo/pygpt-MHP/bin/build.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 # This script is used to build the app using pyinstaller
 
 VERSION="2.5.8"

--- a/repo/pygpt-MHP/bin/clean.sh
+++ b/repo/pygpt-MHP/bin/clean.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 # This script is used to recursive remove the __pycache__ directories
 
 cd "$(dirname "$0")"

--- a/repo/pygpt-MHP/bin/resources.sh
+++ b/repo/pygpt-MHP/bin/resources.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 
 cd "$(dirname "$0")"
 DIR_CURRENT="$(pwd)"

--- a/repo/pygpt-MHP/bin/sort_locale.sh
+++ b/repo/pygpt-MHP/bin/sort_locale.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 INI_FILES_DIR="$SCRIPT_DIR/../src/pygpt_net/data/locale"

--- a/repo/pygpt-MHP/docs/build-en.sh
+++ b/repo/pygpt-MHP/docs/build-en.sh
@@ -1,2 +1,10 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 make -e SPHINXOPTS="-D language='en'" html
 make latexpdf -e SPHINXOPTS="-D language='en'"

--- a/repo/pygpt-MHP/docs/build-pl.sh
+++ b/repo/pygpt-MHP/docs/build-pl.sh
@@ -1,2 +1,10 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 make -e SPHINXOPTS="-D language='pl'" html
 make latexpdf -e SPHINXOPTS="-D language='pl'"

--- a/repo/pygpt-MHP/docs/rebuild-lang.sh
+++ b/repo/pygpt-MHP/docs/rebuild-lang.sh
@@ -1,2 +1,10 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 make gettext
 sphinx-intl update -p build/gettext -l pl

--- a/repo/pygpt-MHP/docs/rst_to_md.sh
+++ b/repo/pygpt-MHP/docs/rst_to_md.sh
@@ -1,3 +1,11 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 FILES=*.rst
 for f in $FILES
 do

--- a/repo/pygpt-MHP/docs/source/rst_to_md.sh
+++ b/repo/pygpt-MHP/docs/source/rst_to_md.sh
@@ -1,3 +1,11 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 FILES=*.rst
 for f in $FILES
 do

--- a/repo/pygpt-MHP/docs/update.sh
+++ b/repo/pygpt-MHP/docs/update.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 sphinx-intl update -p build/gettext

--- a/repo/pygpt-MHP/install.sh
+++ b/repo/pygpt-MHP/install.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 # This script is used to install the app dependencies and run the app using the virtual environment
 python -m venv ./venv
 source ./venv/bin/activate

--- a/repo/pygpt-MHP/run-tests.sh
+++ b/repo/pygpt-MHP/run-tests.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 # This script is used to run the tests using the virtual environment
 source ./venv/bin/activate
 pytest -vv

--- a/repo/pygpt-MHP/run.sh
+++ b/repo/pygpt-MHP/run.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 # This script is used to run the app using the virtual environment
 source ./venv/bin/activate
 python3 run.py "$@"

--- a/repo/pygpt-MHP/shortcut.sh
+++ b/repo/pygpt-MHP/shortcut.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 # This script is used to run the app using the virtual environment
 cd "$(dirname "$0")"
 source ./venv/bin/activate

--- a/repo/pygpt-MHP/snaprun.sh
+++ b/repo/pygpt-MHP/snaprun.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 
 # This script is used to run the app in the snap environment
 # export QTWEBENGINE_DISABLE_GPU=1

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/run-tests.sh` from the pygpt-MHP repo.

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 # This script is used to run the app using the virtual environment
 source ./venv/bin/activate
 python3 run.py "$@"

--- a/scripts/docker_cleanup.sh
+++ b/scripts/docker_cleanup.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 set -e
 
 # Stop and remove compose services

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 set -e
 
 # Build Docker image

--- a/scripts/k8s_cleanup.sh
+++ b/scripts/k8s_cleanup.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 set -e
 
 K8S_DIR="k8s"

--- a/scripts/k8s_setup.sh
+++ b/scripts/k8s_setup.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 set -e
 
 K8S_DIR="k8s"

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 
 set -e
 

--- a/setup/Debian13/update.sh
+++ b/setup/Debian13/update.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 
 # Define the directory for the virtual environment
 VENV_DIR="venv"

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 
 set -e
 

--- a/shortcut.sh
+++ b/shortcut.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/shortcut.sh` from the pygpt-MHP repo.

--- a/snaprun.sh
+++ b/snaprun.sh
@@ -1,1 +1,9 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.05.2025
+# ==================================================
 Placeholder for `repo/pygpt-MHP/snaprun.sh` from the pygpt-MHP repo.


### PR DESCRIPTION
## Summary
- add the Monkey Head Project header block to all `.sh` scripts
- restore executable permissions on helper scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423fb46694832ba5e1c8ed89f1a248