### PR TITLE
Add final experimental warning

### DIFF
--- a/monkey_head/license_cli.py
+++ b/monkey_head/license_cli.py
@@ -52,6 +52,7 @@ def show_license_cli(config_path: str | Path = DEFAULT_CONFIG) -> None:
     response = prompt_response("Do you accept the license terms? [y/n]: ")
     if response == "yes":
         manager.set_setting("license.accepted", True)
+        print("WARNING: This is experimental software. Proceed with caution.")
     else:
         raise RuntimeError("License declined")
 

--- a/monkey_head/license_gui.py
+++ b/monkey_head/license_gui.py
@@ -52,6 +52,10 @@ def show_license_gui(config_path: str | Path = "config/pygpt_net/config.json") -
     def on_accept() -> None:
         accept_license(config_path)
         messagebox.showinfo("License", "License accepted")
+        messagebox.showwarning(
+            "Experimental",
+            "This is experimental software. Proceed with caution.",
+        )
         root.destroy()
 
     def on_decline() -> None:


### PR DESCRIPTION
## Summary
- warn users that Monkey Head Project is experimental after accepting the license
- print similar warning for CLI license acceptance

## Testing
- `pytest -q` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684a609c9be4832ba1cf3ae5a5d477f4