### PR TITLE
Add memory PDF updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ activates the project's virtual environment and launches `run.py`. The
 `run-tests.sh` script performs the same activation step before executing
 the test suite with `pytest -vv`. Both scripts report an error if the
 `venv` directory is missing, reminding you to run `install.sh` first.
+`update_memory_pdfs.py` regenerates text versions of the bundled PDF files
+under `memory/PDF`. Run this script whenever you add or edit PDF documents
+to keep the preloaded dataset up to date.
 
 ### Docker and Kubernetes Utilities
 

--- a/monkey_head/scripts/update_memory_pdfs.py
+++ b/monkey_head/scripts/update_memory_pdfs.py
@@ -1,0 +1,34 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.05.2025
+# ==================================================
+import logging
+from pathlib import Path
+
+from .convert_pdf_to_text import convert_pdf_to_text, save_text_to_file
+from ..logging_setup import configure_logging
+
+configure_logging()
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+PDF_DIR = BASE_DIR / "memory" / "PDF"
+
+
+def update_memory_pdfs() -> None:
+    """Regenerate text files for bundled PDF documents."""
+    if not PDF_DIR.is_dir():
+        logging.error(f"PDF directory {PDF_DIR} not found")
+        return
+
+    for pdf_path in sorted(PDF_DIR.glob("*.pdf")):
+        txt_path = PDF_DIR / f"{pdf_path.stem}.txt"
+        text = convert_pdf_to_text(str(pdf_path))
+        save_text_to_file(text, txt_path)
+
+
+if __name__ == "__main__":
+    update_memory_pdfs()


### PR DESCRIPTION
## Summary
- add `update_memory_pdfs.py` script to regenerate text files for bundled PDF docs
- document the new script in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0a798cd4832b973e9fb8cc5e113d