### PR TITLE
Add OS debloating documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Docker Desktop, and other required tools on Windows. On macOS the installer
 invokes `setup/macOS/install.sh` to configure Homebrew and the Python
 environment. The batch script supports both Windows 10 and Windows 11.
 By default the repository is cloned to `%ProgramFiles%\Monkey-Head-Project`.
+For a lean Windows setup you can run `setup/Windows10/windows-remove-tool.bat` after installation. This optional script removes pre-installed apps, disables telemetry, and tunes settings for maximum speed.
 
 ### Headless Installation
 
@@ -348,6 +349,7 @@ Visit the [GitHub Repository](https://github.com/DylanLRPollock/Monkey-Head-Proj
 
 The `docs/` directory contains extended documentation on the project’s architecture, historical phases, and governance design. New contributors should start with [docs/README.md](docs/README.md) and [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for detailed guidelines.
 For an introductory overview, see [docs/New-To-AI.md](docs/New-To-AI.md).
+For tips on removing unnecessary software and disabling services, see [docs/os-debloating.md](docs/os-debloating.md).
 
 ---
 

--- a/docs/os-debloating.md
+++ b/docs/os-debloating.md
@@ -1,0 +1,32 @@
+# Operating System Debloating
+
+For best performance, the Monkey Head Project encourages minimizing unnecessary programs and services before installing GenCore. Removing bloat reduces memory and CPU overhead, ensuring that the AI/OS runs smoothly even on older hardware.
+
+## Windows 10 & 11
+
+A complete optimization script is provided at `setup/Windows10/windows-remove-tool.bat`. Run this batch file as **Administrator** after installation to remove default applications, disable telemetry, clean temporary files, and set the High Performance power profile. The script is compatible with both Windows 10 and Windows 11 and can be executed as follows:
+
+```cmd
+setup\Windows10\windows-remove-tool.bat
+```
+
+This debloating step is optional but recommended for systems dedicated to the project.
+
+## Debian 13
+
+While no automatic script is supplied for Linux, you can achieve a lightweight installation by uninstalling packages you do not require and disabling unused services:
+
+```bash
+sudo apt-get purge libreoffice-* games-* thunderbird
+sudo systemctl disable cups.service
+```
+
+After cleaning up, update the system and install only the packages listed in `setup/Debian13/install.sh`.
+
+## macOS
+
+On macOS, disable resource-heavy animations and remove unnecessary startup items via **System Settings**. Tools like **CleanMyMac** can help remove unneeded applications. Keeping the system lean ensures GenCore runs efficiently on Apple hardware.
+
+---
+
+Trimming excess applications and services lets GenCore allocate resources where they matter most. For a full walkthrough, see the installation instructions in this repository's `README.md`.


### PR DESCRIPTION
## Summary
- document how to slim down Windows, Debian, and macOS installations
- mention debloating step in Windows install docs
- link to the new guide in Additional Resources

## Testing
- `bash run-tests.sh` *(fails: Virtual environment not found)*
- `pytest -vv` *(fails: missing packages `distro`, `PIL` etc.)*


------
https://chatgpt.com/codex/tasks/task_e_684a3bd3cc14832bb31c1a02778a6009