### PR TITLE
Improve Huey config handling and add tests

### DIFF
--- a/huey/config.py
+++ b/huey/config.py
@@ -8,16 +8,20 @@
 # ==================================================
 # huey/config.py
 
-import yaml
-
-
-def load_config(config_file="config.yaml"):
+def load_config(config_file: str = "config.yaml"):
     """Load configuration settings from a YAML file."""
     try:
-        with open(config_file, "r") as file:
+        import yaml
+    except ImportError as exc:
+        raise ImportError("PyYAML is required to load configuration.") from exc
+
+    try:
+        with open(config_file, "r", encoding="utf-8") as file:
             config = yaml.safe_load(file)
         return config
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Configuration file '{config_file}' not found.")
-    except yaml.YAMLError as e:
-        raise Exception(f"Error parsing configuration file: {e}")
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Configuration file '{config_file}' not found."
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise Exception(f"Error parsing configuration file: {exc}") from exc

--- a/tests/test_huey_cli_config.py
+++ b/tests/test_huey_cli_config.py
@@ -1,0 +1,49 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from huey.config import load_config
+from huey.cli import parse_arguments, run_cli
+from huey.exceptions import HueyError, DataNotFoundError, InvalidInputError
+
+
+# Tests for configuration loading
+
+def test_load_config_success(tmp_path):
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("foo: bar")
+    result = load_config(str(cfg))
+    assert result["foo"] == "bar"
+
+
+def test_load_config_missing(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_config(str(tmp_path / "missing.yml"))
+
+
+# Tests for CLI argument parsing and invocation
+
+def test_parse_arguments_verbose():
+    test_args = ["prog", "--config", "file.yml", "--verbose"]
+    with patch.object(sys, "argv", test_args):
+        args = parse_arguments()
+        assert args.config == "file.yml"
+        assert args.verbose is True
+
+
+def test_run_cli_invokes_main(tmp_path):
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("logging:\n  level: INFO")
+    test_args = ["prog", "--config", str(cfg)]
+    with patch.object(sys, "argv", test_args), \
+         patch("huey.cli.huey_main") as main_mock:
+        run_cli()
+        main_mock.assert_called_once_with(config_file=str(cfg))
+
+
+# Tests for exception hierarchy
+
+def test_exceptions_inherit_from_base():
+    assert issubclass(DataNotFoundError, HueyError)
+    assert issubclass(InvalidInputError, HueyError)


### PR DESCRIPTION
## Summary
- add a dedicated test module covering Huey's config loader, CLI and exceptions
- make `load_config` import PyYAML lazily and provide a helpful error message

## Testing
- `pytest -q`
- `flake8 --exclude=venv,repo/pygpt-MHP`

------
https://chatgpt.com/codex/tasks/task_e_6846633016c0832bb889cf03a10811a3