### PR TITLE
Add API key configuration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ the test suite with `pytest -vv`. Both scripts report an error if the
 `update_memory_pdfs.py` regenerates text versions of the bundled PDF files
 under `memory/PDF`. Run this script whenever you add or edit PDF documents
 to keep the preloaded dataset up to date.
+`set_api_keys.py` walks you through entering API credentials. Choose
+which services to connect (OpenAI, Google, or DeepSeek) or select the
+auto option to configure all of them at once.
 
 The `huey` package also provides a small CLI. Use `huey convert` to
 convert image files between formats at maximum quality. Supply an input

--- a/scripts/set_api_keys.py
+++ b/scripts/set_api_keys.py
@@ -1,0 +1,58 @@
+import json
+import os
+
+CONFIG_PATH = os.path.join('config', 'pygpt_net', 'config.json')
+
+SERVICES = {
+    'openai': 'api_key',
+    'google': 'api_key_google',
+    'deepseek': 'api_key_deepseek',
+}
+
+def load_config():
+    if os.path.exists(CONFIG_PATH):
+        with open(CONFIG_PATH, 'r', encoding='utf-8') as fh:
+            return json.load(fh)
+    return {}
+
+def save_config(data):
+    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+    with open(CONFIG_PATH, 'w', encoding='utf-8') as fh:
+        json.dump(data, fh, indent=2)
+
+def prompt_service_choice():
+    print("Select services to connect:")
+    print("1) Auto - All")
+    print("2) Manual - choose from OpenAI, Google, DeepSeek")
+    choice = input("Enter choice [1/2]: ").strip()
+    if choice == '1':
+        return list(SERVICES.keys())
+    selected = []
+    for name in SERVICES:
+        ans = input(f"Use {name.title()}? [y/N]: ").strip().lower()
+        if ans == 'y':
+            selected.append(name)
+    return selected
+
+def prompt_keys(selected, data):
+    for name in selected:
+        key_name = SERVICES[name]
+        existing = data.get(key_name, '')
+        prompt = f"Enter {name.title()} API key" + (f" [current: {existing}]" if existing else '') + ': '
+        value = input(prompt).strip()
+        if value:
+            data[key_name] = value
+
+
+def main():
+    config = load_config()
+    services = prompt_service_choice()
+    if not services:
+        print('No services selected.')
+        return
+    prompt_keys(services, config)
+    save_config(config)
+    print('API keys saved to', CONFIG_PATH)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script to set API keys for OpenAI, Google and DeepSeek
- document new script in README

## Testing
- `bash run-tests.sh` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4348c2e0832bb4801e136fed4589