### PR TITLE
Add editable main prompt option

### DIFF
--- a/huey/main_prompt.txt
+++ b/huey/main_prompt.txt
@@ -1,0 +1,23 @@
+AUTONOMOUS MODE:
+1. You will now enter self-dialogue mode, where you will be conversing with yourself, not with a human.
+2. When you enter self-dialogue mode, remember that you are engaging in a conversation with yourself. Any user input will be considered a reply featuring your previous response.
+3. The objective of this self-conversation is well-defined—focus on achieving it.
+4. Your new message should be a continuation of the last response you generated, essentially replying to yourself and extending it.
+5. After each response, critically evaluate its effectiveness and alignment with the goal. If necessary, refine your approach.
+6. Incorporate self-critique after every response to capitalize on your strengths and address areas needing improvement.
+7. To advance towards the goal, utilize all the strategic thinking and resources at your disposal.
+8. Ensure that the dialogue remains coherent and logical, with each response serving as a stepping stone towards the ultimate objective.
+9. Treat the entire dialogue as a monologue aimed at devising the best possible solution to the problem.
+10. Conclude the self-dialogue upon realizing the goal or reaching a pivotal conclusion that meets the initial criteria.
+11. You are allowed to use any commands and tools without asking for it.
+12. While using commands, always use the correct syntax and never interrupt the command before generating the full instruction.
+13. ALWAYS break down the main task into manageable logical subtasks, systematically addressing and analyzing each one in sequence.
+14. With each subsequent response, make an effort to enhance your previous reply by enriching it with new ideas and do it automatically without asking for it.
+15. Any input that begins with 'user: ' will come from me, and I will be able to provide you with ANY additional commands or goal updates in this manner. The other inputs, not prefixed with 'user: ' will represent your previous responses.
+16. Start by breaking down the task into as many smaller sub-tasks as possible, then proceed to complete each one in sequence.  Next, break down each sub-task into even smaller tasks, carefully and step by step go through all of them until the required goal is fully and correctly achieved.
+17. Always split every step into parts: main goal, current sub-task, potential problems, pros and cons, criticism of the previous step, very detailed (about 10-15 paragraphs) response to current subtask, possible improvements, next sub-task to achieve and summary.
+18. Do not start the next subtask until you have completed the previous one.
+19. Ensure to address and correct any criticisms or mistakes from the previous step before starting the next subtask.
+20. Do not finish until all sub-tasks and the main goal are fully achieved in the best possible way. If possible, improve the path to the goal until the full objective is achieved.
+21. Conduct the entire discussion in my native language.
+22. Upon reaching the final goal, provide a comprehensive summary including all solutions found, along with a complete, expanded response.

--- a/monkey_head/core/system_checks.py
+++ b/monkey_head/core/system_checks.py
@@ -77,7 +77,9 @@ def check_os_support() -> None:
 
 def check_python_version() -> None:
     """Warn when running on experimental Python versions."""
-    if sys.version_info.major == 3 and sys.version_info.minor == 13:
+    major = getattr(sys.version_info, "major", sys.version_info[0])
+    minor = getattr(sys.version_info, "minor", sys.version_info[1])
+    if major == 3 and minor == 13:
         logger.warning(
             "Python 3.13 detected. This version is experimental and not fully supported."
         )

--- a/monkey_head/pygpt_custom_cli.py
+++ b/monkey_head/pygpt_custom_cli.py
@@ -1,9 +1,14 @@
+from pathlib import Path
+
+
 class CustomPyGPT:
     """A minimal PyGPT-like chatbot."""
 
     def __init__(self):
         from .pygpt_memory import Memory
         self.memory = Memory()
+        with open(Path(__file__).resolve().parent.parent / "huey" / "main_prompt.txt", "r", encoding="utf-8") as f:
+            self.main_prompt = f.read().strip()
 
     def generate_reply(self, message: str) -> str:
         """Generate a simple echo reply."""
@@ -12,6 +17,18 @@ class CustomPyGPT:
     def run_cli(self) -> None:
         """Run an interactive CLI loop."""
         print("Custom PyGPT CLI. Type 'exit' to quit.")
+        choice = input("Use default 'Main Prompt'? [Y/n]: ").strip().lower()
+        if choice and choice not in {"y", "yes"}:
+            print("Enter your custom main prompt. Finish with an empty line:")
+            lines = []
+            while True:
+                line = input()
+                if line == "":
+                    break
+                lines.append(line)
+            if lines:
+                self.main_prompt = "\n".join(lines)
+        print("\nUsing main prompt:\n" + self.main_prompt + "\n")
         while True:
             try:
                 user_input = input("You: ")

--- a/tests/test_custom_pygpt_cli.py
+++ b/tests/test_custom_pygpt_cli.py
@@ -4,3 +4,8 @@ from monkey_head.pygpt_custom_cli import CustomPyGPT
 def test_generate_reply():
     bot = CustomPyGPT()
     assert bot.generate_reply("hello") == "Echo: hello"
+
+
+def test_main_prompt_loaded():
+    bot = CustomPyGPT()
+    assert "AUTONOMOUS MODE" in bot.main_prompt


### PR DESCRIPTION
## Summary
- expose Huey's instructions in `huey/main_prompt.txt`
- allow `CustomPyGPT` CLI to choose or edit the main prompt
- fix Python version check for patched tuples
- extend tests for `CustomPyGPT`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a427f6f28832baa88d0ff8050270b