### PR TITLE
Switch to GUI-first workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,18 +126,18 @@ python installer.py
 The installer now displays the license agreement using a small Tkinter
 dialog. You must accept these terms before the setup can finish.
 
-### Optional GUI
+### GUI Interface (Default)
 
-For a minimal graphical interface you can launch the Tkinter GUI:
+The GUI is now the primary way to install and control the project. Simply run:
 
 ```bash
-python -m gui.main_ui
+python run.py
 ```
 
-This window lets you run the install or update scripts directly and
-automatically chooses the correct script for your platform. A "Run" option
-is also provided to launch `run.bat` or `run.sh` so you can start the
-application without opening a terminal.
+This launches a Tkinter window where you can install, update, or run the
+application. The correct setup script is chosen automatically. A "Run" button
+lets you start the program without opening a terminal. For the original
+command‑line behaviour use `python run.py --cli`.
 
 ### Docker and Kubernetes Utilities
 
@@ -265,8 +265,9 @@ GenCore offers extensive customization through the `config.yaml` file at the
 project root and the JSON profiles found under `config/pygpt_net/`. You can
 add your own YAML files in `config/` to override default behaviors, define
 hardware profiles, or enable experimental modules. After editing a
-configuration file, restart the system with `python run.py` or
-`docker-compose restart` to apply the changes.
+configuration file, restart the system with `python run.py` (or
+`python run.py --cli` for command-line mode) or `docker-compose restart` to
+apply the changes.
 
 ### Sample Configuration Snippet
 

--- a/run.py
+++ b/run.py
@@ -17,13 +17,39 @@
 # Updated Date: 2023.12.05 22:00:00                  #
 # ================================================== #
 
+import argparse
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str((Path(__file__).parent / 'src').resolve()))
+sys.path.insert(0, str((Path(__file__).parent / "src").resolve()))
 
-from pygpt_net.app import run
+from pygpt_net.app import run as cli_run
 
-if __name__ == '__main__':
-    run()
+
+def main() -> None:
+    """Launch the GUI by default with an optional CLI mode."""
+
+    parser = argparse.ArgumentParser(description="Launch the Monkey Head Project")
+    parser.add_argument(
+        "--cli",
+        action="store_true",
+        help="Run in command-line mode instead of the GUI",
+    )
+    args = parser.parse_args()
+
+    if args.cli:
+        cli_run()
+        return
+
+    import tkinter as tk
+
+    from gui.main_ui import MainUI
+
+    root = tk.Tk()
+    app = MainUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()
 


### PR DESCRIPTION
## Summary
- default to launching the GUI from `run.py`
- document the GUI as the primary interface in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fa6be5d0832ba70354c3f1a6e5c0