### PR TITLE
Add TensorFlow learning utility

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -24,6 +24,7 @@ from .media_conversion import (
     convert_video,
     convert_file,
 )
+from .chat_learning import train_from_chat_and_pdfs
 
 # Initialize project-wide logging as soon as the package is imported
 configure_logging()
@@ -38,4 +39,5 @@ __all__ = [
     "convert_audio",
     "convert_video",
     "convert_file",
+    "train_from_chat_and_pdfs",
 ]

--- a/monkey_head/chat_learning.py
+++ b/monkey_head/chat_learning.py
@@ -1,0 +1,84 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.11.2025
+# ==================================================
+"""Simple training utility using TensorFlow.
+
+The function :func:`train_from_chat_and_pdfs` builds a very small language
+model based on conversation history and the text extracted from one or more
+PDF files.  It is intentionally minimal and intended only for demonstration
+and testing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+import fitz  # PyMuPDF
+import tensorflow as tf
+
+
+def _read_pdf_text(pdf_path: str | Path) -> str:
+    doc = fitz.open(pdf_path)
+    text = "\n".join(page.get_text() for page in doc)
+    doc.close()
+    return text
+
+
+def _prepare_dataset(texts: Iterable[str]):
+    joined = " ".join(texts).lower()
+    tokenizer = tf.keras.preprocessing.text.Tokenizer()
+    tokenizer.fit_on_texts([joined])
+    seq = tokenizer.texts_to_sequences([joined])[0]
+    if len(seq) < 2:
+        raise ValueError("Not enough text for training")
+    xs = tf.constant(seq[:-1])
+    ys = tf.constant(seq[1:])
+    xs = tf.expand_dims(xs, axis=-1)
+    return xs, ys, tokenizer
+
+
+def train_from_chat_and_pdfs(
+    chat_history: List[str], pdf_files: List[str], epochs: int = 1
+) -> tf.keras.Model:
+    """Train a tiny model on chat history and PDFs.
+
+    Args:
+        chat_history: List of chat messages.
+        pdf_files: Paths to PDF files whose text will be used.
+        epochs: Training epochs (default 1).
+
+    Returns:
+        The trained :class:`tensorflow.keras.Model`.
+    """
+    pdf_texts = [_read_pdf_text(p) for p in pdf_files]
+    xs, ys, tokenizer = _prepare_dataset(list(chat_history) + pdf_texts)
+    vocab_size = len(tokenizer.word_index) + 1
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Embedding(vocab_size, 8, input_length=1),
+            tf.keras.layers.Flatten(),
+            tf.keras.layers.Dense(vocab_size, activation="softmax"),
+        ]
+    )
+    model.compile(optimizer="adam", loss="sparse_categorical_crossentropy")
+    model.fit(xs, ys, epochs=epochs, verbose=0)
+    return model
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Train from chat and PDFs")
+    parser.add_argument("pdf", nargs="+", help="PDF files to include")
+    parser.add_argument("--chat", nargs="*", default=[], help="Chat messages")
+    parser.add_argument("--epochs", type=int, default=1)
+    args = parser.parse_args()
+
+    model = train_from_chat_and_pdfs(args.chat, args.pdf, epochs=args.epochs)
+    print(model.summary())

--- a/requirements.txt
+++ b/requirements.txt
@@ -3490,3 +3490,4 @@ zipp==3.21.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4 \
     --hash=sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931
 pygpt-net>=0.1.0
+tensorflow==2.19.0

--- a/tests/test_chat_learning.py
+++ b/tests/test_chat_learning.py
@@ -1,0 +1,10 @@
+import tensorflow as tf
+from monkey_head.chat_learning import train_from_chat_and_pdfs
+
+
+def test_train_from_chat_and_pdfs(tmp_path):
+    chat = ["hello world", "goodbye world"]
+    pdf_file = "memory/PDF/Linux_on_PlayStation_3.pdf"
+    model = train_from_chat_and_pdfs(chat, [pdf_file], epochs=1)
+    assert isinstance(model, tf.keras.Model)
+


### PR DESCRIPTION
## Summary
- create a small TensorFlow training module `train_from_chat_and_pdfs`
- expose the training function in `monkey_head.__init__`
- update `requirements.txt` with TensorFlow
- add unit test for new training module

## Testing
- `pytest tests/test_chat_learning.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0d5d0f90832ba52422f2f58fc2fe