### PR TITLE
Add offline TTS provider

### DIFF
--- a/repo/pygpt-MHP/src/pygpt_net/app.py
+++ b/repo/pygpt-MHP/src/pygpt_net/app.py
@@ -104,6 +104,7 @@ from pygpt_net.provider.audio_output.openai_tts import OpenAITextToSpeech
 from pygpt_net.provider.audio_output.ms_azure_tts import MSAzureTextToSpeech
 from pygpt_net.provider.audio_output.google_tts import GoogleTextToSpeech
 from pygpt_net.provider.audio_output.eleven_labs import ElevenLabsTextToSpeech
+from pygpt_net.provider.audio_output.offline_tts import OfflineTextToSpeech
 
 # web search engine providers
 from pygpt_net.provider.web.google_custom_search import GoogleCustomSearch
@@ -248,6 +249,7 @@ def run(**kwargs):
     launcher.add_audio_output(MSAzureTextToSpeech())
     launcher.add_audio_output(GoogleTextToSpeech())
     launcher.add_audio_output(ElevenLabsTextToSpeech())
+    launcher.add_audio_output(OfflineTextToSpeech())
 
     # register custom audio providers
     providers = kwargs.get('audio_input', None)

--- a/repo/pygpt-MHP/src/pygpt_net/provider/audio_output/offline_tts.py
+++ b/repo/pygpt-MHP/src/pygpt_net/provider/audio_output/offline_tts.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ================================================== #
+# This file is a part of PYGPT package               #
+# Website: https://pygpt.net                         #
+# GitHub:  https://github.com/szczyglis-dev/py-gpt   #
+# MIT License                                        #
+# Created By  : Marcin Szczygliński                  #
+# Updated Date: 2025.02.25 00:00:00                  #
+# ================================================== #
+
+import os
+import pyttsx3
+
+from .base import BaseProvider
+
+
+class OfflineTextToSpeech(BaseProvider):
+    def __init__(self, *args, **kwargs):
+        """Offline Text to Speech provider"""
+        super(OfflineTextToSpeech, self).__init__(*args, **kwargs)
+        self.plugin = kwargs.get("plugin")
+        self.id = "offline_tts"
+        self.name = "Offline TTS"
+
+    def init_options(self):
+        """Initialize options (none required)"""
+        pass
+
+    def speech(self, text: str) -> str:
+        """Speech text to audio using pyttsx3"""
+        output_file = self.plugin.output_file
+        path = os.path.join(
+            self.plugin.window.core.config.path,
+            output_file,
+        )
+        engine = pyttsx3.init()
+        engine.save_to_file(text, path)
+        engine.runAndWait()
+        return path
+
+    def is_configured(self) -> bool:
+        """Check if provider is configured"""
+        try:
+            import pyttsx3  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    def get_config_message(self) -> str:
+        """Return message to display when provider is not configured"""
+        return "pyttsx3 is required for Offline TTS. Please install it."

--- a/requirements.txt
+++ b/requirements.txt
@@ -3491,3 +3491,5 @@ zipp==3.21.0 ; python_version >= "3.10" and python_version < "3.13" \
     --hash=sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931
 pygpt-net>=0.1.0
 tensorflow==2.19.0
+pyttsx3==2.98
+deepspeech==0.9.3

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ setup(
         "psutil==7.0.0",
         "platformdirs==4.3.8",
         "py-cpuinfo==9.0.0",
+        "pyttsx3==2.98",
+        "deepspeech==0.9.3",
         "PyQt6==6.9.1",  # Choose one: PyQt6 or PySide6
         "PySimpleGUI==5.0.8.3",
         "boto3==1.38.35",


### PR DESCRIPTION
## Summary
- add Offline TTS provider using `pyttsx3`
- register offline TTS in default app providers
- update dependencies with `pyttsx3` and `deepspeech`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_684b0e9c97a8832bbe9d30d81df13d96