### PR TITLE
Add headless CLI installer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,21 @@ invokes `setup/macOS/install.sh` to configure Homebrew and the Python
 environment. The batch script supports both Windows 10 and Windows 11.
 By default the repository is cloned to `%ProgramFiles%\Monkey-Head-Project`.
 
+### Headless CLI Installation
+
+If you are installing on a server without a graphical environment you can
+perform the same setup entirely in the terminal. Pass the `--headless` flag to
+the cross-platform installer so the license agreement is displayed in the
+console instead of a Tkinter window:
+
+```bash
+sudo python installer.py --headless
+```
+
+The OS-specific scripts recognize the `HEADLESS=1` environment variable and will
+run `license_cli.py` to capture your consent. All other installation steps are
+identical to the GUI workflow.
+
 ### Uninstallation and Cleanup
 
 Run the cross-platform uninstaller to remove the project and optional packages:

--- a/README.md
+++ b/README.md
@@ -258,8 +258,9 @@ sudo python installer.py --headless
 ```
 
 The OS-specific scripts recognize the `HEADLESS=1` environment variable and will
-run `license_cli.py` to capture your consent. All other installation steps are
-identical to the GUI workflow.
+run `license_cli.py` to capture your consent. The CLI helper gracefully
+re-prompts on invalid input and logs any unexpected errors to `app.log`.
+All other installation steps are identical to the GUI workflow.
 
 ### Uninstallation and Cleanup
 

--- a/installer.py
+++ b/installer.py
@@ -10,6 +10,7 @@ import os
 import platform
 import subprocess
 import sys
+import argparse
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -67,11 +68,17 @@ def update_submodules() -> None:
         raise
 
 
-def run_installer():
+def run_installer() -> int:
+    parser = argparse.ArgumentParser(description="Cross-platform installer")
+    parser.add_argument("--headless", action="store_true", help="Run without GUI prompts")
+    args = parser.parse_args()
+
     system = platform.system()
     hardware = select_hardware()
     env = os.environ.copy()
     env["MHP_HARDWARE"] = hardware
+    if args.headless:
+        env["HEADLESS"] = "1"
     try:
         update_submodules()
         if system == "Linux":

--- a/monkey_head/license_cli.py
+++ b/monkey_head/license_cli.py
@@ -1,0 +1,36 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.05.2025
+# ==================================================
+"""Command-line license acceptance helper."""
+from pathlib import Path
+
+from .license_gui import accept_license
+from .config_manager import ConfigManager
+
+
+def show_license_cli(config_path: str | Path = "config/pygpt_net/config.json") -> None:
+    """Display license text in the terminal and prompt for acceptance."""
+    manager = ConfigManager(str(config_path))
+    if manager.get_setting("license.accepted"):
+        return
+
+    try:
+        license_text = Path("docs/LICENSE").read_text(encoding="utf-8")
+    except Exception:
+        license_text = "License file not found."
+
+    print(license_text)
+    response = input("Do you accept the license terms? [y/N]: ").strip().lower()
+    if response in {"y", "yes"}:
+        accept_license(config_path)
+    else:
+        raise RuntimeError("License not accepted")
+
+
+if __name__ == "__main__":
+    show_license_cli()

--- a/monkey_head/license_cli.py
+++ b/monkey_head/license_cli.py
@@ -11,22 +11,47 @@ from pathlib import Path
 
 from .license_gui import accept_license
 from .config_manager import ConfigManager
+from .error_handler import ErrorHandler
 
 
-def show_license_cli(config_path: str | Path = "config/pygpt_net/config.json") -> None:
+def load_license_text(license_path: str | Path = "docs/LICENSE") -> str:
+    """Return the license text or a fallback message."""
+    try:
+        return Path(license_path).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return "License file not found."
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        ErrorHandler().handle_exception(exc)
+        return "License file not available." 
+
+
+def prompt_response() -> bool:
+    """Prompt user for license acceptance and validate the response."""
+    for _ in range(3):
+        response = input("Do you accept the license terms? [y/N]: ").strip().lower()
+        if response in {"y", "yes"}:
+            return True
+        if response in {"n", "no", ""}:
+            return False
+        print("Please respond with 'y' or 'n'.")
+    return False
+
+
+def show_license_cli(
+    config_path: str | Path = "config/pygpt_net/config.json",
+    license_path: str | Path = "docs/LICENSE",
+) -> None:
     """Display license text in the terminal and prompt for acceptance."""
-    manager = ConfigManager(str(config_path))
+    try:
+        manager = ConfigManager(str(config_path))
+    except Exception as exc:
+        raise RuntimeError(f"Failed to load config: {exc}") from exc
+
     if manager.get_setting("license.accepted"):
         return
 
-    try:
-        license_text = Path("docs/LICENSE").read_text(encoding="utf-8")
-    except Exception:
-        license_text = "License file not found."
-
-    print(license_text)
-    response = input("Do you accept the license terms? [y/N]: ").strip().lower()
-    if response in {"y", "yes"}:
+    print(load_license_text(license_path))
+    if prompt_response():
         accept_license(config_path)
     else:
         raise RuntimeError("License not accepted")

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -73,10 +73,14 @@ function setup_python_env {
     pip install -e repo/pygpt-MHP || error_exit "Failed to install pygpt-MHP."
 }
 
-function show_license_gui {
+function show_license {
     echo "Displaying license agreement..."
     source "$VENV_DIR/bin/activate" || error_exit "Failed to activate virtual environment."
-    python src/license_gui.py || echo "License dialog could not be displayed"
+    if [ -n "$HEADLESS" ]; then
+        python src/license_cli.py || error_exit "License not accepted"
+    else
+        python src/license_gui.py || python src/license_cli.py || echo "License dialog could not be displayed"
+    fi
 }
 
 function update_submodules {
@@ -91,7 +95,7 @@ install_common_tools
 install_additional_tools
 update_submodules
 setup_python_env
-show_license_gui
+show_license
 
 function preload_data {
     echo "Preloading bundled data..."

--- a/setup/Windows11/01-FULL.bat
+++ b/setup/Windows11/01-FULL.bat
@@ -189,12 +189,15 @@ choco install -y azure-cli
 call :checkError "Azure CLI Installation"
 goto :eof
 
-:: Function to display license GUI
-:showLicenseGui
+:: Function to display license agreement
+:showLicense
 echo Displaying license agreement...
 call venv\Scripts\activate
-python src\license_gui.py
-if %errorlevel% neq 0 echo License dialog could not be displayed
+if defined HEADLESS (
+    python src\license_cli.py || exit /b 1
+) else (
+    python src\license_gui.py || python src\license_cli.py || echo License dialog could not be displayed
+)
 goto :eof
 
 :: Main Execution Flow
@@ -235,7 +238,7 @@ echo Installing optional tools...
 call :installOptionalTools
 
 echo Displaying license agreement...
-call :showLicenseGui
+call :showLicense
 
 echo [****| Full setup complete! |****]
 echo.

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -61,10 +61,14 @@ function setup_python_env() {
     pip install -e repo/pygpt-MHP
 }
 
-function show_license_gui() {
+function show_license() {
     echo "Displaying license agreement..."
     source "$VENV_DIR/bin/activate"
-    python src/license_gui.py || echo "License dialog could not be displayed"
+    if [ -n "$HEADLESS" ]; then
+        python src/license_cli.py || exit 1
+    else
+        python src/license_gui.py || python src/license_cli.py || echo "License dialog could not be displayed"
+    fi
 }
 
 function update_submodules() {
@@ -77,7 +81,7 @@ copy_project_files
 install_packages
 update_submodules
 setup_python_env
-show_license_gui
+show_license
 
 function preload_data() {
     echo "Preloading bundled data..."

--- a/tests/test_license_cli.py
+++ b/tests/test_license_cli.py
@@ -31,6 +31,20 @@ class TestLicenseCli(unittest.TestCase):
         self.assertTrue(updated.get("license.accepted"))
         os.remove(temp_path)
 
+    def test_show_license_cli_declines(self):
+        temp_path = Path("/tmp/test_config_cli.json")
+        with temp_path.open("w", encoding="utf-8") as f:
+            json.dump({"license.accepted": False}, f)
+
+        with patch("builtins.input", side_effect=["n"]):
+            with self.assertRaises(RuntimeError):
+                show_license_cli(temp_path)
+
+        with temp_path.open(encoding="utf-8") as f:
+            data = json.load(f)
+        self.assertFalse(data.get("license.accepted"))
+        os.remove(temp_path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_license_cli.py
+++ b/tests/test_license_cli.py
@@ -1,0 +1,36 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.05.2025
+# ==================================================
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from monkey_head.license_cli import show_license_cli
+
+
+class TestLicenseCli(unittest.TestCase):
+    def test_show_license_cli_accepts(self):
+        temp_path = Path("/tmp/test_config_cli.json")
+        data = {"license.accepted": False}
+        with temp_path.open("w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+        with patch("builtins.input", return_value="y"):
+            show_license_cli(temp_path)
+
+        with temp_path.open(encoding="utf-8") as f:
+            updated = json.load(f)
+
+        self.assertTrue(updated.get("license.accepted"))
+        os.remove(temp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow CLI-based license acceptance
- update OS install scripts to check HEADLESS env
- add `--headless` flag to cross-platform installer
- document headless installation method in README
- test license_cli helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684a3771c330832b9bf35344189c8621