### PR TITLE
Add unified logging across modules

### DIFF
--- a/monkey_head/Huey.py
+++ b/monkey_head/Huey.py
@@ -7,7 +7,7 @@
 # Updated: 06.05.2025
 # ==================================================
 import os
-import logging
+from .logger import get_logger
 import subprocess
 from flask import Flask, jsonify
 
@@ -37,8 +37,7 @@ from .scripts.backup_restore import backup_config, restore_config
 app = Flask(__name__)
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @app.route("/health", methods=["GET"])

--- a/monkey_head/chapter_splitter.py
+++ b/monkey_head/chapter_splitter.py
@@ -6,6 +6,9 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from .logger import get_logger
+
+logger = get_logger(__name__)
 """Utility for splitting a text file into individual chapter files."""
 import os
 
@@ -46,7 +49,9 @@ def split_chapters(input_file, output_dir):
         except OSError as e:
             raise OSError(f"Error writing chapter file '{chapter_file}': {e}")
 
-    print(f"Chapters split and saved to '{output_dir}'")
+    message = f"Chapters split and saved to '{output_dir}'"
+    print(message)
+    logger.info(message)
 
 
 if __name__ == "__main__":
@@ -60,4 +65,5 @@ if __name__ == "__main__":
     try:
         split_chapters(args.input_file, args.output_dir)
     except Exception as e:
+        logger.exception("Error splitting chapters from CLI")
         print(f"Error: {e}")

--- a/monkey_head/cli.py
+++ b/monkey_head/cli.py
@@ -6,8 +6,11 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from .logger import get_logger
 from .config_manager import ConfigManager
 from .file_manager import FileManager
+
+logger = get_logger(__name__)
 
 
 class CLI:
@@ -19,15 +22,20 @@ class CLI:
         while True:
             command = input("Enter command (type 'exit' to quit): ")
             if command == "exit":
+                logger.info("Exiting CLI")
                 break
             elif command.startswith("set "):
                 _, key, value = command.split()
                 self.config_manager.set_setting(key, value)
+                logger.info(f"Set {key} to {value}")
             elif command.startswith("get "):
                 _, key = command.split()
-                print(self.config_manager.get_setting(key))
+                value = self.config_manager.get_setting(key)
+                print(value)
+                logger.info(f"Retrieved setting {key}: {value}")
             else:
                 print("Unknown command")
+                logger.warning(f"Unknown command: {command}")
 
 
 if __name__ == "__main__":

--- a/monkey_head/convert_pdf_to_text.py
+++ b/monkey_head/convert_pdf_to_text.py
@@ -6,6 +6,9 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from .logger import get_logger
+
+logger = get_logger(__name__)
 import os
 from PyPDF2 import PdfReader
 
@@ -42,7 +45,9 @@ def convert_pdf_to_text(pdf_file, output_file):
     except OSError as e:
         raise OSError(f"Error writing text file '{output_file}': {e}")
 
-    print(f"PDF converted to text and saved to '{output_file}'")
+    message = f"PDF converted to text and saved to '{output_file}'"
+    print(message)
+    logger.info(message)
 
 
 if __name__ == "__main__":
@@ -56,4 +61,5 @@ if __name__ == "__main__":
     try:
         convert_pdf_to_text(args.pdf_file, args.output_file)
     except Exception as e:
+        logger.exception("Error converting PDF from CLI")
         print(f"Error: {e}")

--- a/monkey_head/core/installations.py
+++ b/monkey_head/core/installations.py
@@ -6,11 +6,11 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import logging
 import subprocess
 from .system_checks import check_error
+from ..logger import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def install_common_tools():

--- a/monkey_head/core/system_checks.py
+++ b/monkey_head/core/system_checks.py
@@ -6,11 +6,11 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import logging
 import os
 import subprocess
+from ..logger import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def ensure_admin() -> None:

--- a/monkey_head/gencore.py
+++ b/monkey_head/gencore.py
@@ -6,6 +6,9 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from .logger import get_logger
+
+logger = get_logger(__name__)
 def generate_core_data(input_data):
     """
     Generates core data based on the input data.
@@ -22,7 +25,9 @@ def generate_core_data(input_data):
         core_data["processed"] = True
         core_data["input_length"] = len(input_data)
         core_data["details"] = input_data
+        logger.debug("Core data generated successfully")
     except Exception as e:
+        logger.exception("Error generating core data")
         raise ValueError(f"Error generating core data: {e}")
 
     return core_data
@@ -41,6 +46,9 @@ if __name__ == "__main__":
     try:
         input_data = json.loads(args.input_data)
         core_data = generate_core_data(input_data)
-        print(json.dumps(core_data, indent=4))
+        output = json.dumps(core_data, indent=4)
+        print(output)
+        logger.info(output)
     except Exception as e:
+        logger.exception("Error generating core data from CLI")
         print(f"Error: {e}")

--- a/monkey_head/gencore_checks.py
+++ b/monkey_head/gencore_checks.py
@@ -6,6 +6,9 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from .logger import get_logger
+
+logger = get_logger(__name__)
 def check_core_data(core_data):
     """
     Checks the validity of core data.
@@ -25,8 +28,10 @@ def check_core_data(core_data):
             core_data["input_length"], int
         ):
             raise ValueError("Invalid input length in core data.")
+        logger.debug("Core data validated successfully")
         return True
     except Exception as e:
+        logger.exception("Error checking core data")
         print(f"Error checking core data: {e}")
         return False
 
@@ -42,6 +47,9 @@ if __name__ == "__main__":
     try:
         core_data = json.loads(args.core_data)
         is_valid = check_core_data(core_data)
-        print(f"Core data is valid: {is_valid}")
+        message = f"Core data is valid: {is_valid}"
+        print(message)
+        logger.info(message)
     except Exception as e:
+        logger.exception("Error validating core data from CLI")
         print(f"Error: {e}")

--- a/monkey_head/gencore_core.py
+++ b/monkey_head/gencore_core.py
@@ -6,6 +6,9 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from .logger import get_logger
+
+logger = get_logger(__name__)
 def process_core_data(input_data):
     """
     Processes the input data to generate core data.
@@ -22,7 +25,9 @@ def process_core_data(input_data):
         core_data["processed"] = True
         core_data["input_length"] = len(input_data)
         core_data["details"] = {k: v for k, v in input_data.items() if v is not None}
+        logger.debug("Core data processed successfully")
     except Exception as e:
+        logger.exception("Error processing core data")
         raise ValueError(f"Error processing core data: {e}")
 
     return core_data
@@ -41,6 +46,9 @@ if __name__ == "__main__":
     try:
         input_json = json.loads(args.input_data)
         core_data = process_core_data(input_json)
-        print(json.dumps(core_data, indent=4))
+        output = json.dumps(core_data, indent=4)
+        print(output)
+        logger.info(output)
     except Exception as e:
+        logger.exception("Error processing core data from CLI")
         print(f"Error: {e}")

--- a/monkey_head/gencore_disk_manager_temp.py
+++ b/monkey_head/gencore_disk_manager_temp.py
@@ -6,6 +6,9 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from .logger import get_logger
+
+logger = get_logger(__name__)
 import os
 import shutil
 
@@ -32,13 +35,18 @@ def manage_temp_files(temp_dir, action):
         if action == "delete":
             shutil.rmtree(temp_dir)
             os.makedirs(temp_dir)
+            logger.info(f"Temporary files in '{temp_dir}' deleted.")
             print(f"Temporary files in '{temp_dir}' deleted.")
         elif action == "archive":
             archive_dir = temp_dir + "_archive"
             shutil.move(temp_dir, archive_dir)
             os.makedirs(temp_dir)
+            logger.info(
+                f"Temporary files in '{temp_dir}' archived to '{archive_dir}'."
+            )
             print(f"Temporary files in '{temp_dir}' archived to '{archive_dir}'.")
     except OSError as e:
+        logger.exception("Error managing temporary files")
         raise OSError(f"Error managing temporary files in '{temp_dir}': {e}")
 
 
@@ -59,4 +67,5 @@ if __name__ == "__main__":
     try:
         manage_temp_files(args.temp_dir, args.action)
     except Exception as e:
+        logger.exception("Error managing temporary files from CLI")
         print(f"Error: {e}")

--- a/monkey_head/gencore_linux.py
+++ b/monkey_head/gencore_linux.py
@@ -6,6 +6,9 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from .logger import get_logger
+
+logger = get_logger(__name__)
 import subprocess
 
 
@@ -30,14 +33,19 @@ def check_linux_service(service_name):
         )
         status = result.stdout.decode("utf-8").strip()
         if status == "active":
+            logger.debug(f"Service {service_name} is active")
             return "active"
         elif status == "inactive":
+            logger.debug(f"Service {service_name} is inactive")
             return "inactive"
         elif status == "failed":
+            logger.debug(f"Service {service_name} has failed")
             return "failed"
         else:
+            logger.debug(f"Service {service_name} status unknown: {status}")
             return "unknown"
     except OSError as e:
+        logger.exception("Error checking linux service")
         raise OSError(f"Error checking service '{service_name}': {e}")
 
 
@@ -50,6 +58,9 @@ if __name__ == "__main__":
 
     try:
         status = check_linux_service(args.service_name)
-        print(f"Service '{args.service_name}' is {status}.")
+        message = f"Service '{args.service_name}' is {status}."
+        print(message)
+        logger.info(message)
     except Exception as e:
+        logger.exception("Error checking linux service from CLI")
         print(f"Error: {e}")

--- a/monkey_head/gencore_remover.py
+++ b/monkey_head/gencore_remover.py
@@ -6,6 +6,9 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from .logger import get_logger
+
+logger = get_logger(__name__)
 import os
 
 
@@ -29,8 +32,10 @@ def remove_files(directory, extension):
             if filename.endswith(extension):
                 file_path = os.path.join(directory, filename)
                 os.remove(file_path)
+                logger.info(f"Removed file: {file_path}")
                 print(f"Removed file: {file_path}")
     except OSError as e:
+        logger.exception("Error removing files")
         raise OSError(
             f"Error removing files in '{directory}': {e}"
         ) from e
@@ -49,4 +54,5 @@ if __name__ == "__main__":
     try:
         remove_files(args.directory, args.extension)
     except Exception as e:
+        logger.exception("Error removing files from CLI")
         print(f"Error: {e}")

--- a/monkey_head/logger.py
+++ b/monkey_head/logger.py
@@ -1,0 +1,20 @@
+import logging
+import os
+
+
+def get_logger(name: str = __name__, log_file: str = "logs/app.log", level=logging.INFO) -> logging.Logger:
+    """Return a configured logger that writes to ``log_file``.
+
+    If the logger already has handlers configured, they will be reused.
+    """
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.FileHandler(log_file)
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(level)
+    return logger

--- a/monkey_head/main.py
+++ b/monkey_head/main.py
@@ -6,8 +6,8 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import logging
 from flask import Flask, jsonify
+from .logger import get_logger
 from .core.system_checks import system_check, ensure_admin
 from .modules.updates import update_system, update_python_packages
 from .core.installations import (
@@ -33,8 +33,7 @@ from .scripts.backup_restore import backup_config, restore_config
 app = Flask(__name__)
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @app.route("/health", methods=["GET"])

--- a/monkey_head/modules/updates.py
+++ b/monkey_head/modules/updates.py
@@ -6,11 +6,11 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import logging
 import subprocess
+from ..logger import get_logger
 from ..core.system_checks import check_error
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def update_system():

--- a/monkey_head/scripts/backup_restore.py
+++ b/monkey_head/scripts/backup_restore.py
@@ -7,11 +7,11 @@
 # Updated: 06.05.2025
 # ==================================================
 import os
-import logging
 import subprocess
 from ..core.system_checks import check_error
+from ..logger import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def backup_config():

--- a/monkey_head/services/container_management.py
+++ b/monkey_head/services/container_management.py
@@ -6,13 +6,13 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import logging
 import os
 import subprocess
+from ..logger import get_logger
 
 from ..core.system_checks import check_error
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def manage_containers():

--- a/monkey_head/services/environment_setup.py
+++ b/monkey_head/services/environment_setup.py
@@ -7,12 +7,12 @@
 # Updated: 06.05.2025
 # ==================================================
 import os
-import logging
 import subprocess
+from ..logger import get_logger
 
 from ..core.system_checks import check_error
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 DEFAULT_REPO_URL = "https://github.com/DylanLRPollock/Monkey-Head-Project.git"

--- a/monkey_head/subos_manager.py
+++ b/monkey_head/subos_manager.py
@@ -7,13 +7,13 @@
 # Updated: 06.05.2025
 # ==================================================
 import os
-import logging
 import subprocess
+from .logger import get_logger
 import pwd
 
 from .core.system_checks import check_error, ensure_admin
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def update_system() -> None:

--- a/monkey_head/utils/list_by_mtime.py
+++ b/monkey_head/utils/list_by_mtime.py
@@ -6,6 +6,9 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+from ..logger import get_logger
+
+logger = get_logger(__name__)
 import os
 from typing import List
 
@@ -34,3 +37,4 @@ if __name__ == "__main__":
 
     for file_path in list_files_by_mtime(args.directory):
         print(file_path)
+        logger.info(f"Listed file: {file_path}")


### PR DESCRIPTION
## Summary
- introduce `logger.py` to centralize logging setup
- hook up the new logger in CLI helpers and utilities
- record log events when running CLI tools
- extend unified logger usage across remaining modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68467bc1f258832bb5ede301d25f89c1