### PR TITLE
Expand GUI framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ displayed (for example on a headless server), the launcher automatically falls
 back to the command-line interface. You can also force CLI mode with
 `python run.py --cli`.
 
+The GUI now checks whether you've accepted the license on startup and
+offers a **Tools** menu. From there you can reopen the license dialog or
+view a summary of bundled prompts and memory files.
+
 ### Docker and Kubernetes Utilities
 
 The `scripts/` directory contains helper scripts for container management:

--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -14,6 +14,9 @@ from pathlib import Path
 import tkinter as tk
 from tkinter import messagebox, scrolledtext, ttk
 
+from monkey_head.license_gui import show_license_gui
+from monkey_head.scripts.preload_data import preload_all
+
 
 class MainUI:
     def __init__(self, root):
@@ -22,6 +25,7 @@ class MainUI:
         self.setup_paths()
         self.create_menu()
         self.create_widgets()
+        self.check_license()
 
     def setup_paths(self):
         """Determine installer paths based on the current platform."""
@@ -56,6 +60,11 @@ class MainUI:
         file_menu.add_separator()
         file_menu.add_command(label="Exit", command=self.root.quit)
         menu_bar.add_cascade(label="File", menu=file_menu)
+
+        tools_menu = tk.Menu(menu_bar, tearoff=0)
+        tools_menu.add_command(label="License", command=self.show_license)
+        tools_menu.add_command(label="Data Summary", command=self.show_data_summary)
+        menu_bar.add_cascade(label="Tools", menu=tools_menu)
 
     def create_widgets(self):
         self.log_text = scrolledtext.ScrolledText(self.root, width=80, height=20)
@@ -131,6 +140,24 @@ class MainUI:
         self.status_label.config(text="Status: Updating")
         self.progress.start()
         threading.Thread(target=self.run_script, args=(self.update_path,)).start()
+
+    def check_license(self):
+        """Display the license agreement if not yet accepted."""
+        show_license_gui()
+
+    def show_license(self):
+        """Manually open the license dialog."""
+        show_license_gui()
+
+    def show_data_summary(self):
+        """Display counts of bundled prompts and memory files."""
+        data = preload_all()
+        prompts = len(data.get("prompts", []))
+        memory_files = sum(len(v) for v in data.get("memory", {}).values())
+        messagebox.showinfo(
+            "Data Summary",
+            f"Prompts: {prompts}\nMemory files: {memory_files}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+from gui.main_ui import MainUI
+
+
+def test_check_license_calls_gui():
+    ui = MainUI.__new__(MainUI)
+    with patch('gui.main_ui.show_license_gui') as gui_call:
+        MainUI.check_license(ui)
+        gui_call.assert_called_once()
+
+
+def test_show_license_calls_gui():
+    ui = MainUI.__new__(MainUI)
+    with patch('gui.main_ui.show_license_gui') as gui_call:
+        MainUI.show_license(ui)
+        gui_call.assert_called_once()
+
+
+def test_show_data_summary_displays_info():
+    ui = MainUI.__new__(MainUI)
+    sample = {"prompts": [1, 2], "memory": {"a": ["x", "y"]}}
+    with patch('gui.main_ui.preload_all', return_value=sample), \
+         patch('gui.main_ui.messagebox.showinfo') as info:
+        MainUI.show_data_summary(ui)
+        info.assert_called_once()


### PR DESCRIPTION
## Summary
- enhance GUI with license check and new Tools menu
- display prompt/memory counts via new data summary window
- update README to explain new GUI features
- add tests for GUI helper methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846616ad834832b8d109e7ee2039fdb