### PR TITLE
Add Docker and Kubernetes controls to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,10 @@ back to the command-line interface. You can also force CLI mode with
 
 The GUI now checks whether you've accepted the license on startup and
 offers a **Tools** menu. From there you can reopen the license dialog or
-view a summary of bundled prompts and memory files.
+view a summary of bundled prompts and memory files. Additional **Docker** and
+**Kubernetes** menus provide one-click access to common container tasks such as
+building images, starting or stopping containers, cleaning up resources, and
+deploying or scaling Kubernetes manifests.
 
 ### Customizing prompts and personalities
 

--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 try:  # pragma: no cover - optional dependency
     import tkinter as tk
-    from tkinter import messagebox, scrolledtext, ttk
+    from tkinter import messagebox, scrolledtext, simpledialog, ttk
 except Exception:  # pragma: no cover - can't import GUI libs
     tk = None
     messagebox = None
@@ -24,6 +24,18 @@ except Exception:  # pragma: no cover - can't import GUI libs
 from monkey_head.license_gui import show_license_gui
 from monkey_head.scripts.preload_data import preload_all
 from monkey_head.gui_scaling import apply_scaling
+from monkey_head.services.container_management import (
+    build_docker_image,
+    cleanup_images,
+    cleanup_kubernetes,
+    deploy_kubernetes,
+    get_pod_logs,
+    manage_containers,
+    manage_networks,
+    manage_volumes,
+    scale_deployment,
+    stop_containers,
+)
 
 # Dark theme colors
 DARK_BG = "#2d2b57"  # dark purple background
@@ -129,6 +141,24 @@ class MainUI:
         tools_menu.add_command(label="License", command=self.show_license)
         tools_menu.add_command(label="Data Summary", command=self.show_data_summary)
         menu_bar.add_cascade(label="Tools", menu=tools_menu)
+
+        docker_menu = tk.Menu(menu_bar, tearoff=0, bg=DARK_BG, fg=LIGHT_FG)
+        docker_menu.add_command(label="Build Image", command=self.build_image)
+        docker_menu.add_command(label="Start Containers", command=self.start_containers)
+        docker_menu.add_command(label="Stop Containers", command=self.stop_containers)
+        docker_menu.add_command(label="Cleanup Images", command=self.cleanup_images)
+        docker_menu.add_command(label="Manage Volumes", command=self.manage_volumes)
+        docker_menu.add_command(label="Manage Networks", command=self.manage_networks)
+        menu_bar.add_cascade(label="Docker", menu=docker_menu)
+
+        k8s_menu = tk.Menu(menu_bar, tearoff=0, bg=DARK_BG, fg=LIGHT_FG)
+        k8s_menu.add_command(label="Deploy", command=self.deploy_kubernetes)
+        k8s_menu.add_command(
+            label="Scale Deployment", command=self.scale_deployment_prompt
+        )
+        k8s_menu.add_command(label="Get Pod Logs", command=self.get_pod_logs_prompt)
+        k8s_menu.add_command(label="Cleanup", command=self.cleanup_kubernetes)
+        menu_bar.add_cascade(label="Kubernetes", menu=k8s_menu)
 
     def create_widgets(self):
         self.log_text = scrolledtext.ScrolledText(
@@ -256,9 +286,117 @@ class MainUI:
         prompts = len(data.get("prompts", []))
         memory_files = sum(len(v) for v in data.get("memory", {}).values())
         messagebox.showinfo(
-            "Data Summary",
-            f"Prompts: {prompts}\nMemory files: {memory_files}"
+            "Data Summary", f"Prompts: {prompts}\nMemory files: {memory_files}"
         )
+
+    def _run_container_func(self, func, *args):
+        try:
+            func(*args)
+            self.log_message("Operation completed successfully.")
+        except Exception as exc:  # pragma: no cover - subprocess failures
+            self.log_message(f"Exception: {exc}")
+        finally:
+            self.progress.stop()
+            self.status_label.config(text="Status: Ready")
+
+    def build_image(self):
+        self.log_message("Building Docker image...")
+        self.status_label.config(text="Status: Building")
+        self.progress.start()
+        threading.Thread(
+            target=self._run_container_func, args=(build_docker_image,)
+        ).start()
+
+    def start_containers(self):
+        self.log_message("Starting containers...")
+        self.status_label.config(text="Status: Starting")
+        self.progress.start()
+        threading.Thread(
+            target=self._run_container_func, args=(manage_containers,)
+        ).start()
+
+    def stop_containers(self):
+        self.log_message("Stopping containers...")
+        self.status_label.config(text="Status: Stopping")
+        self.progress.start()
+        threading.Thread(
+            target=self._run_container_func, args=(stop_containers,)
+        ).start()
+
+    def cleanup_images(self):
+        self.log_message("Pruning images...")
+        self.status_label.config(text="Status: Cleaning")
+        self.progress.start()
+        threading.Thread(
+            target=self._run_container_func, args=(cleanup_images,)
+        ).start()
+
+    def manage_volumes(self):
+        self.log_message("Managing volumes...")
+        self.status_label.config(text="Status: Volumes")
+        self.progress.start()
+        threading.Thread(
+            target=self._run_container_func, args=(manage_volumes,)
+        ).start()
+
+    def manage_networks(self):
+        self.log_message("Managing networks...")
+        self.status_label.config(text="Status: Networks")
+        self.progress.start()
+        threading.Thread(
+            target=self._run_container_func, args=(manage_networks,)
+        ).start()
+
+    def deploy_kubernetes(self):
+        self.log_message("Deploying Kubernetes resources...")
+        self.status_label.config(text="Status: Deploying")
+        self.progress.start()
+        threading.Thread(
+            target=self._run_container_func, args=(deploy_kubernetes,)
+        ).start()
+
+    def cleanup_kubernetes(self):
+        self.log_message("Cleaning Kubernetes resources...")
+        self.status_label.config(text="Status: Cleaning")
+        self.progress.start()
+        threading.Thread(
+            target=self._run_container_func, args=(cleanup_kubernetes,)
+        ).start()
+
+    def scale_deployment_prompt(self):
+        name = simpledialog.askstring("Deployment", "Deployment name:")
+        if not name:
+            return
+        replicas = simpledialog.askinteger("Replicas", "Number of replicas:")
+        if replicas is None:
+            return
+        self.log_message(f"Scaling {name} to {replicas}...")
+        self.status_label.config(text="Status: Scaling")
+        self.progress.start()
+        threading.Thread(
+            target=self._run_container_func,
+            args=(scale_deployment, name, replicas),
+        ).start()
+
+    def get_pod_logs_prompt(self):
+        pod = simpledialog.askstring("Pod", "Pod name:")
+        if not pod:
+            return
+        self.log_message(f"Fetching logs for {pod}...")
+        self.status_label.config(text="Status: Logs")
+        self.progress.start()
+        threading.Thread(target=self._get_logs, args=(pod,)).start()
+
+    def _get_logs(self, pod):
+        try:
+            logs = get_pod_logs(pod)
+            self.log_message(logs)
+            self.log_message("Operation completed successfully.")
+        except Exception as exc:  # pragma: no cover - subprocess failures
+            self.log_message(f"Exception: {exc}")
+        finally:
+            self.progress.stop()
+            self.status_label.config(text="Status: Ready")
 
 
 if __name__ == "__main__":

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from types import SimpleNamespace
 from gui.main_ui import MainUI
 
 
@@ -42,3 +43,49 @@ def test_choose_screen_mode_prompt():
     ):
         mode = MainUI.choose_screen_mode(ui)
         assert mode == "4k"
+
+
+def test_build_image_calls_runner():
+    ui = MainUI.__new__(MainUI)
+    ui.status_label = SimpleNamespace(config=lambda **_: None)
+    ui.progress = SimpleNamespace(start=lambda: None, stop=lambda: None)
+    with patch.object(MainUI, "_run_container_func") as runner, patch.object(
+        MainUI, "log_message"
+    ), patch("gui.main_ui.threading.Thread") as th:
+        th.side_effect = lambda target, args: SimpleNamespace(
+            start=lambda: target(*args)
+        )
+        MainUI.build_image(ui)
+        runner.assert_called_once()
+
+
+def test_deploy_kubernetes_calls_runner():
+    ui = MainUI.__new__(MainUI)
+    ui.status_label = SimpleNamespace(config=lambda **_: None)
+    ui.progress = SimpleNamespace(start=lambda: None, stop=lambda: None)
+    with patch.object(MainUI, "_run_container_func") as runner, patch.object(
+        MainUI, "log_message"
+    ), patch("gui.main_ui.threading.Thread") as th:
+        th.side_effect = lambda target, args: SimpleNamespace(
+            start=lambda: target(*args)
+        )
+        MainUI.deploy_kubernetes(ui)
+        runner.assert_called_once()
+
+
+def test_scale_deployment_prompt_collects_input():
+    ui = MainUI.__new__(MainUI)
+    ui.status_label = SimpleNamespace(config=lambda **_: None)
+    ui.progress = SimpleNamespace(start=lambda: None, stop=lambda: None)
+    with patch("gui.main_ui.simpledialog.askstring", return_value="demo"), patch(
+        "gui.main_ui.simpledialog.askinteger", return_value=2
+    ), patch.object(MainUI, "_run_container_func") as runner, patch.object(
+        MainUI, "log_message"
+    ), patch(
+        "gui.main_ui.threading.Thread"
+    ) as th:
+        th.side_effect = lambda target, args: SimpleNamespace(
+            start=lambda: target(*args)
+        )
+        MainUI.scale_deployment_prompt(ui)
+        runner.assert_called_once()


### PR DESCRIPTION
## Summary
- expose Docker/Kubernetes actions through the GUI
- add convenience Docker/Kubernetes menus
- document new options in README
- test new GUI hooks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a45931418832b9dcf8ec6850118a4