### PR TITLE
Enhance logger utility

### DIFF
--- a/monkey_head/cli_print.py
+++ b/monkey_head/cli_print.py
@@ -4,29 +4,43 @@
 # GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
 # License:   https://opensource.org/license/gpl-3-0
 # Overseen By:   Dylan L.R. Pollock
-# Updated: 06.08.2025
+# Updated: 06.11.2025
 # ==================================================
+import logging
+from .utils.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+
 def print_message(message, message_type="info"):
-    """
-    Prints a message to the console with a specific format based on the message type.
+    """Print ``message`` to stdout and log it.
 
-    Args:
-        message (str): The message to print.
-        message_type (str): The type of message ('info', 'warning', 'error'). Default is 'info'.
+    Parameters
+    ----------
+    message:
+        Text to display.
+    message_type:
+        One of ``"info"``, ``"warning"``, or ``"error"``. Defaults to ``"info"``.
 
-    Raises:
-        ValueError: If the message_type is not one of 'info', 'warning', or 'error'.
+    Raises
+    ------
+    ValueError
+        If ``message_type`` is not recognised.
     """
-    if message_type == "info":
-        print(f"[INFO] {message}")
-    elif message_type == "warning":
-        print(f"[WARNING] {message}")
-    elif message_type == "error":
-        print(f"[ERROR] {message}")
-    else:
+
+    level_map = {
+        "info": "INFO",
+        "warning": "WARNING",
+        "error": "ERROR",
+    }
+    level_name = level_map.get(message_type)
+    if level_name is None:
         raise ValueError(
             f"Invalid message_type '{message_type}'. Expected 'info', 'warning', or 'error'."
         )
+    logger.log(getattr(logging, level_name), message)
+    print(f"[{level_name}] {message}")
 
 
 if __name__ == "__main__":

--- a/monkey_head/utils/logger.py
+++ b/monkey_head/utils/logger.py
@@ -3,7 +3,21 @@ import logging
 from ..logging_setup import configure_logging
 
 
-def get_logger(name: str | None = None) -> logging.Logger:
-    """Return a logger with the given name configured via project settings."""
-    configure_logging()
-    return logging.getLogger(name)
+def get_logger(name: str | None = None, level: str | None = None) -> logging.Logger:
+    """Return a logger configured via project settings.
+
+    Parameters
+    ----------
+    name:
+        The logger name. Defaults to the root logger when ``None``.
+    level:
+        Optional logging level name (e.g. ``"DEBUG"``). When provided the
+        returned logger's level will be updated accordingly.
+    """
+
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        configure_logging()
+    if level is not None:
+        logger.setLevel(getattr(logging, level.upper(), logging.INFO))
+    return logger


### PR DESCRIPTION
## Summary
- extend `get_logger` to accept an optional level
- log messages from `print_message`

## Testing
- `pytest tests/test_cli_print.py tests/test_logging_setup.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PyPDF2', ImportError: PyYAML is required to load configuration, FileNotFoundError: 'ffmpeg', NameError: 'subprocess' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684a58452b38832b879aad242dd708cb