### PR TITLE
Add customizable main prompt support

### DIFF
--- a/monkey_head/core/system_checks.py
+++ b/monkey_head/core/system_checks.py
@@ -78,11 +78,11 @@ def check_os_support() -> None:
 def check_python_version() -> None:
     """Warn when running on experimental Python versions."""
     info = sys.version_info
-    try:
-        major = info.major
-        minor = info.minor
-    except AttributeError:  # pragma: no cover - handle tuple version_info
+    if isinstance(info, tuple):  # support tests that patch a tuple
         major, minor = info[0], info[1]
+    else:
+        major = getattr(info, "major", 0)
+        minor = getattr(info, "minor", 0)
     if major == 3 and minor == 13:
         logger.warning(
             "Python 3.13 detected. This version is experimental and not fully supported."

--- a/monkey_head/pygpt_custom_cli.py
+++ b/monkey_head/pygpt_custom_cli.py
@@ -1,9 +1,23 @@
+from pathlib import Path
+
+
 class CustomPyGPT:
     """A minimal PyGPT-like chatbot."""
 
-    def __init__(self):
+    def __init__(self, prompt_file: str | Path | None = None):
         from .pygpt_memory import Memory
         self.memory = Memory()
+        if prompt_file is None:
+            prompt_file = Path(__file__).resolve().parent.parent / "prompts" / "huey_main_prompt.txt"
+        self.prompt_file = Path(prompt_file)
+        self.main_prompt = self.load_main_prompt()
+
+    def load_main_prompt(self) -> str:
+        """Load the default main prompt from ``self.prompt_file``."""
+        try:
+            return self.prompt_file.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return ""
 
     def generate_reply(self, message: str) -> str:
         """Generate a simple echo reply."""
@@ -12,6 +26,12 @@ class CustomPyGPT:
     def run_cli(self) -> None:
         """Run an interactive CLI loop."""
         print("Custom PyGPT CLI. Type 'exit' to quit.")
+        user_prompt = input(
+            f"Enter main prompt or press Enter to use default:\n{self.main_prompt}\n> "
+        ).strip()
+        if user_prompt:
+            self.main_prompt = user_prompt
+        print("Chat starting...")
         while True:
             try:
                 user_input = input("You: ")

--- a/prompts/huey_main_prompt.txt
+++ b/prompts/huey_main_prompt.txt
@@ -1,0 +1,2 @@
+You are Huey, the helpful assistant of the Monkey Head Project.
+Provide concise and polite answers to any questions.

--- a/tests/test_custom_pygpt_cli.py
+++ b/tests/test_custom_pygpt_cli.py
@@ -4,3 +4,10 @@ from monkey_head.pygpt_custom_cli import CustomPyGPT
 def test_generate_reply():
     bot = CustomPyGPT()
     assert bot.generate_reply("hello") == "Echo: hello"
+
+
+def test_load_main_prompt(tmp_path):
+    prompt_file = tmp_path / "prompt.txt"
+    prompt_file.write_text("default text")
+    bot = CustomPyGPT(prompt_file=prompt_file)
+    assert bot.main_prompt == "default text"


### PR DESCRIPTION
## Summary
- add Huey's default main prompt file
- load the default prompt in `CustomPyGPT`
- allow overriding the prompt before chat begins
- support tuple-based mocks in `check_python_version`
- extend tests for prompt loading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'distro')*

------
https://chatgpt.com/codex/tasks/task_e_684a44514274832b96dc3b90d2ac6ea4