### PR TITLE
Add data preloader

### DIFF
--- a/monkey_head/scripts/preload_data.py
+++ b/monkey_head/scripts/preload_data.py
@@ -1,0 +1,57 @@
+import csv
+from pathlib import Path
+from typing import Dict, List
+
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+
+
+def load_prompts() -> List[Dict[str, str]]:
+    """Load prompts from the CSV dataset."""
+    prompts_file = BASE_DIR / "prompts" / "pygpt_prompts.csv"
+    if not prompts_file.is_file():
+        return []
+    with prompts_file.open(encoding="utf-8") as f:
+        lines = [line for line in f if line.strip()]
+    reader = csv.DictReader(lines[1:])  # skip comment line
+    return list(reader)
+
+
+def load_memory() -> Dict[str, List[str]]:
+    """Collect memory files from bundled memory directory."""
+    memory_dir = BASE_DIR / "memory"
+    result: Dict[str, List[str]] = {}
+    if not memory_dir.is_dir():
+        return result
+    for sub in memory_dir.iterdir():
+        if sub.is_dir():
+            result[sub.name] = [str(p.resolve()) for p in sub.iterdir() if p.is_file()]
+    return result
+
+
+def preload_all() -> Dict[str, object]:
+    """Load prompts and memory files."""
+    return {
+        "prompts": load_prompts(),
+        "memory": load_memory(),
+    }
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Preload memory and prompts")
+    parser.add_argument("--summary", action="store_true", help="Print summary only")
+    args = parser.parse_args()
+
+    data = preload_all()
+    if args.summary:
+        print(f"Prompts loaded: {len(data['prompts'])}")
+        for key, files in data["memory"].items():
+            print(f"{key}: {len(files)} files")
+    else:
+        print(data)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -72,4 +72,12 @@ update_submodules
 setup_python_env
 show_license_gui
 
+function preload_data {
+    echo "Preloading bundled data..."
+    source "$VENV_DIR/bin/activate" || error_exit "Failed to activate virtual environment."
+    python -m monkey_head.scripts.preload_data --summary || echo "Data preload failed"
+}
+
+preload_data
+
 echo "Installation completed successfully."

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -61,4 +61,12 @@ update_submodules
 setup_python_env
 show_license_gui
 
+function preload_data() {
+    echo "Preloading bundled data..."
+    source "$VENV_DIR/bin/activate"
+    python -m monkey_head.scripts.preload_data --summary || echo "Data preload failed"
+}
+
+preload_data
+
 echo "Installation completed successfully."

--- a/tests/test_preloader.py
+++ b/tests/test_preloader.py
@@ -1,0 +1,7 @@
+from monkey_head.scripts.preload_data import preload_all
+
+
+def test_preload_all():
+    data = preload_all()
+    assert data['prompts'], "Prompts should not be empty"
+    assert 'PDF' in data['memory'] and data['memory']['PDF'], "PDF memory should not be empty"


### PR DESCRIPTION
## Summary
- implement `preload_data.py` for loading prompts and memory files
- add test for the preloader
- call preloader in Linux and macOS install scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684658c24180832b99da21a45ecb94be