### PR TITLE
Add manual software install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,13 @@ sudo python installer.py
 
 During installation you'll be asked whether to use **auto** or **manual**
 hardware selection. Choosing **manual** lets you pick from common devices such
+
 as SuperMicro X9 QRI-F+, MacBook Pro 2019, iMac 5K 2017, Raspberry Pi models,
 and more. Selecting **auto** performs a general installation.
+
+Next you'll choose the software profile. Selecting **auto** installs all default
+packages, while **manual** lets you pick specific packages and programs to
+install.
 
 This invokes `setup/Debian13/install.sh`, which updates `/etc/apt/sources.list` to Debian **Trixie**, installs Git, Node.js, Python 3, and Docker, then creates a virtual environment and preloads bundled data. Accept the license agreement when prompted. The project files are copied to `/opt/monkey_head`.
 

--- a/installer.py
+++ b/installer.py
@@ -24,6 +24,15 @@ HARDWARE_OPTIONS = [
     "Lenovo Legion Go",
 ]
 
+# Software package options for manual selection
+SOFTWARE_OPTIONS = [
+    "git",
+    "nodejs",
+    "python3",
+    "python3-venv",
+    "docker.io",
+]
+
 
 def select_hardware() -> str:
     """Prompt user to select hardware configuration."""
@@ -51,6 +60,38 @@ def select_hardware() -> str:
 
     return hardware
 
+
+def select_software() -> str:
+    """Prompt user to select software packages."""
+    print("Select software installation:")
+    print("1) auto - install all default packages")
+    print("2) manual - choose packages to install")
+    mode = input("Enter choice [1/2]: ").strip()
+    if mode == "2":
+        print("Available packages:")
+        for idx, pkg in enumerate(SOFTWARE_OPTIONS, start=1):
+            print(f"{idx}) {pkg}")
+        selection = input(
+            "Enter package numbers separated by spaces: "
+        ).strip()
+        packages: list[str] = []
+        for num in selection.split():
+            try:
+                packages.append(SOFTWARE_OPTIONS[int(num) - 1])
+            except (ValueError, IndexError):
+                print(f"Invalid selection: {num}")
+        software = " ".join(packages) if packages else "auto"
+    else:
+        software = "auto"
+
+    config_dir = os.path.join(SCRIPT_DIR, "config")
+    os.makedirs(config_dir, exist_ok=True)
+    with open(os.path.join(config_dir, "software.txt"), "w", encoding="utf-8") as fh:
+        fh.write(software + "\n")
+
+    return software
+
+
 LINUX_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Debian13", "install.sh")
 MAC_INSTALL = os.path.join(SCRIPT_DIR, "setup", "macOS", "install.sh")
 WINDOWS_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Windows11", "01-FULL.bat")
@@ -70,8 +111,10 @@ def update_submodules() -> None:
 def run_installer():
     system = platform.system()
     hardware = select_hardware()
+    software = select_software()
     env = os.environ.copy()
     env["MHP_HARDWARE"] = hardware
+    env["MHP_SOFTWARE"] = software
     try:
         update_submodules()
         if system == "Linux":

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -50,14 +50,17 @@ function update_system {
     apt-get upgrade -y || error_exit "apt-get upgrade failed."
 }
 
-function install_common_tools {
-    echo "Installing common tools..."
-    apt-get install -y git nodejs || error_exit "Failed to install common tools."
-}
 
-function install_additional_tools {
-    echo "Installing additional tools..."
-    apt-get install -y python3 python3-venv docker.io || error_exit "Failed to install additional tools."
+# Default package list if MHP_SOFTWARE is set to "auto" or empty
+DEFAULT_PACKAGES="git nodejs python3 python3-venv docker.io"
+
+function install_selected_packages {
+    local packages="${MHP_SOFTWARE:-auto}"
+    if [ "$packages" = "auto" ] || [ -z "$packages" ]; then
+        packages="$DEFAULT_PACKAGES"
+    fi
+    echo "Installing packages: $packages..."
+    apt-get install -y $packages || error_exit "Failed to install packages."
 }
 
 function setup_python_env {
@@ -87,8 +90,7 @@ function update_submodules {
 ensure_root
 copy_project_files
 update_system
-install_common_tools
-install_additional_tools
+install_selected_packages
 update_submodules
 setup_python_env
 show_license_gui


### PR DESCRIPTION
## Summary
- allow selecting software packages in `installer.py`
- save packages to `config/software.txt` and set `MHP_SOFTWARE`
- install selected packages in Debian installer
- document the new installer step in the README

## Testing
- `flake8 installer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684a371ddeb4832b836b475ba6a21092