### PR TITLE
Ensure MATE desktop for GenCore and SubOS

### DIFF
--- a/GenCore.sh
+++ b/GenCore.sh
@@ -14,7 +14,7 @@ set -e
 
 REPO_URL="https://github.com/DylanLRPollock/Monkey-Head-Project.git"
 INSTALL_DIR="/opt/monkey_head"
-DEFAULT_PACKAGES="git nodejs python3 python3-venv docker.io"
+DEFAULT_PACKAGES="git nodejs python3 python3-venv docker.io mate-desktop-environment-core"
 
 function ensure_root() {
     if [ "$EUID" -ne 0 ]; then

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A hierarchical adaptive OS divided into specialized layers:
 * **HostOS Environment:** Runs on either **Windows 10**, **Windows 11**, or **macOS Ventura** (or newer), providing a familiar desktop operating system for overall system control.
 * **SubOS Environment:** A **Debian Trixie** installation with **Python 3.12** preloaded, handling mid-level coordination and task scheduling.
 * **NanoOS Environment:** A lightweight **Python 3.12** runtime used for granular execution of hardware-level tasks.
+* **Desktop Environment:** Both GenCore and SubOS use the lightweight **MATE** desktop, providing a consistent interface across layers.
 
 #### GenCore Logic
 GenCore is a custom Debian **Trixie** distribution engineered to run bare metal on Huey. It boots directly on the robot's hardware and orchestrates containerised SubOS and NanoOS layers without an intermediary OS. Real-time patches and robotics drivers keep latency low, enabling deterministic control over sensors and actuators while maintaining the flexibility of modular containers.

--- a/monkey_head/subos_manager.py
+++ b/monkey_head/subos_manager.py
@@ -35,6 +35,7 @@ def install_tools() -> None:
         "virt-manager",
         "python3",
         "python3-venv",
+        "mate-desktop-environment-core",
     ]
     run_command(["apt-get", "install", "-y", *tools])
 

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -52,7 +52,7 @@ function update_system {
 
 
 # Default package list if MHP_SOFTWARE is set to "auto" or empty
-DEFAULT_PACKAGES="git build-essential g++ nodejs python3 python3-venv docker.io"
+DEFAULT_PACKAGES="git build-essential g++ nodejs python3 python3-venv docker.io mate-desktop-environment-core"
 
 function install_selected_packages {
     local packages="${MHP_SOFTWARE:-auto}"


### PR DESCRIPTION
## Summary
- install MATE desktop during GenCore setup
- add MATE desktop to Debian installer packages
- include MATE desktop in SubOS tool installation
- document MATE desktop in README

## Testing
- `bash run-tests.sh` *(fails: Virtual environment not found)*
- `pytest -q` *(fails: ModuleNotFoundError for distro, PIL, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684b0cb5c138832b9622255812a8e161