### PR TITLE
Add CLI license handler and headless docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,20 @@ invokes `setup/macOS/install.sh` to configure Homebrew and the Python
 environment. The batch script supports both Windows 10 and Windows 11.
 By default the repository is cloned to `%ProgramFiles%\Monkey-Head-Project`.
 
+### Headless Installation
+
+If no graphical environment is available you can run the license prompt
+from the command line using `license_cli.py`:
+
+```bash
+python monkey_head/license_cli.py
+```
+
+The script prints the license text and will keep asking for confirmation
+until you answer `yes` or `no`. Any errors are written to `app.log` and
+declining raises a `RuntimeError` without modifying the configuration
+file.
+
 ### Uninstallation and Cleanup
 
 Run the cross-platform uninstaller to remove the project and optional packages:

--- a/docs/headless_install.md
+++ b/docs/headless_install.md
@@ -1,0 +1,16 @@
+# Headless Installation
+
+For servers without a graphical environment you can run the license
+agreement from the command line.
+
+```bash
+python monkey_head/license_cli.py
+```
+
+`license_cli.py` prints the license text and prompts whether you accept
+the terms. If you enter anything other than `yes` or `no` it asks again
+until a valid response is received. Any errors during this process are
+logged to `app.log`.
+
+Declining the license raises `RuntimeError` and leaves the configuration
+file unchanged.

--- a/huey/cli.py
+++ b/huey/cli.py
@@ -9,16 +9,21 @@
 # huey/cli.py
 
 import argparse
+import sys
 from pathlib import Path
 from .main import main as huey_main
 from .utils import convert_image, convert_images_in_directory
 
 
-def parse_arguments():
+def parse_arguments(argv=None):
     """Parse command-line arguments."""
+    if argv is None:
+        argv = sys.argv[1:]
+
     parser = argparse.ArgumentParser(description="Huey Project Command-Line Interface")
 
     subparsers = parser.add_subparsers(dest="command")
+    parser.set_defaults(command="run")
 
     run_parser = subparsers.add_parser("run", help="Run the Huey application")
     run_parser.add_argument(
@@ -42,7 +47,10 @@ def parse_arguments():
         help="Quality for conversion (default: 100)",
     )
 
-    return parser.parse_args()
+    if not argv or argv[0].startswith("-"):
+        argv = ["run"] + argv
+
+    return parser.parse_args(argv)
 
 
 def run_cli():

--- a/monkey_head/license_cli.py
+++ b/monkey_head/license_cli.py
@@ -1,0 +1,60 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.05.2025
+# ==================================================
+from pathlib import Path
+from typing import Optional
+
+from .config_manager import ConfigManager
+from .error_handler import ErrorHandler
+
+
+DEFAULT_CONFIG = "config/pygpt_net/config.json"
+LICENSE_PATH = "docs/LICENSE"
+
+
+def load_license_text(path: str | Path = LICENSE_PATH) -> str:
+    """Load license text from file, logging errors if not found."""
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except Exception as e:  # pragma: no cover - log and fallback
+        ErrorHandler().handle_exception(e)
+        return "License file not found."
+
+
+def prompt_response(prompt: str) -> str:
+    """Prompt the user repeatedly until 'yes' or 'no' is entered."""
+    while True:  # pragma: no cover - loops until valid input
+        try:
+            answer = input(prompt).strip().lower()
+        except Exception as e:  # pragma: no cover - log and retry
+            ErrorHandler().handle_exception(e)
+            print("Error reading input. Please try again.")
+            continue
+        if answer in {"y", "yes"}:
+            return "yes"
+        if answer in {"n", "no"}:
+            return "no"
+        print("Please respond with 'yes' or 'no'.")
+
+
+def show_license_cli(config_path: str | Path = DEFAULT_CONFIG) -> None:
+    """Display license text and prompt for acceptance on the command line."""
+    manager = ConfigManager(str(config_path))
+    if manager.get_setting("license.accepted"):
+        return
+
+    print(load_license_text())
+    response = prompt_response("Do you accept the license terms? [y/n]: ")
+    if response == "yes":
+        manager.set_setting("license.accepted", True)
+    else:
+        raise RuntimeError("License declined")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    show_license_cli()

--- a/tests/test_license_cli.py
+++ b/tests/test_license_cli.py
@@ -1,0 +1,18 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from monkey_head.license_cli import show_license_cli
+
+
+def test_license_decline(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"license.accepted": False}))
+
+    with patch("monkey_head.license_cli.prompt_response", return_value="no"):
+        with pytest.raises(RuntimeError):
+            show_license_cli(cfg)
+
+    data = json.loads(cfg.read_text())
+    assert data.get("license.accepted") is False


### PR DESCRIPTION
## Summary
- document CLI license usage for headless installs
- implement `license_cli.py` with repeated prompting and error logging
- ensure Huey CLI defaults to `run` when no command provided
- test license decline behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a39f1aa18832b9dd340f21b5ff2a6