### PR TITLE
Fix placeholder sync logic and update bin scripts

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca
@@ -6,4 +7,40 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated:   06.05.2025
 # ==================================================
-Placeholder for `repo/pygpt-MHP/bin/build.sh` from the pygpt-MHP repo.
+# This script is used to build the app using pyinstaller
+
+VERSION="2.5.8"
+
+cd "$(dirname "$0")" || exit
+DIR_CURRENT="$(pwd)"
+DIR_PARENT="$(dirname "$DIR_CURRENT")"
+
+cd "$DIR_PARENT" || exit
+
+source ./venv/bin/activate
+pyinstaller --noconfirm linux.spec
+
+cp -rf "$DIR_PARENT"/LICENSE "$DIR_PARENT"/dist/Linux/
+cp -rf "$DIR_PARENT"/README.md "$DIR_PARENT"/dist/Linux/
+cp -rf "$DIR_PARENT"/CHANGELOG.md "$DIR_PARENT"/dist/Linux/
+cp -rf "$DIR_PARENT"/SECURITY.md "$DIR_PARENT"/dist/Linux/
+cp -rf "$DIR_PARENT"/icon.png "$DIR_PARENT"/dist/Linux/
+
+mv "$DIR_PARENT"/dist/Linux "$DIR_PARENT"/dist/pygpt-$VERSION
+cd "$DIR_PARENT"/dist || exit
+zip -r pygpt-$VERSION.zip pygpt-$VERSION -9
+cd "$DIR_PARENT" || exit
+
+python -m build
+twine check dist/*
+
+if [ -f "$DIR_PARENT/dist/pygpt-$VERSION.zip" ]; then
+        sha1sum "$DIR_PARENT"/dist/pygpt-$VERSION.zip
+fi
+
+if [ -f "$DIR_PARENT/dist/pygpt-$VERSION.msi" ]; then
+        sha1sum "$DIR_PARENT"/dist/pygpt-$VERSION.msi
+fi
+
+# twine check dist/*
+# twine upload dist/*

--- a/bin/resources.py
+++ b/bin/resources.py
@@ -1,9 +1,81 @@
-# ==================================================
-# This file is a part of the 'Monkey Head Project'
-# Website:   https://dlrp.ca
-# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
-# License:   https://opensource.org/license/gpl-3-0
-# Overseen By:   Dylan L.R. Pollock
-# Updated: 06.05.2025
-# ==================================================
-# Placeholder for `repo/pygpt-MHP/bin/resources.py` from the pygpt-MHP repo.
+import os
+
+
+def generate_resource_file(source_dirs, output_file, file_extension, resource_prefix):
+    files = []
+    for source_dir in source_dirs:
+        for f in os.listdir(source_dir):
+            if f.endswith(file_extension) or file_extension == "*":
+                files.append((f, os.path.join(source_dir, f)))
+    files.sort()
+
+    qrc_content = "<RCC>\n"
+    qrc_content += f'    <qresource prefix="{resource_prefix}">\n'
+    for file_name, file_path in files:
+        qrc_content += f'        <file alias="{file_name}">{file_path}</file>\n'
+    qrc_content += "    </qresource>\n"
+    qrc_content += "</RCC>"
+
+    with open(output_file, "w") as file:
+        file.write(qrc_content)
+    print(f"Generated: {output_file}")
+
+
+if __name__ == "__main__":
+    # icons
+    icons_source_dir = os.path.join(
+        os.path.dirname(__file__), "..", "src", "pygpt_net", "data", "icons"
+    )
+    icons_output_file = os.path.join(
+        os.path.dirname(__file__), "..", "src", "pygpt_net", "icons.qrc"
+    )
+    generate_resource_file([icons_source_dir], icons_output_file, ".svg", "/icons")
+
+    # javascript
+    js_source_dirs = [
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "src",
+            "pygpt_net",
+            "data",
+            "js",
+            "highlight",
+        ),
+        os.path.join(
+            os.path.dirname(__file__), "..", "src", "pygpt_net", "data", "js", "katex"
+        ),
+    ]
+    js_output_file = os.path.join(
+        os.path.dirname(__file__), "..", "src", "pygpt_net", "js.qrc"
+    )
+    generate_resource_file(js_source_dirs, js_output_file, ".js", "/js")
+
+    # CSS
+    css_source_dirs = [
+        os.path.join(
+            os.path.dirname(__file__), "..", "src", "pygpt_net", "data", "js", "katex"
+        ),
+    ]
+    css_output_file = os.path.join(
+        os.path.dirname(__file__), "..", "src", "pygpt_net", "css.qrc"
+    )
+    generate_resource_file(css_source_dirs, css_output_file, ".css", "/css")
+
+    # fonts
+    fonts_source_dirs = [
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "src",
+            "pygpt_net",
+            "data",
+            "js",
+            "katex",
+            "fonts",
+        ),
+    ]
+    fonts_output_file = os.path.join(
+        os.path.dirname(__file__), "..", "src", "pygpt_net", "fonts.qrc"
+    )
+    generate_resource_file(fonts_source_dirs, fonts_output_file, "*", "/fonts")

--- a/sync_pygpt_structure.py
+++ b/sync_pygpt_structure.py
@@ -24,13 +24,20 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 def _should_copy_file(dst: str) -> bool:
-    """Return True if file should be copied from the source."""
+    """Return True if ``dst`` does not exist or contains a placeholder header."""
     if not os.path.exists(dst):
         return True
+
     try:
         with open(dst, "r", errors="ignore") as f:
-            first = f.readline().strip()
-        return first.startswith("Placeholder for")
+            for _ in range(10):
+                line = f.readline()
+                if not line:
+                    break
+                cleaned = line.lstrip("# ").strip()
+                if cleaned.startswith("Placeholder for"):
+                    return True
+        return False
     except Exception:
         return False
 
@@ -58,6 +65,7 @@ def mirror_tree(src_root: str, dst_root: str, depth: int | None = None) -> None:
         dst_path = os.path.join(dst_root, item)
         sync(src_path, dst_path, None if depth is None else depth - 1)
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Copy files from the pygpt-MHP submodule into the main project"
@@ -70,4 +78,3 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     mirror_tree(PYGPT_DIR, ROOT_DIR, depth=args.depth)
-


### PR DESCRIPTION
## Summary
- improve placeholder detection so sync script copies real files
- replace stub `bin/build.sh` and `bin/resources.py` with live versions from the submodule

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'distro')*

------
https://chatgpt.com/codex/tasks/task_e_684a3f3adb34832bb4c30ebab178b430