### PR TITLE
Add JPEG to PNG conversion utility

### DIFF
--- a/huey/utils.py
+++ b/huey/utils.py
@@ -9,6 +9,11 @@
 # huey/utils.py
 
 import logging
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+
 from .exceptions import InvalidInputError
 
 
@@ -37,3 +42,35 @@ def validate_input(value, expected_type):
     if not isinstance(value, expected_type):
         raise InvalidInputError(f"Expected {expected_type}, got {type(value)} instead.")
     return True
+
+
+def convert_jpeg_to_png(jpeg_path: str, png_path: Optional[str] | None = None) -> str:
+    """Convert a JPEG image to PNG format.
+
+    Parameters
+    ----------
+    jpeg_path : str
+        Path to the input JPEG file.
+    png_path : str, optional
+        Desired output path for the PNG file. Defaults to the same base name
+        as ``jpeg_path`` with a ``.png`` extension.
+
+    Returns
+    -------
+    str
+        The path to the saved PNG image.
+    """
+
+    jpeg_file = Path(jpeg_path)
+    if not jpeg_file.is_file():
+        raise FileNotFoundError(f"{jpeg_path} does not exist")
+
+    if png_path is None:
+        png_file = jpeg_file.with_suffix(".png")
+    else:
+        png_file = Path(png_path)
+
+    with Image.open(jpeg_file) as img:
+        img.save(png_file, format="PNG")
+
+    return str(png_file)

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,31 +1,38 @@
 from monkey_head.gui_scaling import apply_scaling
 
+
 class DummyTk:
     def __init__(self):
         self.args = None
+
     def call(self, *args):
         self.args = args
+
 
 class DummyRoot:
     def __init__(self):
         self.tk = DummyTk()
 
+
 class DummyFont:
     def configure(self, size=None):
         self.size = size
+
 
 class DummyFontModule:
     def nametofont(self, name):
         return DummyFont()
 
+
 def test_apply_scaling_1080p(monkeypatch):
-    monkeypatch.setattr('monkey_head.gui_scaling.tkfont', DummyFontModule())
+    monkeypatch.setattr("monkey_head.gui_scaling.tkfont", DummyFontModule())
     root = DummyRoot()
-    apply_scaling(root, mode='1080p')
-    assert root.tk.args == ('tk', 'scaling', 1.0)
+    apply_scaling(root, mode="1080p")
+    assert root.tk.args == ("tk", "scaling", 1.0)
+
 
 def test_apply_scaling_4k(monkeypatch):
-    monkeypatch.setattr('monkey_head.gui_scaling.tkfont', DummyFontModule())
+    monkeypatch.setattr("monkey_head.gui_scaling.tkfont", DummyFontModule())
     root = DummyRoot()
-    apply_scaling(root, mode='4k')
-    assert root.tk.args == ('tk', 'scaling', 2.0)
+    apply_scaling(root, mode="4k")
+    assert root.tk.args == ("tk", "scaling", 2.0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,8 +8,13 @@
 # ==================================================
 # tests/test_utils.py
 
+import os
+from pathlib import Path
 import unittest
-from huey.utils import calculate_sum, validate_input
+
+from PIL import Image
+
+from huey.utils import calculate_sum, validate_input, convert_jpeg_to_png
 from huey.exceptions import InvalidInputError
 
 
@@ -22,6 +27,25 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(validate_input(5, int))
         with self.assertRaises(InvalidInputError):
             validate_input("five", int)
+
+    def test_convert_jpeg_to_png(self):
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            img = Image.new("RGB", (10, 10), color="red")
+            jpeg_path = tmp_path / "img.jpg"
+            img.save(jpeg_path, "JPEG")
+
+            png_path = convert_jpeg_to_png(str(jpeg_path))
+            assert os.path.exists(png_path)
+            assert Path(png_path).suffix == ".png"
+
+            custom_out = tmp_path / "out" / "out.png"
+            custom_out.parent.mkdir()
+            result_path = convert_jpeg_to_png(str(jpeg_path), str(custom_out))
+            assert result_path == str(custom_out)
+            assert custom_out.is_file()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `convert_jpeg_to_png` helper in `huey.utils`
- extend test suite for the new function
- tidy `test_scaling` formatting so flake8 passes

## Testing
- `flake8 huey tests`
- `pytest tests/test_utils.py tests/test_scaling.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2fb7bcc4832bb2f4f16e2c4cc81a