### PR TITLE
Update install scripts for build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Ensure the following tools are installed before running the project:
 - **Git**
 - **Kubernetes** (`kubectl` CLI)
 - **Python 3.12+** and `pip`
+- **Build tools** (`build-essential` on Debian, Xcode Command Line Tools on macOS)
 
 ## 🖥️ Installation and Usage
 

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -52,7 +52,7 @@ function update_system {
 
 
 # Default package list if MHP_SOFTWARE is set to "auto" or empty
-DEFAULT_PACKAGES="git nodejs python3 python3-venv docker.io"
+DEFAULT_PACKAGES="git build-essential g++ nodejs python3 python3-venv docker.io"
 
 function install_selected_packages {
     local packages="${MHP_SOFTWARE:-auto}"

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -23,6 +23,15 @@ function command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+function ensure_xcode_cli() {
+    if ! xcode-select -p >/dev/null 2>&1; then
+        echo "Installing Xcode command line tools..."
+        xcode-select --install || true
+    else
+        echo "Xcode command line tools already installed."
+    fi
+}
+
 function copy_project_files() {
     if [ "$PROJECT_ROOT" != "$INSTALL_DIR" ]; then
         echo "Copying project files to $INSTALL_DIR..."
@@ -45,7 +54,7 @@ function install_homebrew() {
 function install_packages() {
     echo "Installing required packages..."
     brew update
-    brew install git python docker || true
+    brew install git python docker gcc || true
 }
 
 function setup_python_env() {
@@ -73,6 +82,7 @@ function update_submodules() {
 }
 
 install_homebrew
+ensure_xcode_cli
 copy_project_files
 install_packages
 update_submodules


### PR DESCRIPTION
## Summary
- mention required build tools in README
- install `build-essential` on Debian
- install gcc and Xcode CLI on macOS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'distro')*

------
https://chatgpt.com/codex/tasks/task_e_684a3e7ec458832ba2a0a42cd3e6ac4a