### PR TITLE
Implement unified logger across modules

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -12,8 +12,9 @@ from .formatter import format_text
 from .gencore import generate_core_data
 from . import subos_manager
 from .logging_setup import configure_logging
+from .utils.logger import get_logger
 
 # Initialize project-wide logging as soon as the package is imported
 configure_logging()
 
-__all__ = ["format_text", "generate_core_data", "subos_manager"]
+__all__ = ["format_text", "generate_core_data", "subos_manager", "get_logger"]

--- a/monkey_head/main.py
+++ b/monkey_head/main.py
@@ -6,7 +6,7 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import logging
+from monkey_head.utils.logger import get_logger
 from flask import Flask, jsonify
 from .core.system_checks import system_check, ensure_admin
 from .modules.updates import update_system, update_python_packages
@@ -33,9 +33,9 @@ from .logging_setup import configure_logging
 
 app = Flask(__name__)
 
-# Configure logging using project settings
+# Configure centralized logging
 configure_logging()
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @app.route("/health", methods=["GET"])

--- a/monkey_head/scripts/backup_restore.py
+++ b/monkey_head/scripts/backup_restore.py
@@ -7,13 +7,11 @@
 # Updated: 06.05.2025
 # ==================================================
 import os
-import logging
-from ..logging_setup import configure_logging
+from ..utils.logger import get_logger
 import subprocess
 from ..core.system_checks import check_error
 
-configure_logging()
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def backup_config():

--- a/monkey_head/services/container_management.py
+++ b/monkey_head/services/container_management.py
@@ -6,15 +6,13 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
-import logging
 import os
 import subprocess
-from ..logging_setup import configure_logging
+from ..utils.logger import get_logger
 
 from ..core.system_checks import check_error
 
-configure_logging()
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def manage_containers():

--- a/monkey_head/services/environment_setup.py
+++ b/monkey_head/services/environment_setup.py
@@ -7,14 +7,12 @@
 # Updated: 06.05.2025
 # ==================================================
 import os
-import logging
 import subprocess
-from ..logging_setup import configure_logging
+from ..utils.logger import get_logger
 
 from ..core.system_checks import check_error
 
-configure_logging()
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 DEFAULT_REPO_URL = "https://github.com/DylanLRPollock/Monkey-Head-Project.git"

--- a/monkey_head/utils/logger.py
+++ b/monkey_head/utils/logger.py
@@ -1,0 +1,9 @@
+"""Centralized logging utilities for Monkey Head."""
+import logging
+from ..logging_setup import configure_logging
+
+
+def get_logger(name: str | None = None) -> logging.Logger:
+    """Return a logger with the given name configured via project settings."""
+    configure_logging()
+    return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- add `get_logger` utility for centralized logging
- export `get_logger` in package init
- use `get_logger` in backup scripts, environment setup, container management
- switch `main.py` to use the unified logger

## Testing
- `pip install pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68467e93d974832bb44dc97c2ce2a199