### PR TITLE
Add media conversion utilities

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -14,7 +14,15 @@ from . import subos_manager
 from .logging_setup import configure_logging
 from .utils.logger import get_logger
 from .convert_png_to_jpeg import convert_png_to_jpeg
-from .pdf_pre_digestion import pdf_pre_digestion
+try:
+    from .pdf_pre_digestion import pdf_pre_digestion
+except Exception:  # pragma: no cover - optional dependency
+    pdf_pre_digestion = None
+from .media_conversion import (
+    convert_audio,
+    convert_video,
+    convert_file,
+)
 
 # Initialize project-wide logging as soon as the package is imported
 configure_logging()
@@ -26,4 +34,7 @@ __all__ = [
     "get_logger",
     "convert_png_to_jpeg",
     "pdf_pre_digestion",
+    "convert_audio",
+    "convert_video",
+    "convert_file",
 ]

--- a/monkey_head/media_conversion.py
+++ b/monkey_head/media_conversion.py
@@ -1,0 +1,44 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.05.2025
+# ==================================================
+"""Media conversion utilities using FFmpeg."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+__all__ = [
+    "convert_audio",
+    "convert_video",
+    "convert_file",
+]
+
+
+def _run_ffmpeg(args: list[str]) -> None:
+    """Run an ffmpeg command and raise if it fails."""
+    cmd = ["ffmpeg", "-y"] + args
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.decode("utf-8", "ignore"))
+
+
+def convert_audio(src: str, dst: str, bitrate: str = "192k") -> None:
+    """Convert an audio file to a new format using ffmpeg."""
+    _run_ffmpeg(["-i", src, "-b:a", bitrate, dst])
+
+
+def convert_video(src: str, dst: str, codec: str = "libx264") -> None:
+    """Convert a video file to a new format using ffmpeg."""
+    _run_ffmpeg(["-i", src, "-vcodec", codec, dst])
+
+
+def convert_file(src: str, dst: str) -> None:
+    """Generic file conversion by copying to a new path."""
+    shutil.copyfile(src, dst)

--- a/tests/test_media_conversion.py
+++ b/tests/test_media_conversion.py
@@ -1,0 +1,57 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.05.2025
+# ==================================================
+from pathlib import Path
+import wave
+import subprocess
+
+from monkey_head.media_conversion import convert_audio, convert_video, convert_file
+
+
+def _make_wav(path: Path) -> None:
+    with wave.open(str(path), "w") as f:
+        f.setnchannels(1)
+        f.setsampwidth(2)
+        f.setframerate(44100)
+        f.writeframes(b"\x00\x00" * 44100)
+
+
+def _make_video(path: Path) -> None:
+    subprocess.run([
+        "ffmpeg",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        "color=c=red:s=16x16:d=1",
+        str(path),
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+
+
+def test_convert_audio(tmp_path: Path) -> None:
+    src = tmp_path / "in.wav"
+    dst = tmp_path / "out.mp3"
+    _make_wav(src)
+    convert_audio(str(src), str(dst))
+    assert dst.exists() and dst.stat().st_size > 0
+
+
+def test_convert_video(tmp_path: Path) -> None:
+    src = tmp_path / "in.mp4"
+    dst = tmp_path / "out.avi"
+    _make_video(src)
+    convert_video(str(src), str(dst))
+    assert dst.exists() and dst.stat().st_size > 0
+
+
+def test_convert_file(tmp_path: Path) -> None:
+    src = tmp_path / "a.txt"
+    dst = tmp_path / "b.bin"
+    src.write_text("hello")
+    convert_file(str(src), str(dst))
+    assert dst.read_text() == "hello"


### PR DESCRIPTION
## Summary
- add FFmpeg-based `media_conversion` utilities for audio, video and generic files
- expose the new utilities through `monkey_head.__init__`
- include tests for the new conversion functions
- make pdf_pre_digestion optional so package can load without heavy deps

## Testing
- `pytest tests/test_media_conversion.py tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684a41891b58832bb7dcf5c8ffee6f49