### PR TITLE
Preload memory PDFs

### DIFF
--- a/repo/pygpt-MHP/src/pygpt_net/core/attachments/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/attachments/__init__.py
@@ -10,6 +10,8 @@
 # ================================================== #
 
 import copy
+import os
+from pathlib import Path
 from typing import Optional, List, Dict
 
 from packaging.version import Version
@@ -464,6 +466,9 @@ class Attachments:
                         attachment.path,
                     )
 
+        # preload bundled memory files
+        self.preload_memory_pdfs()
+
     def save(self):
         """Save attachments"""
         # replace current workdir with placeholder
@@ -476,3 +481,37 @@ class Attachments:
                         attachment.path,
                     )
         self.provider.save(data)
+
+    def preload_memory_pdfs(self, mode: str = "chat") -> None:
+        """Preload PDF files from the built-in memory directory."""
+        base = Path(__file__).resolve().parents[3]
+        pdf_dir = base / "memory" / "PDF"
+        if not pdf_dir.is_dir():
+            return
+
+        if mode not in self.items:
+            self.items[mode] = {}
+
+        existing = {
+            os.path.abspath(item.path)
+            for item in self.items[mode].values()
+            if item.path is not None
+        }
+
+        changed = False
+        for entry in sorted(pdf_dir.iterdir()):
+            if entry.suffix.lower() != ".pdf":
+                continue
+            abs_path = str(entry.resolve())
+            if abs_path in existing:
+                continue
+            self.new(
+                mode=mode,
+                name=entry.name,
+                path=abs_path,
+                auto_save=False,
+            )
+            changed = True
+
+        if changed:
+            self.save()


### PR DESCRIPTION
## Summary
- preload PDF files from `memory/PDF` when attachments load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684653167688832b948de3e7cb8657d1