### PR TITLE
Add hardware selection to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ Run the cross-platform installer with root privileges:
 sudo python installer.py
 ```
 
+During installation you'll be asked whether to use **auto** or **manual**
+hardware selection. Choosing **manual** lets you pick from common devices such
+as SuperMicro X9 QRI-F+, MacBook Pro 2019, iMac 5K 2017, Raspberry Pi models,
+and more. Selecting **auto** performs a general installation.
+
 This invokes `setup/Debian13/install.sh`, which updates `/etc/apt/sources.list` to Debian **Trixie**, installs Git, Node.js, Python 3, and Docker, then creates a virtual environment and preloads bundled data. Accept the license agreement when prompted. The project files are copied to `/opt/monkey_head`.
 
 

--- a/installer.py
+++ b/installer.py
@@ -13,6 +13,44 @@ import sys
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
+# Hardware selection options for manual installation
+HARDWARE_OPTIONS = [
+    "SuperMicro X9 qri-f+",
+    "MacBook Pro 2019",
+    "iMac 5K 2017",
+    "Raspberry Pi 3 B+",
+    "Raspberry Pi 4",
+    "HP Compaq 8200 Elite",
+    "Lenovo Legion Go",
+]
+
+
+def select_hardware() -> str:
+    """Prompt user to select hardware configuration."""
+    print("Select installation mode:")
+    print("1) auto - general hardware installation")
+    print("2) manual - select hardware from list")
+    mode = input("Enter choice [1/2]: ").strip()
+    if mode == "2":
+        print("Available hardware options:")
+        for idx, option in enumerate(HARDWARE_OPTIONS, start=1):
+            print(f"{idx}) {option}")
+        selection = input("Enter hardware number: ").strip()
+        try:
+            hardware = HARDWARE_OPTIONS[int(selection) - 1]
+        except (ValueError, IndexError):
+            print("Invalid choice. Using general hardware configuration.")
+            hardware = "general"
+    else:
+        hardware = "general"
+
+    config_dir = os.path.join(SCRIPT_DIR, "config")
+    os.makedirs(config_dir, exist_ok=True)
+    with open(os.path.join(config_dir, "hardware.txt"), "w", encoding="utf-8") as fh:
+        fh.write(hardware + "\n")
+
+    return hardware
+
 LINUX_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Debian13", "install.sh")
 MAC_INSTALL = os.path.join(SCRIPT_DIR, "setup", "macOS", "install.sh")
 WINDOWS_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Windows11", "01-FULL.bat")
@@ -31,14 +69,17 @@ def update_submodules() -> None:
 
 def run_installer():
     system = platform.system()
+    hardware = select_hardware()
+    env = os.environ.copy()
+    env["MHP_HARDWARE"] = hardware
     try:
         update_submodules()
         if system == "Linux":
-            subprocess.run(["bash", LINUX_INSTALL], check=True)
+            subprocess.run(["bash", LINUX_INSTALL], check=True, env=env)
         elif system == "Darwin":
-            subprocess.run(["bash", MAC_INSTALL], check=True)
+            subprocess.run(["bash", MAC_INSTALL], check=True, env=env)
         elif system == "Windows":
-            subprocess.run(["cmd", "/c", WINDOWS_INSTALL], check=True)
+            subprocess.run(["cmd", "/c", WINDOWS_INSTALL], check=True, env=env)
         else:
             print(f"Unsupported operating system: {system}")
             return 1


### PR DESCRIPTION
## Summary
- allow manual hardware selection during installation
- document the new installer prompt

## Testing
- `bash run-tests.sh` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a366bb304832b9923ac3d5a25f49b