### PR TITLE
Add advanced tests

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+from src.config_manager import ConfigManager
+
+
+def test_config_manager_roundtrip(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    manager = ConfigManager(str(cfg))
+    manager.set_setting("foo", 1)
+    assert cfg.exists()
+    loaded = ConfigManager(str(cfg))
+    assert loaded.get_setting("foo") == 1
+
+
+def test_config_manager_default(tmp_path):
+    cfg = tmp_path / "missing.json"
+    manager = ConfigManager(str(cfg))
+    assert manager.get_setting("unknown", "default") == "default"
+

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -17,5 +17,15 @@ class TestFormatter(unittest.TestCase):
         self.assertEqual(formatted, "one\ntwo\nthree\nfour")
 
 
+def test_format_text_line_lengths():
+    """Validate that no line exceeds the specified length."""
+    text = "one two three four five six seven eight"
+    for length in [5, 10, 15]:
+        formatted = format_text(text, line_length=length)
+        for line in formatted.splitlines():
+            assert len(line) <= length
+        assert "".join(formatted.split()) == text.replace(" ", "")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gencore.py
+++ b/tests/test_gencore.py
@@ -18,6 +18,10 @@ class TestGencore(unittest.TestCase):
         self.assertEqual(result["input_length"], 2)
         self.assertEqual(result["details"], data)
 
+    def test_generate_core_data_invalid_input(self):
+        with self.assertRaises(ValueError):
+            generate_core_data(123)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend formatter tests with line length checks
- add ConfigManager tests
- add invalid input test for gencore

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462a14ced8832ba71ef9e93d03e601