### PR TITLE
Add experimental Python 3.13 warning

### DIFF
--- a/monkey_head/core/system_checks.py
+++ b/monkey_head/core/system_checks.py
@@ -10,6 +10,7 @@ import logging
 import os
 import platform
 import subprocess
+import sys
 
 import distro
 from ..logging_setup import configure_logging
@@ -72,6 +73,14 @@ def check_os_support() -> None:
             )
     else:
         logger.warning("Unsupported operating system detected: %s", system)
+
+
+def check_python_version() -> None:
+    """Warn when running on experimental Python versions."""
+    if sys.version_info.major == 3 and sys.version_info.minor == 13:
+        logger.warning(
+            "Python 3.13 detected. This version is experimental and not fully supported."
+        )
 
 
 def system_check():

--- a/monkey_head/main.py
+++ b/monkey_head/main.py
@@ -8,7 +8,7 @@
 # ==================================================
 from monkey_head.utils.logger import get_logger
 from flask import Flask, jsonify
-from .core.system_checks import system_check, ensure_admin
+from .core.system_checks import system_check, ensure_admin, check_python_version
 from .modules.updates import update_system, update_python_packages
 from .core.installations import (
     install_common_tools,
@@ -51,6 +51,7 @@ def readiness_check():
 def main() -> None:
     """Run full setup and start the health service."""
     ensure_admin()
+    check_python_version()
     system_check()
     update_system()
     install_common_tools()

--- a/run.py
+++ b/run.py
@@ -21,7 +21,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from monkey_head.core.system_checks import check_os_support
+from monkey_head.core.system_checks import check_os_support, check_python_version
 
 sys.path.insert(0, str((Path(__file__).parent / "src").resolve()))
 
@@ -59,6 +59,8 @@ def main() -> None:
 
     # Warn if running on an unsupported operating system
     check_os_support()
+    # Warn if running an experimental Python version
+    check_python_version()
 
     if args.version:
         from pygpt_net import __version__

--- a/tests/test_python_version.py
+++ b/tests/test_python_version.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from monkey_head.core.system_checks import check_python_version
+
+
+def test_python_313_warning():
+    with patch('monkey_head.core.system_checks.sys.version_info', (3, 13, 0)), \
+         patch('monkey_head.core.system_checks.logger') as log:
+        check_python_version()
+        log.warning.assert_called_once()
+
+
+def test_python_supported_no_warning():
+    with patch('monkey_head.core.system_checks.sys.version_info', (3, 12, 0)), \
+         patch('monkey_head.core.system_checks.logger') as log:
+        check_python_version()
+        log.warning.assert_not_called()


### PR DESCRIPTION
## Summary
- warn when running on Python 3.13
- expose Python version check in CLI and setup routines
- test the new version check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'distro')*

------
https://chatgpt.com/codex/tasks/task_e_684a3e58ad20832ba5f516f06ec4f39f