### PR TITLE
Add universal image conversion utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ the test suite with `pytest -vv`. Both scripts report an error if the
 under `memory/PDF`. Run this script whenever you add or edit PDF documents
 to keep the preloaded dataset up to date.
 
+The `huey` package also provides a small CLI. Use `huey convert` to
+convert image files between formats at maximum quality. Supply an input
+file or directory with `--format` specifying the target type (e.g.
+`JPEG`, `PNG`). Converted files are saved alongside the originals or in a
+specified output directory.
+
 ### Docker and Kubernetes Utilities
 
 The `scripts/` directory contains helper scripts for container management:

--- a/huey/cli.py
+++ b/huey/cli.py
@@ -9,22 +9,56 @@
 # huey/cli.py
 
 import argparse
+from pathlib import Path
 from .main import main as huey_main
+from .utils import convert_image, convert_images_in_directory
 
 
 def parse_arguments():
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Huey Project Command-Line Interface")
-    parser.add_argument(
-        "--config", type=str, help="Path to configuration file", default="config.yaml"
+
+    subparsers = parser.add_subparsers(dest="command")
+
+    run_parser = subparsers.add_parser("run", help="Run the Huey application")
+    run_parser.add_argument(
+        "--config",
+        type=str,
+        help="Path to configuration file",
+        default="config.yaml",
     )
-    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
+    run_parser.add_argument(
+        "--verbose", action="store_true", help="Enable verbose output"
+    )
+
+    convert_parser = subparsers.add_parser("convert", help="Convert image files")
+    convert_parser.add_argument("input", help="Input file or directory")
+    convert_parser.add_argument("--format", required=True, help="Output format")
+    convert_parser.add_argument("--output", help="Output file or directory")
+    convert_parser.add_argument(
+        "--quality",
+        type=int,
+        default=100,
+        help="Quality for conversion (default: 100)",
+    )
+
     return parser.parse_args()
 
 
 def run_cli():
     """Run the CLI application."""
     args = parse_arguments()
+
+    if args.command == "convert":
+        inp = Path(args.input)
+        if inp.is_dir():
+            convert_images_in_directory(
+                str(inp), args.format, args.output, quality=args.quality
+            )
+        else:
+            convert_image(str(inp), args.format, args.output, quality=args.quality)
+        return
+
     if args.verbose:
         print("Verbose mode enabled.")
     # Pass the config file path to main

--- a/huey/utils.py
+++ b/huey/utils.py
@@ -10,11 +10,20 @@
 
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 from PIL import Image
-
 from .exceptions import InvalidInputError
+
+# Supported image formats for conversion
+SUPPORTED_FORMATS: Iterable[str] = (
+    "JPEG",
+    "PNG",
+    "BMP",
+    "GIF",
+    "TIFF",
+    "WEBP",
+)
 
 
 def setup_logging(config):
@@ -74,3 +83,107 @@ def convert_jpeg_to_png(jpeg_path: str, png_path: Optional[str] | None = None) -
         img.save(png_file, format="PNG")
 
     return str(png_file)
+
+
+def convert_image(
+    image_path: str,
+    output_format: str,
+    output_path: Optional[str] | None = None,
+    quality: int = 100,
+) -> str:
+    """Convert an image to a different format with maximum quality.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to the source image.
+    output_format : str
+        Desired output format (e.g. ``"PNG"`` or ``"JPEG"``).
+    output_path : str, optional
+        Desired output path. Defaults to the same base name with a new extension.
+    quality : int, optional
+        Output quality for formats that support it. Defaults to ``100``.
+
+    Returns
+    -------
+    str
+        Path to the converted image.
+    """
+
+    img_file = Path(image_path)
+    if not img_file.is_file():
+        raise FileNotFoundError(f"{image_path} does not exist")
+
+    fmt = output_format.upper()
+    if fmt not in SUPPORTED_FORMATS:
+        raise ValueError(f"Unsupported format: {output_format}")
+
+    if output_path is None:
+        suffix = ".jpg" if fmt == "JPEG" else f".{fmt.lower()}"
+        out_file = img_file.with_suffix(suffix)
+    else:
+        out_file = Path(output_path)
+
+    with Image.open(img_file) as img:
+        save_kwargs = {}
+        if fmt == "JPEG" or fmt == "WEBP":
+            save_kwargs["quality"] = quality
+        if fmt == "PNG":
+            save_kwargs["optimize"] = True
+        img.save(out_file, format=fmt, **save_kwargs)
+
+    return str(out_file)
+
+
+def convert_images_in_directory(
+    directory: str,
+    output_format: str,
+    output_directory: Optional[str] | None = None,
+    quality: int = 100,
+) -> list[str]:
+    """Convert all images in a directory to the specified format.
+
+    Parameters
+    ----------
+    directory : str
+        Directory containing images to convert.
+    output_format : str
+        Desired output format.
+    output_directory : str, optional
+        Directory to save converted images. Defaults to ``directory``.
+    quality : int, optional
+        Quality used for conversion. Defaults to ``100``.
+
+    Returns
+    -------
+    list[str]
+        Paths to converted images.
+    """
+
+    dir_path = Path(directory)
+    if not dir_path.is_dir():
+        raise NotADirectoryError(f"{directory} is not a directory")
+
+    out_dir = Path(output_directory) if output_directory else dir_path
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    converted_paths = []
+    for file in dir_path.iterdir():
+        if file.is_file():
+            try:
+                out_name = file.stem + (
+                    ".jpg"
+                    if output_format.upper() == "JPEG"
+                    else f".{output_format.lower()}"
+                )
+                new_path = convert_image(
+                    str(file),
+                    output_format,
+                    str(out_dir / out_name),
+                    quality,
+                )
+                converted_paths.append(new_path)
+            except (ValueError, FileNotFoundError):
+                continue
+
+    return converted_paths

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,13 @@ import unittest
 
 from PIL import Image
 
-from huey.utils import calculate_sum, validate_input, convert_jpeg_to_png
+from huey.utils import (
+    calculate_sum,
+    validate_input,
+    convert_jpeg_to_png,
+    convert_image,
+    convert_images_in_directory,
+)
 from huey.exceptions import InvalidInputError
 
 
@@ -46,6 +52,42 @@ class TestUtils(unittest.TestCase):
             result_path = convert_jpeg_to_png(str(jpeg_path), str(custom_out))
             assert result_path == str(custom_out)
             assert custom_out.is_file()
+
+    def test_convert_image(self):
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            img = Image.new("RGB", (10, 10), color="blue")
+            src = tmp_path / "img.png"
+            img.save(src, "PNG")
+
+            out_jpeg = convert_image(str(src), "JPEG")
+            assert Path(out_jpeg).suffix in {".jpg", ".jpeg"}
+            assert Path(out_jpeg).is_file()
+
+            custom_out = tmp_path / "result.jpg"
+            out_custom = convert_image(str(src), "JPEG", str(custom_out), quality=90)
+            assert out_custom == str(custom_out)
+            assert custom_out.is_file()
+
+    def test_convert_images_in_directory(self):
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            for i in range(3):
+                Image.new("RGB", (10, 10), color="green").save(
+                    tmp_path / f"img_{i}.png", "PNG"
+                )
+
+            out_dir = tmp_path / "out"
+            results = convert_images_in_directory(str(tmp_path), "JPEG", str(out_dir))
+
+            assert len(results) == 3
+            for path in results:
+                assert Path(path).suffix in {".jpg", ".jpeg"}
+                assert Path(path).is_file()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand `huey` utilities with new `convert_image` and directory conversion helper
- add CLI command `huey convert` for batch image conversion
- document new CLI usage in README
- test image conversion functions

## Testing
- `black huey/utils.py huey/cli.py tests/test_utils.py`
- `flake8 huey/utils.py huey/cli.py tests/test_utils.py`
- `pytest tests/test_utils.py -q`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'pdftotext')*

------
https://chatgpt.com/codex/tasks/task_e_684a37a32ad0832b9a23eae749242524