### PR TITLE
Improve GUI resilience and clean tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+exclude = repo/pygpt-MHP
+

--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -11,8 +11,14 @@ import subprocess
 import threading
 from pathlib import Path
 
-import tkinter as tk
-from tkinter import messagebox, scrolledtext, ttk
+try:  # pragma: no cover - optional dependency
+    import tkinter as tk
+    from tkinter import messagebox, scrolledtext, ttk
+except Exception:  # pragma: no cover - can't import GUI libs
+    tk = None
+    messagebox = None
+    scrolledtext = None
+    ttk = None
 
 from monkey_head.license_gui import show_license_gui
 from monkey_head.scripts.preload_data import preload_all
@@ -20,6 +26,9 @@ from monkey_head.scripts.preload_data import preload_all
 
 class MainUI:
     def __init__(self, root):
+        if tk is None:
+            raise RuntimeError("tkinter is not available")
+
         self.root = root
         self.root.title("Program Manager")
         self.setup_paths()

--- a/huey/__init__.py
+++ b/huey/__init__.py
@@ -8,6 +8,7 @@
 # ==================================================
 # huey/__init__.py
 
+# flake8: noqa
 from .main import main
 from .utils import *
 from .exceptions import *

--- a/monkey_head/gencore_tkinter.py
+++ b/monkey_head/gencore_tkinter.py
@@ -6,14 +6,21 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import tkinter as tk
-from tkinter import messagebox
+try:  # pragma: no cover - optional dependency
+    import tkinter as tk
+    from tkinter import messagebox
+except Exception:  # pragma: no cover - can't import GUI libs
+    tk = None
+    messagebox = None
 
 
 def create_tkinter_window():
     """
     Creates a simple Tkinter window with a button that shows a message box.
     """
+    if tk is None:
+        raise RuntimeError("tkinter is not available")
+
     root = tk.Tk()
     root.title("Tkinter Window")
 

--- a/monkey_head/license_gui.py
+++ b/monkey_head/license_gui.py
@@ -6,9 +6,15 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import tkinter as tk
 from pathlib import Path
-from tkinter import messagebox, scrolledtext
+
+try:  # pragma: no cover - optional dependency
+    import tkinter as tk
+    from tkinter import messagebox, scrolledtext
+except Exception:  # pragma: no cover - can't import GUI libs
+    tk = None
+    messagebox = None
+    scrolledtext = None
 
 from .config_manager import ConfigManager
 
@@ -21,6 +27,9 @@ def accept_license(config_path: str | Path) -> None:
 
 def show_license_gui(config_path: str | Path = "config/pygpt_net/config.json") -> None:
     """Display a simple license agreement dialog."""
+    if tk is None:
+        raise RuntimeError("tkinter is not available")
+
     manager = ConfigManager(str(config_path))
     if manager.get_setting("license.accepted"):
         return

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,6 +1,3 @@
-import json
-from pathlib import Path
-
 from monkey_head.config_manager import ConfigManager
 
 
@@ -17,4 +14,3 @@ def test_config_manager_default(tmp_path):
     cfg = tmp_path / "missing.json"
     manager = ConfigManager(str(cfg))
     assert manager.get_setting("unknown", "default") == "default"
-

--- a/tests/test_container_management_new.py
+++ b/tests/test_container_management_new.py
@@ -1,4 +1,3 @@
-import subprocess
 from unittest.mock import patch
 
 from monkey_head.services.container_management import (

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -6,7 +6,6 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import os
 import time
 
 from monkey_head.utils.list_by_mtime import list_files_by_mtime

--- a/tests/test_misc_modules.py
+++ b/tests/test_misc_modules.py
@@ -1,10 +1,5 @@
-import os
-import shutil
-import tempfile
-from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 from monkey_head.ai_processor import AIProcessor
 from monkey_head.chapter_splitter import split_chapters
@@ -94,19 +89,23 @@ def test_error_handler(tmp_path):
 
 
 def test_create_tkinter_window():
+
     class DummyRoot:
         def title(self, t):
             self.t = t
+
         def mainloop(self):
             self.ran = True
+
     class DummyButton:
         def __init__(self, root, text, command):
             self.command = command
+
         def pack(self, pady=0):
+
             self.command()
-    with patch('tkinter.Tk', return_value=DummyRoot()) as mtk, \
+    with patch('tkinter.Tk', return_value=DummyRoot()), \
          patch('tkinter.Button', DummyButton), \
          patch('tkinter.messagebox.showinfo') as mbox:
         create_tkinter_window()
         mbox.assert_called_once()
-

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -7,7 +7,6 @@
 # Updated: 06.05.2025
 # ==================================================
 import unittest
-import os
 import sys
 import importlib.util
 from pathlib import Path
@@ -30,7 +29,7 @@ spec = importlib.util.spec_from_file_location("placeholder_module", MODULE_PATH)
 placeholder_module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(placeholder_module)
 Placeholder = placeholder_module.Placeholder
-from pygpt_net.item.preset import PresetItem
+from pygpt_net.item.preset import PresetItem  # noqa: E402
 
 
 class DummyWindow:

--- a/tests/test_preloader.py
+++ b/tests/test_preloader.py
@@ -4,4 +4,6 @@ from monkey_head.scripts.preload_data import preload_all
 def test_preload_all():
     data = preload_all()
     assert data['prompts'], "Prompts should not be empty"
-    assert 'PDF' in data['memory'] and data['memory']['PDF'], "PDF memory should not be empty"
+    assert 'PDF' in data['memory'] and data['memory']['PDF'], (
+        "PDF memory should not be empty"
+    )


### PR DESCRIPTION
## Summary
- handle missing `tkinter` in GUI modules
- silence `flake8` warnings in placeholder test
- tidy dummy classes in `test_misc_modules`
- wrap long assertion in `test_preloader`
- remove stray newline in config manager test

## Testing
- `flake8 huey tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466c98a178832bab277193014acadc