### PR TITLE
Align OS naming in unit test

### DIFF
--- a/tests/test_gencore.py
+++ b/tests/test_gencore.py
@@ -10,7 +10,7 @@ import unittest
 from monkey_head.gencore import generate_core_data
 
 
-class TestGencore(unittest.TestCase):
+class TestGenCore(unittest.TestCase):
     def test_generate_core_data(self):
         data = {"a": 1, "b": 2}
         result = generate_core_data(data)


### PR DESCRIPTION
## Summary
- update class name in `tests/test_gencore.py` to match `GenCore` naming convention

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'distro')*

------
https://chatgpt.com/codex/tasks/task_e_684a3d341c70832b921b0e7ead80b20d