### PR TITLE
Install to OS-specific program folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Run the cross-platform installer with root privileges:
 sudo python installer.py
 ```
 
-This invokes `setup/Debian13/install.sh`, which updates `/etc/apt/sources.list` to Debian **Trixie**, installs Git, Node.js, Python 3, and Docker, then creates a virtual environment and preloads bundled data. Accept the license agreement when prompted.
+This invokes `setup/Debian13/install.sh`, which updates `/etc/apt/sources.list` to Debian **Trixie**, installs Git, Node.js, Python 3, and Docker, then creates a virtual environment and preloads bundled data. Accept the license agreement when prompted. The project files are copied to `/opt/monkey_head`.
 
 
 ### macOS Installation
@@ -211,6 +211,7 @@ ensures Homebrew is available, installs Git, Python 3, Docker, and sets up the
 project's Python virtual environment automatically. During setup it also
 initializes git submodules, displays the license agreement, and preloads bundled
 data.
+All files are installed into `/Applications/MonkeyHeadProject`.
 
 ### Windows 10 & 11 Installation
 
@@ -229,6 +230,7 @@ This launches `setup/Windows11/01-FULL.bat`, which installs Chocolatey, Git,
 Docker Desktop, and other required tools on Windows. On macOS the installer
 invokes `setup/macOS/install.sh` to configure Homebrew and the Python
 environment. The batch script supports both Windows 10 and Windows 11.
+By default the repository is cloned to `%ProgramFiles%\Monkey-Head-Project`.
 
 ### Uninstallation and Cleanup
 

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -13,7 +13,11 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-VENV_DIR="venv"
+# Install location for the application
+INSTALL_DIR="/opt/monkey_head"
+
+# Virtual environment lives inside the install directory
+VENV_DIR="$INSTALL_DIR/venv"
 
 function error_exit {
     echo "$1" >&2
@@ -24,6 +28,17 @@ function ensure_root {
     if [ "$EUID" -ne 0 ]; then
         echo "Please run this script with sudo or as root." >&2
         exit 1
+    fi
+}
+
+function copy_project_files {
+    if [ "$PROJECT_ROOT" != "$INSTALL_DIR" ]; then
+        echo "Copying project files to $INSTALL_DIR..."
+        mkdir -p "$INSTALL_DIR" || error_exit "Cannot create $INSTALL_DIR"
+        rsync -a --exclude 'venv' "$PROJECT_ROOT/" "$INSTALL_DIR/" || \
+            error_exit "Failed to copy project files"
+        PROJECT_ROOT="$INSTALL_DIR"
+        cd "$PROJECT_ROOT" || error_exit "Cannot cd to $PROJECT_ROOT"
     fi
 }
 
@@ -70,6 +85,7 @@ function update_submodules {
 }
 
 ensure_root
+copy_project_files
 update_system
 install_common_tools
 install_additional_tools

--- a/setup/Debian13/uninstall.sh
+++ b/setup/Debian13/uninstall.sh
@@ -10,7 +10,12 @@
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-VENV_DIR="$PROJECT_ROOT/venv"
+
+# Installation directory
+INSTALL_DIR="/opt/monkey_head"
+
+# Virtual environment inside the installation directory
+VENV_DIR="$INSTALL_DIR/venv"
 
 function error_exit() {
     echo "$1" >&2
@@ -42,9 +47,17 @@ function cleanup_docker() {
     docker system prune -a -f --volumes || true
 }
 
+function remove_install_dir() {
+    if [ -d "$INSTALL_DIR" ]; then
+        echo "Removing installed files..."
+        rm -rf "$INSTALL_DIR"
+    fi
+}
+
 ensure_root
 remove_python_env
 remove_packages
 cleanup_docker
+remove_install_dir
 
 echo "Uninstallation completed successfully."

--- a/setup/Windows11/01-FULL.bat
+++ b/setup/Windows11/01-FULL.bat
@@ -9,6 +9,9 @@
 @echo off
 setlocal enabledelayedexpansion
 
+:: Default installation directory
+set "INSTALL_DIR=%ProgramFiles%\Monkey-Head-Project"
+
 :: Change to the script's own directory
 cd /d "%~dp0"
 
@@ -109,18 +112,20 @@ goto :eof
 :: Function to clone the repository
 :cloneRepository
 echo Cloning repository...
-if not exist "%USERPROFILE%\Source" mkdir "%USERPROFILE%\Source"
-cd "%USERPROFILE%\Source"
-git clone --recurse-submodules https://github.com/DylanLRPollock/Monkey-Head-Project.git
+if exist "%INSTALL_DIR%" (
+    rmdir /S /Q "%INSTALL_DIR%"
+)
+mkdir "%INSTALL_DIR%"
+cd "%INSTALL_DIR%"
+git clone --recurse-submodules https://github.com/DylanLRPollock/Monkey-Head-Project.git .
 call :checkError "Git Clone"
-cd Monkey-Head-Project
 git submodule update --init --recursive
 goto :eof
 
 :: Function to set up Python environment
 :setupPythonEnv
 echo Setting up Python environment...
-cd "%USERPROFILE%\Source\Monkey-Head-Project"
+cd "%INSTALL_DIR%"
 python -m venv venv
 call :checkError "Python Virtual Environment Setup"
 venv\Scripts\activate

--- a/setup/Windows11/03-CLEANUP.bat
+++ b/setup/Windows11/03-CLEANUP.bat
@@ -9,6 +9,9 @@
 @echo off
 setlocal enabledelayedexpansion
 
+:: Installation directory used during setup
+set "INSTALL_DIR=%ProgramFiles%\Monkey-Head-Project"
+
 :: Change to the script's own directory
 cd /d "%~dp0"
 
@@ -46,8 +49,8 @@ goto :eof
 :: Function to remove virtual environment
 :removeVirtualEnv
 echo Removing virtual environment...
-if exist "repository\venv" (
-    rmdir /S /Q "repository\venv"
+if exist "%INSTALL_DIR%\venv" (
+    rmdir /S /Q "%INSTALL_DIR%\venv"
     call :checkError "Removing Virtual Environment"
 ) else (
     echo No virtual environment found.
@@ -56,12 +59,12 @@ goto :eof
 
 :: Function to remove cloned repository
 :removeRepository
-echo Removing cloned repository...
-if exist "repository" (
-    rmdir /S /Q "repository"
-    call :checkError "Removing Cloned Repository"
+echo Removing installed files...
+if exist "%INSTALL_DIR%" (
+    rmdir /S /Q "%INSTALL_DIR%"
+    call :checkError "Removing Installed Files"
 ) else (
-    echo No cloned repository found.
+    echo No installation directory found.
 )
 goto :eof
 

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -10,10 +10,27 @@
 
 set -e
 
-VENV_DIR="venv"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Application install location
+INSTALL_DIR="/Applications/MonkeyHeadProject"
+
+# Virtual environment inside the install directory
+VENV_DIR="$INSTALL_DIR/venv"
 
 function command_exists() {
     command -v "$1" >/dev/null 2>&1
+}
+
+function copy_project_files() {
+    if [ "$PROJECT_ROOT" != "$INSTALL_DIR" ]; then
+        echo "Copying project files to $INSTALL_DIR..."
+        mkdir -p "$INSTALL_DIR" || exit 1
+        rsync -a --exclude 'venv' "$PROJECT_ROOT/" "$INSTALL_DIR/" || exit 1
+        PROJECT_ROOT="$INSTALL_DIR"
+        cd "$PROJECT_ROOT" || exit 1
+    fi
 }
 
 function install_homebrew() {
@@ -56,6 +73,7 @@ function update_submodules() {
 }
 
 install_homebrew
+copy_project_files
 install_packages
 update_submodules
 setup_python_env

--- a/setup/macOS/uninstall.sh
+++ b/setup/macOS/uninstall.sh
@@ -8,7 +8,15 @@
 # Updated:   06.05.2025
 # ==================================================
 set -e
-VENV_DIR="venv"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Installation directory
+INSTALL_DIR="/Applications/MonkeyHeadProject"
+
+# Virtual environment path
+VENV_DIR="$INSTALL_DIR/venv"
 
 function command_exists() {
     command -v "$1" >/dev/null 2>&1
@@ -34,8 +42,16 @@ function cleanup_docker() {
     docker system prune -a -f --volumes || true
 }
 
+function remove_install_dir() {
+    if [ -d "$INSTALL_DIR" ]; then
+        echo "Removing installed files..."
+        rm -rf "$INSTALL_DIR"
+    fi
+}
+
 remove_python_env
 remove_packages
 cleanup_docker
+remove_install_dir
 
 echo "Uninstallation completed successfully."


### PR DESCRIPTION
## Summary
- install to `/opt/monkey_head` on Debian
- install to `/Applications/MonkeyHeadProject` on macOS
- install to `%ProgramFiles%\Monkey-Head-Project` on Windows
- remove installed files on uninstall
- document install locations

## Testing
- `bash run-tests.sh` *(fails: Virtual environment not found)*
- `pytest -q` *(fails: PyYAML missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a2195adc8832ba67fc231d46a4d48