### PR TITLE
Add OS version checks

### DIFF
--- a/monkey_head/core/system_checks.py
+++ b/monkey_head/core/system_checks.py
@@ -7,9 +7,12 @@
 # Updated: 06.05.2025
 # ==================================================
 import logging
-from ..logging_setup import configure_logging
 import os
+import platform
 import subprocess
+
+import distro
+from ..logging_setup import configure_logging
 
 configure_logging()
 logger = logging.getLogger(__name__)
@@ -33,6 +36,42 @@ def check_error(command, description):
         )
         log_error(error_message)
         raise RuntimeError(error_message)
+
+
+def check_os_support() -> None:
+    """Log a warning if the current OS is not officially supported."""
+    system = platform.system()
+    if system == "Windows":
+        release = platform.release()
+        try:
+            major = int(release.split(".")[0])
+        except ValueError:
+            major = 0
+        if major < 10:
+            logger.warning(
+                "Unsupported Windows version detected (%s). Windows 10 or newer is required.",
+                release,
+            )
+    elif system == "Darwin":
+        ver_str, _, _ = platform.mac_ver()
+        try:
+            major = int(ver_str.split(".")[0])
+        except ValueError:
+            major = 0
+        if major < 13:
+            logger.warning(
+                "Unsupported macOS version detected (%s). macOS Ventura or newer is required.",
+                ver_str,
+            )
+    elif system == "Linux":
+        if distro.id() != "debian" or distro.codename().lower() not in {"trixie", "testing"}:
+            logger.warning(
+                "Unsupported Linux distribution detected (%s %s). Debian Trixie/testing is required.",
+                distro.id(),
+                distro.codename(),
+            )
+    else:
+        logger.warning("Unsupported operating system detected: %s", system)
 
 
 def system_check():

--- a/run.py
+++ b/run.py
@@ -21,6 +21,8 @@ import argparse
 import sys
 from pathlib import Path
 
+from monkey_head.core.system_checks import check_os_support
+
 sys.path.insert(0, str((Path(__file__).parent / "src").resolve()))
 
 from pygpt_net.app import run as cli_run
@@ -54,6 +56,9 @@ def main() -> None:
         help="Print pygpt_net version and exit",
     )
     args = parser.parse_args()
+
+    # Warn if running on an unsupported operating system
+    check_os_support()
 
     if args.version:
         from pygpt_net import __version__

--- a/tests/test_os_check.py
+++ b/tests/test_os_check.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+from monkey_head.core.system_checks import check_os_support
+
+
+def test_windows_warning():
+    with patch('platform.system', return_value='Windows'), \
+         patch('platform.release', return_value='8'), \
+         patch('monkey_head.core.system_checks.logger') as log:
+        check_os_support()
+        log.warning.assert_called_once()
+
+
+def test_linux_supported_no_warning():
+    with patch('platform.system', return_value='Linux'), \
+         patch('distro.id', return_value='debian'), \
+         patch('distro.codename', return_value='trixie'), \
+         patch('monkey_head.core.system_checks.logger') as log:
+        check_os_support()
+        log.warning.assert_not_called()
+
+
+def test_macos_old_warning():
+    with patch('platform.system', return_value='Darwin'), \
+         patch('platform.mac_ver', return_value=('12.5', ('', '', ''), '')), \
+         patch('monkey_head.core.system_checks.logger') as log:
+        check_os_support()
+        log.warning.assert_called_once()


### PR DESCRIPTION
## Summary
- log a warning when running on unsupported operating systems
- call the OS support checker during startup
- cover OS version checks in unit tests

## Testing
- `pytest -vv` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684a388cf43c832bab8eba18955d7e52