### PR TITLE
Expand media conversion and GUI integration

### DIFF
--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -14,11 +14,18 @@ from pathlib import Path
 
 try:  # pragma: no cover - optional dependency
     import tkinter as tk
-    from tkinter import messagebox, scrolledtext, simpledialog, ttk
+    from tkinter import (
+        messagebox,
+        scrolledtext,
+        simpledialog,
+        filedialog,
+        ttk,
+    )
 except Exception:  # pragma: no cover - can't import GUI libs
     tk = None
     messagebox = None
     scrolledtext = None
+    filedialog = None
     ttk = None
 
 from monkey_head.license_gui import show_license_gui
@@ -36,6 +43,7 @@ from monkey_head.services.container_management import (
     scale_deployment,
     stop_containers,
 )
+from monkey_head.media_conversion import convert_media
 
 # Dark theme colors
 # Updated to use a black background with green text and
@@ -147,6 +155,7 @@ class MainUI:
         tools_menu = tk.Menu(menu_bar, tearoff=0, bg=DARK_BG, fg=LIGHT_FG)
         tools_menu.add_command(label="License", command=self.show_license)
         tools_menu.add_command(label="Data Summary", command=self.show_data_summary)
+        tools_menu.add_command(label="Convert Media", command=self.convert_media_prompt)
         menu_bar.add_cascade(label="Tools", menu=tools_menu)
 
         docker_menu = tk.Menu(menu_bar, tearoff=0, bg=DARK_BG, fg=LIGHT_FG)
@@ -399,6 +408,38 @@ class MainUI:
         self.status_label.config(text="Status: Logs")
         self.progress.start()
         threading.Thread(target=self._get_logs, args=(pod,)).start()
+
+    def convert_media_prompt(self):
+        if filedialog is None:
+            messagebox.showerror("Error", "Tkinter is not available")
+            return
+        src = filedialog.askopenfilename(title="Select source file")
+        if not src:
+            return
+        dst = filedialog.asksaveasfilename(title="Select output file")
+        if not dst:
+            return
+        bitrate = simpledialog.askstring(
+            "Audio Bitrate", "Bitrate", initialvalue="192k"
+        )
+        codec = simpledialog.askstring("Video Codec", "Codec", initialvalue="libx264")
+        self.log_message(f"Converting {src} -> {dst}...")
+        self.status_label.config(text="Status: Converting")
+        self.progress.start()
+        threading.Thread(
+            target=self._convert_media_thread,
+            args=(src, dst, bitrate, codec),
+        ).start()
+
+    def _convert_media_thread(self, src, dst, bitrate, codec):
+        try:
+            convert_media(src, dst, bitrate=bitrate, codec=codec)
+            self.log_message("Operation completed successfully.")
+        except Exception as exc:  # pragma: no cover - ffmpeg errors
+            self.log_message(f"Exception: {exc}")
+        finally:
+            self.progress.stop()
+            self.status_label.config(text="Status: Ready")
 
     def _get_logs(self, pod):
         try:

--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -24,8 +24,14 @@ from .media_conversion import (
     convert_video,
     convert_file,
 )
-from .chat_learning import train_from_chat_and_pdfs
-from .tensorflow_feed import train_from_project_sources
+import os
+
+if os.environ.get("MONKEY_HEAD_LIGHT_IMPORTS"):
+    train_from_chat_and_pdfs = None
+    train_from_project_sources = None
+else:
+    from .chat_learning import train_from_chat_and_pdfs
+    from .tensorflow_feed import train_from_project_sources
 
 # Initialize project-wide logging as soon as the package is imported
 configure_logging()

--- a/monkey_head/media_conversion.py
+++ b/monkey_head/media_conversion.py
@@ -18,6 +18,7 @@ __all__ = [
     "convert_audio",
     "convert_video",
     "convert_file",
+    "convert_media",
 ]
 
 
@@ -42,3 +43,37 @@ def convert_video(src: str, dst: str, codec: str = "libx264") -> None:
 def convert_file(src: str, dst: str) -> None:
     """Generic file conversion by copying to a new path."""
     shutil.copyfile(src, dst)
+
+
+AUDIO_EXTENSIONS = {".wav", ".mp3", ".flac", ".m4a", ".aac", ".ogg"}
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".flv"}
+
+
+def convert_media(
+    src: str,
+    dst: str,
+    *,
+    bitrate: str = "192k",
+    codec: str = "libx264",
+) -> None:
+    """Convert an audio or video file, falling back to copy.
+
+    Parameters
+    ----------
+    src : str
+        Path to the input file.
+    dst : str
+        Path to the output file.
+    bitrate : str, optional
+        Audio bitrate used for audio conversion.
+    codec : str, optional
+        Video codec used for video conversion.
+    """
+
+    ext = Path(src).suffix.lower()
+    if ext in AUDIO_EXTENSIONS:
+        convert_audio(src, dst, bitrate=bitrate)
+    elif ext in VIDEO_EXTENSIONS:
+        convert_video(src, dst, codec=codec)
+    else:
+        convert_file(src, dst)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -89,3 +89,29 @@ def test_scale_deployment_prompt_collects_input():
         )
         MainUI.scale_deployment_prompt(ui)
         runner.assert_called_once()
+
+
+def test_convert_media_prompt_runs_thread():
+    ui = MainUI.__new__(MainUI)
+    ui.status_label = SimpleNamespace(config=lambda **_: None)
+    ui.progress = SimpleNamespace(start=lambda: None, stop=lambda: None)
+    with patch("gui.main_ui.filedialog.askopenfilename", return_value="in.wav"), patch(
+        "gui.main_ui.filedialog.asksaveasfilename",
+        return_value="out.mp3",
+    ), patch(
+        "gui.main_ui.simpledialog.askstring",
+        side_effect=["128k", "libx264"],
+    ), patch(
+        "gui.main_ui.convert_media"
+    ) as conv, patch(
+        "gui.main_ui.threading.Thread"
+    ) as th, patch.object(
+        MainUI, "log_message"
+    ):
+        th.side_effect = lambda target, args: SimpleNamespace(
+            start=lambda: target(*args)
+        )
+        MainUI.convert_media_prompt(ui)
+        conv.assert_called_once_with(
+            "in.wav", "out.mp3", bitrate="128k", codec="libx264"
+        )

--- a/tests/test_media_conversion.py
+++ b/tests/test_media_conversion.py
@@ -10,7 +10,20 @@ from pathlib import Path
 import wave
 import subprocess
 
-from monkey_head.media_conversion import convert_audio, convert_video, convert_file
+import importlib.util
+from types import ModuleType
+
+spec = importlib.util.spec_from_file_location(
+    "media_conversion",
+    str(Path(__file__).resolve().parents[1] / "monkey_head" / "media_conversion.py"),
+)
+mc: ModuleType = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mc)
+convert_audio = mc.convert_audio
+convert_video = mc.convert_video
+convert_file = mc.convert_file
+convert_media = mc.convert_media
 
 
 def _make_wav(path: Path) -> None:
@@ -60,3 +73,27 @@ def test_convert_file(tmp_path: Path) -> None:
     src.write_text("hello")
     convert_file(str(src), str(dst))
     assert dst.read_text() == "hello"
+
+
+def test_convert_media_audio(tmp_path: Path) -> None:
+    src = tmp_path / "snd.wav"
+    dst = tmp_path / "snd.mp3"
+    _make_wav(src)
+    convert_media(str(src), str(dst))
+    assert dst.exists() and dst.stat().st_size > 0
+
+
+def test_convert_media_video(tmp_path: Path) -> None:
+    src = tmp_path / "vid.mp4"
+    dst = tmp_path / "vid.avi"
+    _make_video(src)
+    convert_media(str(src), str(dst))
+    assert dst.exists() and dst.stat().st_size > 0
+
+
+def test_convert_media_generic(tmp_path: Path) -> None:
+    src = tmp_path / "data.bin"
+    dst = tmp_path / "copy.bin"
+    src.write_text("x")
+    convert_media(str(src), str(dst))
+    assert dst.read_text() == "x"


### PR DESCRIPTION
## Summary
- add `convert_media` utility and expose it in `media_conversion`
- integrate media conversion options in the Tk GUI
- make heavy imports optional via `MONKEY_HEAD_LIGHT_IMPORTS`
- extend GUI and media conversion tests

## Testing
- `MONKEY_HEAD_LIGHT_IMPORTS=1 pytest tests/test_media_conversion.py tests/test_gui.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_684b16006a10832b91b26d35fa980aa8