### PR TITLE
Add headless minimal run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ application. The correct setup script is chosen automatically. A "Run" button
 lets you start the program without opening a terminal. If the GUI cannot be
 displayed (for example on a headless server), the launcher automatically falls
 back to the command-line interface. You can also force CLI mode with
-`python run.py --cli`.
+`python run.py --cli`. For an even lighter headless run you can launch the
+minimal echo chatbot with `python run.py --minimal`.
 
 The GUI now checks whether you've accepted the license on startup and
 offers a **Tools** menu. From there you can reopen the license dialog or

--- a/docs/headless_install.md
+++ b/docs/headless_install.md
@@ -12,5 +12,14 @@ the terms. If you enter anything other than `yes` or `no` it asks again
 until a valid response is received. Any errors during this process are
 logged to `app.log`.
 
+Once the license is accepted you can start a lightweight headless session
+with:
+
+```bash
+python run.py --minimal
+```
+
+This launches a very small echo chatbot without any GUI dependencies.
+
 Declining the license raises `RuntimeError` and leaves the configuration
 file unchanged.

--- a/run.py
+++ b/run.py
@@ -18,14 +18,25 @@
 # ================================================== #
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
-from monkey_head.core.system_checks import check_os_support, check_python_version
 
-sys.path.insert(0, str((Path(__file__).parent / "src").resolve()))
+def minimal_run() -> None:
+    """Run the lightweight CLI without GUI dependencies."""
+    os.environ["MONKEY_HEAD_LIGHT_IMPORTS"] = "1"
+    from monkey_head.pygpt_custom_cli import CustomPyGPT
 
-from pygpt_net.app import run as cli_run
+    CustomPyGPT().run_cli()
+
+
+def _load_cli() -> "callable":
+    """Import and return the standard CLI runner."""
+    sys.path.insert(0, str((Path(__file__).parent / "src").resolve()))
+    from pygpt_net.app import run as cli_run
+
+    return cli_run
 
 
 def launch_gui() -> None:
@@ -51,11 +62,23 @@ def main() -> None:
         help="Run in command-line mode instead of the GUI",
     )
     parser.add_argument(
+        "--minimal",
+        action="store_true",
+        help="Run lightweight CustomPyGPT CLI",
+    )
+    parser.add_argument(
         "--version",
         action="store_true",
         help="Print pygpt_net version and exit",
     )
     args = parser.parse_args()
+
+    if args.minimal:
+        minimal_run()
+        return
+
+    from monkey_head.core.system_checks import check_os_support, check_python_version
+    cli_run = _load_cli()
 
     # Warn if running on an unsupported operating system
     check_os_support()

--- a/tests/test_run_minimal.py
+++ b/tests/test_run_minimal.py
@@ -1,0 +1,13 @@
+import os
+from run import minimal_run
+from monkey_head.pygpt_custom_cli import CustomPyGPT
+
+
+def test_minimal_run(monkeypatch):
+    called = {}
+    def fake_run(self):
+        called['x'] = True
+    monkeypatch.setattr(CustomPyGPT, 'run_cli', fake_run)
+    minimal_run()
+    assert called.get('x') is True
+    assert os.environ.get('MONKEY_HEAD_LIGHT_IMPORTS') == '1'


### PR DESCRIPTION
## Summary
- support a minimal run mode in `run.py`
- document `--minimal` usage in README and headless install guide
- test the minimal run helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_684b19572740832b865eec7dbc8c36c4