### PR TITLE
Set default profile/agent name to Huey

### DIFF
--- a/huey/config.py
+++ b/huey/config.py
@@ -8,6 +8,7 @@
 # ==================================================
 # huey/config.py
 
+
 def load_config(config_file: str = "config.yaml"):
     """Load configuration settings from a YAML file."""
     try:

--- a/repo/pygpt-MHP/src/pygpt_net/core/profile/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/profile/__init__.py
@@ -85,7 +85,7 @@ class Profile:
         self.current = uuid
         self.profiles = {}
         self.profiles[uuid] = {
-            'name': 'Default',
+            'name': 'Huey',
             'workdir': path.replace(str(Path.home()), "%HOME%")
         }
         self.save()

--- a/repo/pygpt-MHP/src/pygpt_net/plugin/agent/config.py
+++ b/repo/pygpt-MHP/src/pygpt_net/plugin/agent/config.py
@@ -109,7 +109,7 @@ class Config(BaseConfig):
         items = [
             {
                 "enabled": True,
-                "name": "Default",
+                "name": "Huey",
                 "prompt": prompt,
             },
             {

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -4,14 +4,14 @@ from gui.main_ui import MainUI
 
 def test_check_license_calls_gui():
     ui = MainUI.__new__(MainUI)
-    with patch('gui.main_ui.show_license_gui') as gui_call:
+    with patch("gui.main_ui.show_license_gui") as gui_call:
         MainUI.check_license(ui)
         gui_call.assert_called_once()
 
 
 def test_show_license_calls_gui():
     ui = MainUI.__new__(MainUI)
-    with patch('gui.main_ui.show_license_gui') as gui_call:
+    with patch("gui.main_ui.show_license_gui") as gui_call:
         MainUI.show_license(ui)
         gui_call.assert_called_once()
 
@@ -19,8 +19,9 @@ def test_show_license_calls_gui():
 def test_show_data_summary_displays_info():
     ui = MainUI.__new__(MainUI)
     sample = {"prompts": [1, 2], "memory": {"a": ["x", "y"]}}
-    with patch('gui.main_ui.preload_all', return_value=sample), \
-         patch('gui.main_ui.messagebox.showinfo') as info:
+    with patch("gui.main_ui.preload_all", return_value=sample), patch(
+        "gui.main_ui.messagebox.showinfo"
+    ) as info:
         MainUI.show_data_summary(ui)
         info.assert_called_once()
 
@@ -28,7 +29,7 @@ def test_show_data_summary_displays_info():
 def test_choose_screen_mode_env(monkeypatch):
     ui = MainUI.__new__(MainUI)
     monkeypatch.setenv("SCREEN_MODE", "1080p")
-    with patch('gui.main_ui.messagebox.askquestion') as ask:
+    with patch("gui.main_ui.messagebox.askquestion") as ask:
         mode = MainUI.choose_screen_mode(ui)
         ask.assert_not_called()
         assert mode == "1080p"
@@ -36,7 +37,8 @@ def test_choose_screen_mode_env(monkeypatch):
 
 def test_choose_screen_mode_prompt():
     ui = MainUI.__new__(MainUI)
-    with patch.dict('os.environ', {}, clear=True), \
-         patch('gui.main_ui.messagebox.askquestion', return_value='yes'):
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "gui.main_ui.messagebox.askquestion", return_value="yes"
+    ):
         mode = MainUI.choose_screen_mode(ui)
         assert mode == "4k"

--- a/tests/test_huey_cli_config.py
+++ b/tests/test_huey_cli_config.py
@@ -10,6 +10,7 @@ from huey.exceptions import HueyError, DataNotFoundError, InvalidInputError
 
 # Tests for configuration loading
 
+
 def test_load_config_success(tmp_path):
     cfg = tmp_path / "cfg.yml"
     cfg.write_text("foo: bar")
@@ -24,6 +25,7 @@ def test_load_config_missing(tmp_path):
 
 # Tests for CLI argument parsing and invocation
 
+
 def test_parse_arguments_verbose():
     test_args = ["prog", "--config", "file.yml", "--verbose"]
     with patch.object(sys, "argv", test_args):
@@ -36,13 +38,13 @@ def test_run_cli_invokes_main(tmp_path):
     cfg = tmp_path / "cfg.yml"
     cfg.write_text("logging:\n  level: INFO")
     test_args = ["prog", "--config", str(cfg)]
-    with patch.object(sys, "argv", test_args), \
-         patch("huey.cli.huey_main") as main_mock:
+    with patch.object(sys, "argv", test_args), patch("huey.cli.huey_main") as main_mock:
         run_cli()
         main_mock.assert_called_once_with(config_file=str(cfg))
 
 
 # Tests for exception hierarchy
+
 
 def test_exceptions_inherit_from_base():
     assert issubclass(DataNotFoundError, HueyError)

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -8,7 +8,9 @@ def test_configure_logging_creates_log(tmp_path):
     cfg = tmp_path / "cfg.ini"
     log_file = tmp_path / "app.log"
     cfg.write_text(
-        "[logging]\nlog_level = INFO\nlog_file = {}\nlog_max_bytes = 1024\nlog_backup_count = 1\n".format(log_file)
+        "[logging]\nlog_level = INFO\nlog_file = {}\nlog_max_bytes = 1024\nlog_backup_count = 1\n".format(
+            log_file
+        )
     )
     root_logger = logging.getLogger()
     for h in list(root_logger.handlers):

--- a/tests/test_misc_modules.py
+++ b/tests/test_misc_modules.py
@@ -15,77 +15,78 @@ from monkey_head.error_handler import ErrorHandler
 
 def test_ai_processor():
     proc = AIProcessor()
-    assert proc.process_data('abc') == 'ABC'
-    assert proc.analyze_data('123')['length'] == 3
+    assert proc.process_data("abc") == "ABC"
+    assert proc.analyze_data("123")["length"] == 3
 
 
 def test_process_and_check_core_data():
-    data = {'x': 1, 'y': 2}
+    data = {"x": 1, "y": 2}
     processed = process_core_data(data)
     assert check_core_data(processed)
-    assert processed['input_length'] == 2
+    assert processed["input_length"] == 2
 
 
 def test_manage_temp_files_delete(tmp_path):
-    temp_dir = tmp_path / 'tmp'
+    temp_dir = tmp_path / "tmp"
     temp_dir.mkdir()
-    (temp_dir / 'a.txt').write_text('data')
-    manage_temp_files(str(temp_dir), 'delete')
+    (temp_dir / "a.txt").write_text("data")
+    manage_temp_files(str(temp_dir), "delete")
     assert temp_dir.exists() and not any(temp_dir.iterdir())
 
 
 def test_manage_temp_files_archive(tmp_path):
-    temp_dir = tmp_path / 'tmp'
+    temp_dir = tmp_path / "tmp"
     temp_dir.mkdir()
-    (temp_dir / 'a.txt').write_text('data')
-    manage_temp_files(str(temp_dir), 'archive')
-    archive = tmp_path / 'tmp_archive'
+    (temp_dir / "a.txt").write_text("data")
+    manage_temp_files(str(temp_dir), "archive")
+    archive = tmp_path / "tmp_archive"
     assert archive.is_dir()
     assert temp_dir.is_dir()
 
 
 def test_check_linux_service_active():
     class R:
-        stdout = b'active\n'
-    with patch('subprocess.run', return_value=R()):
-        assert check_linux_service('svc') == 'active'
+        stdout = b"active\n"
+
+    with patch("subprocess.run", return_value=R()):
+        assert check_linux_service("svc") == "active"
 
 
 def test_remove_files(tmp_path):
-    f1 = tmp_path / 'a.txt'
-    f2 = tmp_path / 'b.log'
-    f1.write_text('x')
-    f2.write_text('y')
-    remove_files(str(tmp_path), '.txt')
+    f1 = tmp_path / "a.txt"
+    f2 = tmp_path / "b.log"
+    f1.write_text("x")
+    f2.write_text("y")
+    remove_files(str(tmp_path), ".txt")
     assert not f1.exists() and f2.exists()
 
 
 def test_split_chapters(tmp_path):
-    text = 'intro\nCHAPTERfirst\nCHAPTERsecond'
-    infile = tmp_path / 'book.txt'
+    text = "intro\nCHAPTERfirst\nCHAPTERsecond"
+    infile = tmp_path / "book.txt"
     infile.write_text(text)
-    outdir = tmp_path / 'chapters'
+    outdir = tmp_path / "chapters"
     split_chapters(str(infile), str(outdir))
     files = list(outdir.iterdir())
     assert len(files) == 3
 
 
 def test_file_manager(tmp_path):
-    src = tmp_path / 'src.txt'
-    dest = tmp_path / 'dest.txt'
+    src = tmp_path / "src.txt"
+    dest = tmp_path / "dest.txt"
     fm = FileManager()
-    fm.write_file(str(src), 'hi')
-    assert fm.read_file(str(src)) == 'hi'
+    fm.write_file(str(src), "hi")
+    assert fm.read_file(str(src)) == "hi"
     fm.move_file(str(src), str(dest))
-    assert dest.read_text() == 'hi'
+    assert dest.read_text() == "hi"
 
 
 def test_error_handler(tmp_path):
-    log = tmp_path / 'log.txt'
+    log = tmp_path / "log.txt"
     handler = ErrorHandler(str(log))
-    handler.log_info('info')
-    handler.log_error('error')
-    handler.handle_exception(Exception('boom'))
+    handler.log_info("info")
+    handler.log_error("error")
+    handler.handle_exception(Exception("boom"))
 
 
 def test_create_tkinter_window():
@@ -104,8 +105,9 @@ def test_create_tkinter_window():
         def pack(self, pady=0):
 
             self.command()
-    with patch('tkinter.Tk', return_value=DummyRoot()), \
-         patch('tkinter.Button', DummyButton), \
-         patch('tkinter.messagebox.showinfo') as mbox:
+
+    with patch("tkinter.Tk", return_value=DummyRoot()), patch(
+        "tkinter.Button", DummyButton
+    ), patch("tkinter.messagebox.showinfo") as mbox:
         create_tkinter_window()
         mbox.assert_called_once()

--- a/tests/test_os_check.py
+++ b/tests/test_os_check.py
@@ -4,25 +4,26 @@ from monkey_head.core.system_checks import check_os_support
 
 
 def test_windows_warning():
-    with patch('platform.system', return_value='Windows'), \
-         patch('platform.release', return_value='8'), \
-         patch('monkey_head.core.system_checks.logger') as log:
+    with patch("platform.system", return_value="Windows"), patch(
+        "platform.release", return_value="8"
+    ), patch("monkey_head.core.system_checks.logger") as log:
         check_os_support()
         log.warning.assert_called_once()
 
 
 def test_linux_supported_no_warning():
-    with patch('platform.system', return_value='Linux'), \
-         patch('distro.id', return_value='debian'), \
-         patch('distro.codename', return_value='trixie'), \
-         patch('monkey_head.core.system_checks.logger') as log:
+    with patch("platform.system", return_value="Linux"), patch(
+        "distro.id", return_value="debian"
+    ), patch("distro.codename", return_value="trixie"), patch(
+        "monkey_head.core.system_checks.logger"
+    ) as log:
         check_os_support()
         log.warning.assert_not_called()
 
 
 def test_macos_old_warning():
-    with patch('platform.system', return_value='Darwin'), \
-         patch('platform.mac_ver', return_value=('12.5', ('', '', ''), '')), \
-         patch('monkey_head.core.system_checks.logger') as log:
+    with patch("platform.system", return_value="Darwin"), patch(
+        "platform.mac_ver", return_value=("12.5", ("", "", ""), "")
+    ), patch("monkey_head.core.system_checks.logger") as log:
         check_os_support()
         log.warning.assert_called_once()

--- a/tests/test_preloader.py
+++ b/tests/test_preloader.py
@@ -3,7 +3,7 @@ from monkey_head.scripts.preload_data import preload_all
 
 def test_preload_all():
     data = preload_all()
-    assert data['prompts'], "Prompts should not be empty"
-    assert 'PDF' in data['memory'] and data['memory']['PDF'], (
-        "PDF memory should not be empty"
-    )
+    assert data["prompts"], "Prompts should not be empty"
+    assert (
+        "PDF" in data["memory"] and data["memory"]["PDF"]
+    ), "PDF memory should not be empty"


### PR DESCRIPTION
## Summary
- update default profile name to `Huey`
- set agent plugin's default prompt name to `Huey`
- format Huey and test code with `black`

## Testing
- `black --check huey tests`
- `flake8 huey tests`
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_684a3deb1018832bb39fb5175974a808