### PR TITLE
Add GUI fallback to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,10 @@ python run.py
 
 This launches a Tkinter window where you can install, update, or run the
 application. The correct setup script is chosen automatically. A "Run" button
-lets you start the program without opening a terminal. For the original
-command‑line behaviour use `python run.py --cli`.
+lets you start the program without opening a terminal. If the GUI cannot be
+displayed (for example on a headless server), the launcher automatically falls
+back to the command-line interface. You can also force CLI mode with
+`python run.py --cli`.
 
 ### Docker and Kubernetes Utilities
 

--- a/run.py
+++ b/run.py
@@ -26,6 +26,19 @@ sys.path.insert(0, str((Path(__file__).parent / "src").resolve()))
 from pygpt_net.app import run as cli_run
 
 
+def launch_gui() -> None:
+    """Start the Tkinter GUI."""
+    try:
+        import tkinter as tk
+        from gui.main_ui import MainUI
+    except Exception as exc:
+        raise RuntimeError(f"Unable to load GUI modules: {exc}") from exc
+
+    root = tk.Tk()
+    app = MainUI(root)
+    root.mainloop()
+
+
 def main() -> None:
     """Launch the GUI by default with an optional CLI mode."""
 
@@ -41,13 +54,11 @@ def main() -> None:
         cli_run()
         return
 
-    import tkinter as tk
-
-    from gui.main_ui import MainUI
-
-    root = tk.Tk()
-    app = MainUI(root)
-    root.mainloop()
+    try:
+        launch_gui()
+    except Exception as exc:
+        print(f"GUI failed to launch: {exc}\nFalling back to CLI mode.")
+        cli_run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `launch_gui()` helper to start the Tkinter UI
- fallback to CLI mode if the GUI cannot launch
- document automatic CLI fallback in README

## Testing
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_684623a3e280832bb36b0809f30c4c21