### PR TITLE
Use local pygpt files and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,14 @@ python src/main.py
 
 ### Submodule
 
-This project uses the [pygpt-MHP](https://github.com/DylanLRPollock/pygpt-MHP) submodule located in `repo/pygpt-MHP`. It provides advanced GPT-based capabilities leveraged by GenCore. Clone the repository with `--recurse-submodules` or run `git submodule update --init --recursive` after cloning to ensure it is available. The installer performs this step automatically and installs the package with `pip install -e repo/pygpt-MHP`.
+This project uses the [pygpt-MHP](https://github.com/DylanLRPollock/pygpt-MHP) submodule located in `repo/pygpt-MHP`. Clone with `--recurse-submodules` or run `git submodule update --init --recursive` to fetch it. After cloning, run the helper script below to mirror the submodule into the main repository so you can work entirely from the local `src` directory:
+
+```bash
+python sync_pygpt_structure.py  # copy entire pygpt tree
+# python sync_pygpt_structure.py --depth 2  # limit recursion if desired
+```
+
+Once copied, prefer importing modules from the project root instead of the `repo/pygpt-MHP` path. The installer performs the submodule update and installation with `pip install -e repo/pygpt-MHP` automatically.
 
 ### Running Tests
 

--- a/sync_pygpt_structure.py
+++ b/sync_pygpt_structure.py
@@ -6,10 +6,20 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+"""Synchronize pygpt-MHP submodule files with the local project.
+
+The script copies files from ``repo/pygpt-MHP`` into the main repository so
+modules can be imported directly from ``src``. Existing files will only be
+overwritten if they contain a ``Placeholder for`` header. The ``--depth``
+option controls how deep into the submodule the copy process recurses. By
+default the entire tree is mirrored.
+"""
 import os
 import shutil
+import argparse
 
-PYGPT_DIR = os.path.join('repo', 'pygpt-MHP')
+
+PYGPT_DIR = os.path.join("repo", "pygpt-MHP")
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -25,16 +35,16 @@ def _should_copy_file(dst: str) -> bool:
         return False
 
 
-def sync(src: str, dst: str, depth: int = 0) -> None:
+def sync(src: str, dst: str, depth: int | None = None) -> None:
     """Copy file or directory from src to dst if missing or placeholder."""
     if os.path.isdir(src):
         os.makedirs(dst, exist_ok=True)
-        if depth > 0:
+        if depth is None or depth > 0:
             for item in os.listdir(src):
                 sync(
                     os.path.join(src, item),
                     os.path.join(dst, item),
-                    depth=depth - 1,
+                    None if depth is None else depth - 1,
                 )
     else:
         if _should_copy_file(dst):
@@ -42,12 +52,22 @@ def sync(src: str, dst: str, depth: int = 0) -> None:
             shutil.copy2(src, dst)
 
 
-def mirror_tree(src_root: str, dst_root: str, depth: int = 1) -> None:
+def mirror_tree(src_root: str, dst_root: str, depth: int | None = None) -> None:
     for item in os.listdir(src_root):
         src_path = os.path.join(src_root, item)
         dst_path = os.path.join(dst_root, item)
-        sync(src_path, dst_path, depth=depth - 1)
+        sync(src_path, dst_path, None if depth is None else depth - 1)
 
 if __name__ == "__main__":
-    mirror_tree(PYGPT_DIR, ROOT_DIR, depth=2)
+    parser = argparse.ArgumentParser(
+        description="Copy files from the pygpt-MHP submodule into the main project"
+    )
+    parser.add_argument(
+        "--depth",
+        type=int,
+        default=None,
+        help="Limit recursion depth when copying (default: unlimited)",
+    )
+    args = parser.parse_args()
+    mirror_tree(PYGPT_DIR, ROOT_DIR, depth=args.depth)
 

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -10,20 +10,21 @@ import unittest
 import os
 import sys
 import importlib.util
+from pathlib import Path
 
-ROOT = os.path.dirname(os.path.dirname(__file__))
-MODULE_PATH = os.path.join(
-    ROOT,
-    'repo',
-    'pygpt-MHP',
-    'src',
-    'pygpt_net',
-    'controller',
-    'config',
-    'placeholder.py',
-)
+ROOT = Path(__file__).resolve().parent.parent
+LOCAL_SRC = ROOT / 'src'
+SUBMODULE_SRC = ROOT / 'repo' / 'pygpt-MHP' / 'src'
 
-sys.path.append(os.path.join(ROOT, 'repo', 'pygpt-MHP', 'src'))
+local_module = LOCAL_SRC / 'pygpt_net' / 'controller' / 'config' / 'placeholder.py'
+if local_module.exists():
+    MODULE_PATH = str(local_module)
+    sys.path.append(str(LOCAL_SRC))
+else:
+    MODULE_PATH = str(
+        SUBMODULE_SRC / 'pygpt_net' / 'controller' / 'config' / 'placeholder.py'
+    )
+    sys.path.append(str(SUBMODULE_SRC))
 
 spec = importlib.util.spec_from_file_location('placeholder_module', MODULE_PATH)
 placeholder_module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary
- tweak placeholder unit test to prefer local project files if available
- update README instructions on copying pygpt files into the main project
- expand sync script to copy entire pygpt tree and add depth option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845dd0f69bc832baad5f2e4e720cdb7