### PR TITLE
Fix unused components and add tests

### DIFF
--- a/repo/pygpt-MHP/src/pygpt_net/controller/attachment/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/attachment/__init__.py
@@ -110,8 +110,14 @@ class Attachment:
         """
         Select on list change
         """
-        # TODO: implement this
-        pass
+        widget = self.window.ui.nodes.get('attachments')
+        if widget is None:
+            return
+        indexes = widget.selectedIndexes()
+        if not indexes:
+            return
+        mode = self.window.core.config.get('mode')
+        self.select(mode, indexes[0].row())
 
     def delete(
             self,

--- a/repo/pygpt-MHP/src/pygpt_net/controller/idx/common.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/idx/common.py
@@ -23,7 +23,19 @@ class Common:
 
     def setup(self):
         """Set up UI"""
-        pass
+        checkbox = None
+        try:
+            checkbox = self.window.ui.config['global']['llama.idx.raw']
+        except Exception:
+            checkbox = None
+        if checkbox is not None:
+            value = self.window.core.config.get('llama.idx.raw', False)
+            checkbox.setChecked(value)
+
+    def toggle_raw(self, value: bool):
+        """Toggle raw query mode"""
+        self.window.core.config.set('llama.idx.raw', value)
+        self.window.core.config.save()
 
     def get_loaders_choices(self) -> List[Dict[str, str]]:
         """

--- a/repo/pygpt-MHP/tests/controller/idx/test_idx_common.py
+++ b/repo/pygpt-MHP/tests/controller/idx/test_idx_common.py
@@ -17,4 +17,19 @@ from pygpt_net.controller.idx.common import Common
 
 def test_setup(mock_window):
     """Test setup"""
-    pass
+    checkbox = MagicMock()
+    mock_window.ui.config = {'global': {'llama.idx.raw': checkbox}}
+    mock_window.core.config.get = MagicMock(return_value=True)
+    common = Common(mock_window)
+    common.setup()
+    checkbox.setChecked.assert_called_once_with(True)
+
+
+def test_toggle_raw(mock_window):
+    """Test toggle_raw"""
+    mock_window.core.config.set = MagicMock()
+    mock_window.core.config.save = MagicMock()
+    common = Common(mock_window)
+    common.toggle_raw(True)
+    mock_window.core.config.set.assert_called_once_with('llama.idx.raw', True)
+    mock_window.core.config.save.assert_called_once()

--- a/repo/pygpt-MHP/tests/controller/test_attachment.py
+++ b/repo/pygpt-MHP/tests/controller/test_attachment.py
@@ -268,3 +268,16 @@ def test_is_send_clear(mock_window):
     assert attachment.is_send_clear() is True
     mock_window.core.config.has.assert_called_once_with('attachments_send_clear')
     mock_window.core.config.get.assert_called_once_with('attachments_send_clear')
+
+
+def test_selection_change(mock_window):
+    attachment = Attachment(mock_window)
+    index = MagicMock()
+    index.row.return_value = 2
+    widget = MagicMock()
+    widget.selectedIndexes.return_value = [index]
+    mock_window.ui.nodes['attachments'] = widget
+    mock_window.core.config.get = MagicMock(return_value='vision')
+    attachment.select = MagicMock()
+    attachment.selection_change()
+    attachment.select.assert_called_once_with('vision', 2)


### PR DESCRIPTION
## Summary
- implement selection change logic for attachments
- implement checkbox setup and toggle for index common
- expand tests for attachment and new index common functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'distro')*

------
https://chatgpt.com/codex/tasks/task_e_684a3ea6386c832b942f3fa4e3ef2dc3