### PR TITLE
Add critical error GUI handler

### DIFF
--- a/monkey_head/logging_setup.py
+++ b/monkey_head/logging_setup.py
@@ -3,6 +3,33 @@ import logging.handlers
 import os
 from configparser import ConfigParser
 
+try:  # pragma: no cover - optional GUI dependency
+    import tkinter as tk
+    from tkinter import messagebox
+except Exception:  # pragma: no cover - can't import GUI libs
+    tk = None
+    messagebox = None
+
+
+class CriticalErrorHandler(logging.Handler):
+    """Display a GUI dialog for critical log records."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - GUI
+        if messagebox is None or tk is None:
+            return
+        if record.levelno >= logging.CRITICAL:
+            try:
+                root = tk.Tk()
+                root.withdraw()
+                messagebox.showerror("Critical Error", self.format(record))
+            except Exception:
+                pass
+            finally:
+                try:
+                    root.destroy()
+                except Exception:
+                    pass
+
 
 def configure_logging(config_path=None):
     """Configure root logger using settings from CONFIG.txt."""
@@ -41,7 +68,11 @@ def configure_logging(config_path=None):
     file_handler.setFormatter(formatter)
     stream_handler = logging.StreamHandler()
     stream_handler.setFormatter(formatter)
+    gui_handler = CriticalErrorHandler()
+    gui_handler.setLevel(logging.CRITICAL)
+    gui_handler.setFormatter(formatter)
 
     logger.addHandler(file_handler)
     logger.addHandler(stream_handler)
+    logger.addHandler(gui_handler)
     return logger

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -20,3 +20,46 @@ def test_configure_logging_creates_log(tmp_path):
     assert log_file.exists()
     assert any(isinstance(h, logging.FileHandler) for h in logger.handlers)
     assert "entry" in log_file.read_text()
+
+
+class DummyTk:
+    def withdraw(self):
+        pass
+
+    def destroy(self):
+        pass
+
+
+class DummyTkModule:
+    def __init__(self):
+        self.created = False
+
+    def Tk(self):
+        self.created = True
+        return DummyTk()
+
+
+def test_critical_error_triggers_gui(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.ini"
+    log_file = tmp_path / "app.log"
+    cfg.write_text(
+        "[logging]\nlog_level = INFO\nlog_file = {}\nlog_max_bytes = 1024\nlog_backup_count = 1\n".format(
+            log_file
+        )
+    )
+    root_logger = logging.getLogger()
+    for h in list(root_logger.handlers):
+        root_logger.removeHandler(h)
+
+    dummy_tk = DummyTkModule()
+    monkeypatch.setattr("monkey_head.logging_setup.tk", dummy_tk)
+    calls = []
+    monkeypatch.setattr(
+        "monkey_head.logging_setup.messagebox.showerror",
+        lambda title, message: calls.append((title, message)),
+    )
+
+    logger = configure_logging(str(cfg))
+    logger.critical("boom")
+    assert dummy_tk.created
+    assert calls and "boom" in calls[0][1]


### PR DESCRIPTION
## Summary
- show GUI dialogs for critical errors using Tkinter
- test that GUI handler triggers on critical log messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b09f0fd7c832b975820dbefcaaedb