### PR TITLE
Expand SubOS logic

### DIFF
--- a/monkey_head/Huey.py
+++ b/monkey_head/Huey.py
@@ -31,6 +31,7 @@ from .services.container_management import (
     deploy_kubernetes,
     kubernetes_management,
 )
+from . import subos_manager
 from .scripts.backup_restore import backup_config, restore_config
 
 app = Flask(__name__)
@@ -90,8 +91,7 @@ def setup_hostos() -> None:
 
 def setup_subos() -> None:
     logger.info("Setting up SubOS...")
-    logger.info("SubOS setup is a placeholder.")
-    check_error(subprocess.CompletedProcess(args=[], returncode=0), "Setup SubOS")
+    subos_manager.run()
 
 
 def setup_nanoos() -> None:

--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -10,5 +10,6 @@
 
 from .formatter import format_text
 from .gencore import generate_core_data
+from . import subos_manager
 
-__all__ = ["format_text", "generate_core_data"]
+__all__ = ["format_text", "generate_core_data", "subos_manager"]

--- a/monkey_head/subos_manager.py
+++ b/monkey_head/subos_manager.py
@@ -1,0 +1,99 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.05.2025
+# ==================================================
+import os
+import logging
+import subprocess
+import pwd
+
+from .core.system_checks import check_error, ensure_admin
+
+logger = logging.getLogger(__name__)
+
+
+def update_system() -> None:
+    """Update package lists and installed packages."""
+    logger.info("Updating system packages...")
+    update = subprocess.run(
+        ["apt-get", "update"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    check_error(update, "apt-get update")
+    upgrade = subprocess.run(
+        ["apt-get", "upgrade", "-y"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    check_error(upgrade, "apt-get upgrade")
+
+
+def install_tools() -> None:
+    """Install required virtualization and container tools."""
+    logger.info("Installing SubOS tools...")
+    tools = [
+        "git",
+        "docker.io",
+        "qemu-kvm",
+        "libvirt-daemon-system",
+        "libvirt-clients",
+        "virt-manager",
+        "python3",
+        "python3-venv",
+    ]
+    install = subprocess.run(
+        ["apt-get", "install", "-y", *tools],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    check_error(install, "Install SubOS tools")
+
+
+def create_user(user: str = "subos") -> None:
+    """Create a dedicated SubOS user if missing."""
+    logger.info("Ensuring %s user exists...", user)
+    try:
+        pwd.getpwnam(user)
+        logger.info("User %s already exists", user)
+    except KeyError:
+        add_user = subprocess.run(
+            ["useradd", "-m", user],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        check_error(add_user, f"Create user {user}")
+
+
+def configure_environment() -> None:
+    """Configure directories and environment variables."""
+    logger.info("Configuring SubOS environment...")
+    base = os.path.expanduser("~/SubOS")
+    os.makedirs(base, exist_ok=True)
+    os.environ["SUBOS_PATH"] = base
+    with open(os.path.expanduser("~/.bashrc"), "a") as bashrc:
+        bashrc.write("\nexport SUBOS_PATH=$HOME/SubOS\n")
+
+
+def deploy_subos() -> None:
+    """Deploy the SubOS Docker environment."""
+    logger.info("Deploying SubOS...")
+    os.chdir(os.path.expanduser("~/SubOS"))
+    deploy = subprocess.run(
+        ["docker-compose", "up", "-d"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    check_error(deploy, "SubOS deployment")
+
+
+def run() -> None:
+    """Full SubOS setup routine."""
+    ensure_admin()
+    update_system()
+    install_tools()
+    create_user()
+    configure_environment()
+    deploy_subos()

--- a/tests/test_subos_manager.py
+++ b/tests/test_subos_manager.py
@@ -1,0 +1,51 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.05.2025
+# ==================================================
+import subprocess
+from unittest.mock import patch
+import types
+
+from monkey_head import subos_manager
+
+
+class R:
+    def __init__(self):
+        self.returncode = 0
+
+
+def test_update_system_runs_commands():
+    with patch("subprocess.run", return_value=R()) as mock_run:
+        subos_manager.update_system()
+        mock_run.assert_any_call(
+            ["apt-get", "update"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        mock_run.assert_any_call(
+            ["apt-get", "upgrade", "-y"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+
+def test_create_user_skips_existing():
+    with patch("pwd.getpwnam", return_value=types.SimpleNamespace()), patch(
+        "subprocess.run"
+    ) as mock_run:
+        subos_manager.create_user("nobody")
+        mock_run.assert_not_called()
+
+
+def test_create_user_adds_new():
+    with patch("pwd.getpwnam", side_effect=KeyError), patch(
+        "subprocess.run", return_value=R()
+    ) as mock_run:
+        subos_manager.create_user("subos")
+        mock_run.assert_called_with(
+            ["useradd", "-m", "subos"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )


### PR DESCRIPTION
## Summary
- add a dedicated `subos_manager` module
- integrate SubOS manager in `Huey` and expose in package init
- test SubOS manager functions

## Testing
- `flake8`
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_68466d05d960832bae39d7d4f4976366