### PR TITLE
Add repair reinstall function

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,17 @@ python fresh_install.py       # Windows
 ```
 
 
+### Repair
+
+If the installation becomes corrupted, run the repair script. It clones a fresh
+copy of the repository and installs it:
+
+```bash
+sudo python repair.py  # Linux/macOS
+python repair.py       # Windows
+```
+
+
 
 ### Directory Structure
 

--- a/repair.py
+++ b/repair.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Repair the Monkey Head Project by reinstalling from a fresh clone."""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import installer
+import uninstaller
+
+REPO_URL = "https://github.com/DylanLRPollock/Monkey-Head-Project.git"
+
+
+def run_repair(repo_url: str = REPO_URL) -> int:
+    """Clone the repository and run a fresh installation."""
+    print("Starting repair procedure...")
+
+    uninstall_rc = uninstaller.run_uninstaller()
+    if uninstall_rc != 0:
+        print(f"Uninstall failed with code {uninstall_rc}")
+        return uninstall_rc
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        print(f"Cloning repository from {repo_url}...")
+        clone = subprocess.run([
+            "git",
+            "clone",
+            repo_url,
+            tmpdir,
+        ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if clone.returncode != 0:
+            sys.stderr.write(clone.stderr.decode())
+            return clone.returncode
+
+        print("Running installer from fresh clone...")
+        rc = subprocess.run([
+            sys.executable,
+            "installer.py",
+        ], cwd=tmpdir).returncode
+        if rc != 0:
+            print(f"Installer failed with code {rc}")
+        return rc
+
+
+if __name__ == "__main__":
+    sys.exit(run_repair())

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+import sys
+import repair
+
+
+class DummyCompleted:
+    def __init__(self, returncode=0, stderr=b"", stdout=b""):
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = stdout
+
+
+def test_run_repair_success(tmp_path):
+    with patch("uninstaller.run_uninstaller", return_value=0) as uninst, \
+         patch("subprocess.run") as run_mock, \
+         patch("tempfile.TemporaryDirectory") as tmpdir:
+        tmpdir.return_value.__enter__.return_value = str(tmp_path)
+        run_mock.side_effect = [DummyCompleted(), DummyCompleted()]
+        rc = repair.run_repair("repo-url")
+        assert rc == 0
+        uninst.assert_called_once()
+        run_mock.assert_any_call(
+            ["git", "clone", "repo-url", str(tmp_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        run_mock.assert_any_call([
+            sys.executable,
+            "installer.py",
+        ], cwd=str(tmp_path))
+
+
+def test_run_repair_uninstall_failure():
+    with patch("uninstaller.run_uninstaller", return_value=5):
+        assert repair.run_repair("repo-url") == 5


### PR DESCRIPTION
## Summary
- add new `repair.py` script to reinstall from a clean repo clone
- describe repair usage in README
- test repair logic with `test_repair.py`

## Testing
- `bash run-tests.sh` *(fails: `22 errors during collection`)*

------
https://chatgpt.com/codex/tasks/task_e_684a464d9b98832b8cc6455678a1caa3