### PR TITLE
Add selectable display scaling

### DIFF
--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -6,6 +6,7 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.05.2025
 # ==================================================
+import os
 import platform
 import subprocess
 import threading
@@ -31,12 +32,26 @@ class MainUI:
             raise RuntimeError("tkinter is not available")
 
         self.root = root
-        apply_scaling(self.root)
+        mode = self.choose_screen_mode()
+        apply_scaling(self.root, mode)
         self.root.title("Program Manager")
         self.setup_paths()
         self.create_menu()
         self.create_widgets()
         self.check_license()
+
+    def choose_screen_mode(self) -> str:
+        """Ask the user which display mode to use or read from ``SCREEN_MODE``."""
+        env_mode = os.environ.get("SCREEN_MODE")
+        if env_mode in {"1080p", "4k"}:
+            return env_mode
+        if messagebox is not None:
+            resp = messagebox.askquestion(
+                "Display Mode",
+                "Use 4K display scaling?",
+            )
+            return "4k" if resp == "yes" else "1080p"
+        return "1080p"
 
     def setup_paths(self):
         """Determine installer paths based on the current platform."""

--- a/monkey_head/gencore_tkinter.py
+++ b/monkey_head/gencore_tkinter.py
@@ -15,7 +15,7 @@ except Exception:  # pragma: no cover - can't import GUI libs
     messagebox = None
 
 
-def create_tkinter_window():
+def create_tkinter_window(mode: str = "4k"):
     """
     Creates a simple Tkinter window with a button that shows a message box.
     """
@@ -23,7 +23,7 @@ def create_tkinter_window():
         raise RuntimeError("tkinter is not available")
 
     root = tk.Tk()
-    apply_scaling(root)
+    apply_scaling(root, mode)
     root.title("Tkinter Window")
 
     def show_message():

--- a/monkey_head/gui_scaling.py
+++ b/monkey_head/gui_scaling.py
@@ -8,20 +8,27 @@ except Exception:  # pragma: no cover - can't import GUI libs
     tkfont = None
 
 
-def apply_scaling(root: "tk.Tk", factor: float = 2.0, font_size: int = 14) -> None:
-    """Apply global scaling and increase default font sizes.
+def apply_scaling(root: "tk.Tk", mode: str = "4k") -> None:
+    """Apply global scaling based on the selected display mode.
 
     Parameters
     ----------
     root: tk.Tk
         The root window instance.
-    factor: float, optional
-        Scaling factor for HiDPI displays. Default is ``2.0``.
-    font_size: int, optional
-        Base font size to apply. Default is ``14``.
+    mode: str, optional
+        ``"1080p"`` or ``"4k"`` to adjust scaling appropriately. Defaults to
+        ``"4k"``.
     """
     if tk is None or tkfont is None:
         return
+
+    mode = (mode or "4k").lower()
+    if mode == "1080p":
+        factor = 1.0
+        font_size = 10
+    else:
+        factor = 2.0
+        font_size = 14
 
     try:
         root.tk.call("tk", "scaling", factor)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -23,3 +23,20 @@ def test_show_data_summary_displays_info():
          patch('gui.main_ui.messagebox.showinfo') as info:
         MainUI.show_data_summary(ui)
         info.assert_called_once()
+
+
+def test_choose_screen_mode_env(monkeypatch):
+    ui = MainUI.__new__(MainUI)
+    monkeypatch.setenv("SCREEN_MODE", "1080p")
+    with patch('gui.main_ui.messagebox.askquestion') as ask:
+        mode = MainUI.choose_screen_mode(ui)
+        ask.assert_not_called()
+        assert mode == "1080p"
+
+
+def test_choose_screen_mode_prompt():
+    ui = MainUI.__new__(MainUI)
+    with patch.dict('os.environ', {}, clear=True), \
+         patch('gui.main_ui.messagebox.askquestion', return_value='yes'):
+        mode = MainUI.choose_screen_mode(ui)
+        assert mode == "4k"

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,0 +1,31 @@
+from monkey_head.gui_scaling import apply_scaling
+
+class DummyTk:
+    def __init__(self):
+        self.args = None
+    def call(self, *args):
+        self.args = args
+
+class DummyRoot:
+    def __init__(self):
+        self.tk = DummyTk()
+
+class DummyFont:
+    def configure(self, size=None):
+        self.size = size
+
+class DummyFontModule:
+    def nametofont(self, name):
+        return DummyFont()
+
+def test_apply_scaling_1080p(monkeypatch):
+    monkeypatch.setattr('monkey_head.gui_scaling.tkfont', DummyFontModule())
+    root = DummyRoot()
+    apply_scaling(root, mode='1080p')
+    assert root.tk.args == ('tk', 'scaling', 1.0)
+
+def test_apply_scaling_4k(monkeypatch):
+    monkeypatch.setattr('monkey_head.gui_scaling.tkfont', DummyFontModule())
+    root = DummyRoot()
+    apply_scaling(root, mode='4k')
+    assert root.tk.args == ('tk', 'scaling', 2.0)


### PR DESCRIPTION
## Summary
- let the GUI ask for 1080p or 4k display scaling
- update scaling utility to support display mode
- allow gencore Tkinter window to accept display mode
- add tests for new scaling behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a14091884832ba3893153ce005cf7