### PR TITLE
Implement pygpt sync and update placeholders

### DIFF
--- a/bin/README_PLACEHOLDER.md
+++ b/bin/README_PLACEHOLDER.md
@@ -1,1 +1,2 @@
 This directory mirrors `repo/pygpt-MHP/bin` from the pygpt-MHP repo.
+Run `python sync_pygpt_structure.py` to populate it with the real files.

--- a/docs/source/README_PLACEHOLDER.md
+++ b/docs/source/README_PLACEHOLDER.md
@@ -1,1 +1,2 @@
 This directory mirrors `repo/pygpt-MHP/docs/source` from the pygpt-MHP repo.
+Run `python sync_pygpt_structure.py` to populate it with the real files.

--- a/examples/README_PLACEHOLDER.md
+++ b/examples/README_PLACEHOLDER.md
@@ -1,1 +1,2 @@
 This directory mirrors `repo/pygpt-MHP/examples` from the pygpt-MHP repo.
+Run `python sync_pygpt_structure.py` to populate it with the real files.

--- a/snap/README_PLACEHOLDER.md
+++ b/snap/README_PLACEHOLDER.md
@@ -1,1 +1,2 @@
 This directory mirrors `repo/pygpt-MHP/snap` from the pygpt-MHP repo.
+Run `python sync_pygpt_structure.py` to populate it with the real files.

--- a/snap/gui/README_PLACEHOLDER.md
+++ b/snap/gui/README_PLACEHOLDER.md
@@ -1,1 +1,2 @@
 This directory mirrors `repo/pygpt-MHP/snap/gui` from the pygpt-MHP repo.
+Run `python sync_pygpt_structure.py` to populate it with the real files.

--- a/sync_pygpt_structure.py
+++ b/sync_pygpt_structure.py
@@ -7,32 +7,46 @@
 # Updated: 06.05.2025
 # ==================================================
 import os
+import shutil
 
 PYGPT_DIR = os.path.join('repo', 'pygpt-MHP')
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
-def mirror(src, dst):
-    if os.path.exists(dst):
+def _should_copy_file(dst: str) -> bool:
+    """Return True if file should be copied from the source."""
+    if not os.path.exists(dst):
+        return True
+    try:
+        with open(dst, "r", errors="ignore") as f:
+            first = f.readline().strip()
+        return first.startswith("Placeholder for")
+    except Exception:
         return False
+
+
+def sync(src: str, dst: str, depth: int = 0) -> None:
+    """Copy file or directory from src to dst if missing or placeholder."""
     if os.path.isdir(src):
         os.makedirs(dst, exist_ok=True)
-        placeholder = os.path.join(dst, 'README_PLACEHOLDER.md')
-        with open(placeholder, 'w') as f:
-            f.write(f'This directory mirrors `{src}` from the pygpt-MHP repo.')
+        if depth > 0:
+            for item in os.listdir(src):
+                sync(
+                    os.path.join(src, item),
+                    os.path.join(dst, item),
+                    depth=depth - 1,
+                )
     else:
-        with open(dst, 'w') as f:
-            f.write(f'Placeholder for `{src}` from the pygpt-MHP repo.')
-    return True
+        if _should_copy_file(dst):
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.copy2(src, dst)
 
 
-def mirror_tree(src_root, dst_root, depth=1):
+def mirror_tree(src_root: str, dst_root: str, depth: int = 1) -> None:
     for item in os.listdir(src_root):
         src_path = os.path.join(src_root, item)
         dst_path = os.path.join(dst_root, item)
-        created = mirror(src_path, dst_path)
-        if depth > 1 and os.path.isdir(src_path) and created:
-            mirror_tree(src_path, dst_path, depth=depth-1)
+        sync(src_path, dst_path, depth=depth - 1)
 
 if __name__ == "__main__":
     mirror_tree(PYGPT_DIR, ROOT_DIR, depth=2)


### PR DESCRIPTION
## Summary
- make `sync_pygpt_structure.py` actually copy files from the pygpt-MHP repo
- instruct users how to populate placeholder directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443dcbd5bc832b8846c0be1071033d