### PR TITLE
Fix naming consistency

### DIFF
--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -1,6 +1,6 @@
 services:
   dev-env:
-    container_name: monkey-head-app
+    container_name: monkey-head
     # Build options
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   dev-env:
-    container_name: monkey-head-app
+    container_name: monkey-head
     build:
       context: .
       args:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except FileNotFoundError:
     long_description = "Long description could not be read from README.md"
 
 setup(
-    name='MonkeyHeadProject',
+    name='monkey-head-project',
     version='1.0.1',
     description='A project integrating diverse functionalities including ML, web frameworks, and more.',
     long_description=long_description,
@@ -84,7 +84,7 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'monkeyhead=huey.cli:run_cli'
+            'monkey-head=huey.cli:run_cli'
         ]
     },
 )


### PR DESCRIPTION
## Summary
- standardize container names in Docker compose files
- unify Python package name and console entry point

## Testing
- `pytest -vv`

------
https://chatgpt.com/codex/tasks/task_e_68467e611b38832b9f35f908f20b7429