### PR TITLE
Fill OptionCmd placeholder

### DIFF
--- a/repo/pygpt-MHP/src/pygpt_net/ui/widget/option/cmd.py
+++ b/repo/pygpt-MHP/src/pygpt_net/ui/widget/option/cmd.py
@@ -156,4 +156,20 @@ class OptionCmd(QWidget):
 
     def update(self):
         """Update widget"""
-        pass
+        if self.option is None:
+            return
+
+        data = self.option.get("value", {}) or {}
+
+        # enabled checkbox
+        self.enabled.setChecked(data.get("enabled", True))
+
+        # instruction text
+        instruction = data.get("instruction", "")
+        self.instruction.setPlainText(instruction)
+
+        # params list
+        params = data.get("params", [])
+        self.params.items = list(params)
+        self.params.model.items = list(params)
+        self.params.update()


### PR DESCRIPTION
## Summary
- implement update logic for OptionCmd widget

## Testing
- `pytest tests/test_placeholder.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_684a40d8fd98832b87d0ce5928a6d952