### PR TITLE
Improve GUI scaling for 4K screens

### DIFF
--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -22,6 +22,7 @@ except Exception:  # pragma: no cover - can't import GUI libs
 
 from monkey_head.license_gui import show_license_gui
 from monkey_head.scripts.preload_data import preload_all
+from monkey_head.gui_scaling import apply_scaling
 
 
 class MainUI:
@@ -30,6 +31,7 @@ class MainUI:
             raise RuntimeError("tkinter is not available")
 
         self.root = root
+        apply_scaling(self.root)
         self.root.title("Program Manager")
         self.setup_paths()
         self.create_menu()

--- a/monkey_head/gencore_tkinter.py
+++ b/monkey_head/gencore_tkinter.py
@@ -9,6 +9,7 @@
 try:  # pragma: no cover - optional dependency
     import tkinter as tk
     from tkinter import messagebox
+    from .gui_scaling import apply_scaling
 except Exception:  # pragma: no cover - can't import GUI libs
     tk = None
     messagebox = None
@@ -22,6 +23,7 @@ def create_tkinter_window():
         raise RuntimeError("tkinter is not available")
 
     root = tk.Tk()
+    apply_scaling(root)
     root.title("Tkinter Window")
 
     def show_message():

--- a/monkey_head/gui_scaling.py
+++ b/monkey_head/gui_scaling.py
@@ -1,0 +1,38 @@
+"""Utilities for scaling Tkinter GUIs on high-DPI displays."""
+
+try:
+    import tkinter as tk  # pragma: no cover - optional dependency
+    from tkinter import font as tkfont
+except Exception:  # pragma: no cover - can't import GUI libs
+    tk = None
+    tkfont = None
+
+
+def apply_scaling(root: "tk.Tk", factor: float = 2.0, font_size: int = 14) -> None:
+    """Apply global scaling and increase default font sizes.
+
+    Parameters
+    ----------
+    root: tk.Tk
+        The root window instance.
+    factor: float, optional
+        Scaling factor for HiDPI displays. Default is ``2.0``.
+    font_size: int, optional
+        Base font size to apply. Default is ``14``.
+    """
+    if tk is None or tkfont is None:
+        return
+
+    try:
+        root.tk.call("tk", "scaling", factor)
+    except Exception:
+        pass
+
+    for name in ("TkDefaultFont", "TkTextFont", "TkFixedFont", "TkMenuFont"):
+        try:
+            f = tkfont.nametofont(name)
+            f.configure(size=font_size)
+        except Exception:
+            continue
+
+__all__ = ["apply_scaling"]

--- a/monkey_head/license_gui.py
+++ b/monkey_head/license_gui.py
@@ -17,6 +17,7 @@ except Exception:  # pragma: no cover - can't import GUI libs
     scrolledtext = None
 
 from .config_manager import ConfigManager
+from .gui_scaling import apply_scaling
 
 
 def accept_license(config_path: str | Path) -> None:
@@ -35,6 +36,7 @@ def show_license_gui(config_path: str | Path = "config/pygpt_net/config.json") -
         return
 
     root = tk.Tk()
+    apply_scaling(root)
     root.title("License Agreement")
 
     text = scrolledtext.ScrolledText(root, width=80, height=20, wrap=tk.WORD)

--- a/monkey_head/pygpt_net/data/config/config.json
+++ b/monkey_head/pygpt_net/data/config/config.json
@@ -149,10 +149,10 @@
   "debug.render": false,
   "download.dir": "download",
   "experts.mode": "chat",
-  "font_size": 12,
-  "font_size.input": 12,
-  "font_size.ctx": 12,
-  "font_size.toolbox": 12,
+  "font_size": 16,
+  "font_size.input": 16,
+  "font_size.ctx": 16,
+  "font_size.toolbox": 16,
   "func_call.native": true,
   "frequency_penalty": 0.0,
   "img_dialog_open": true,
@@ -172,7 +172,7 @@
   "layout.dialog.geometry.store": true,
   "layout.dialog.geometry": {},
   "layout.dpi.scaling": true,
-  "layout.dpi.factor": 1.0,
+  "layout.dpi.factor": 2.0,
   "layout.groups": {},
   "layout.splitters": {
         "columns": [


### PR DESCRIPTION
## Summary
- increase default font sizes and DPI factor
- add helper to scale Tkinter GUIs
- apply high DPI scaling in main UI and license dialogs
- apply scaling to Tkinter sample window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a12cb7d70832b9a1fba209018d3f9