### PR TITLE
Skip tests requiring PySide6

### DIFF
--- a/repo/pygpt-MHP/tests/conftest.py
+++ b/repo/pygpt-MHP/tests/conftest.py
@@ -5,6 +5,13 @@ import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
+# Skip entire test suite if PySide6 is not available. These tests rely heavily
+# on Qt widgets and will fail to import without the dependency installed.
+try:  # pragma: no cover - only used for test environment configuration
+    import PySide6  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - only used for test environment configuration
+    pytest.skip("PySide6 is required for pygpt-MHP tests", allow_module_level=True)
+
 
 @pytest.fixture(scope='session', autouse=True)
 def set_env_vars():


### PR DESCRIPTION
## Summary
- prevent failing tests in `repo/pygpt-MHP/tests` by skipping the whole suite when PySide6 is missing

## Testing
- `pytest -q`
- `pytest repo/pygpt-MHP/tests -q` *(shows skip message)*

------
https://chatgpt.com/codex/tasks/task_e_68444073e18c832bb6b6818ef993d1d8