### PR TITLE
Integrate simple chat GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ lets you start the program without opening a terminal. If the GUI cannot be
 displayed (for example on a headless server), the launcher automatically falls
 back to the command-line interface. You can also force CLI mode with
 `python run.py --cli`. For an even lighter headless run you can launch the
-minimal echo chatbot with `python run.py --minimal`.
+minimal echo chatbot with `python run.py --minimal`. A basic Tkinter chat demo
+is also available via `python run.py --simple-chat`.
 
 The GUI now checks whether you've accepted the license on startup and
 offers a **Tools** menu. From there you can reopen the license dialog or

--- a/docs/headless_install.md
+++ b/docs/headless_install.md
@@ -19,7 +19,12 @@ with:
 python run.py --minimal
 ```
 
-This launches a very small echo chatbot without any GUI dependencies.
+This launches a very small echo chatbot without any GUI dependencies. For a
+graphical demonstration you can instead run:
+
+```bash
+python run.py --simple-chat
+```
 
 Declining the license raises `RuntimeError` and leaves the configuration
 file unchanged.

--- a/monkey_head/simple_chat_gui.py
+++ b/monkey_head/simple_chat_gui.py
@@ -1,0 +1,71 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.12.2025
+# ==================================================
+"""Minimal Tkinter chat demonstration."""
+
+from __future__ import annotations
+
+import os
+
+try:  # pragma: no cover - optional dependency
+    import tkinter as tk
+    from tkinter import scrolledtext
+except Exception:  # pragma: no cover - can't import GUI libs
+    tk = None
+    scrolledtext = None
+
+from .gui_scaling import apply_scaling
+from .license_gui import DARK_BG, LIGHT_FG, ACCENT_PURPLE
+
+
+def get_answer(question: str) -> str:
+    """Return a canned response to ``question``."""
+    q = question.lower().strip()
+    if "capital of france" in q:
+        return "The capital of France is Paris."
+    if "2+2" in q or "two plus two" in q:
+        return "2 + 2 equals 4."
+    return "Sorry, I do not know the answer."
+
+
+def run_simple_chat() -> None:
+    """Launch a simple chat GUI using Tkinter."""
+    if tk is None or scrolledtext is None:
+        raise RuntimeError("tkinter is not available")
+
+    root = tk.Tk()
+    apply_scaling(root, os.environ.get("SCREEN_MODE", "1080p"))
+    root.configure(bg=DARK_BG)
+    root.title("Simple Chat Demo")
+
+    entry = tk.Entry(root, width=60, bg=DARK_BG, fg=LIGHT_FG, insertbackground=LIGHT_FG)
+    entry.pack(padx=10, pady=5)
+
+    chat_box = scrolledtext.ScrolledText(
+        root, width=70, height=15, bg=DARK_BG, fg=LIGHT_FG, state=tk.DISABLED
+    )
+    chat_box.pack(padx=10, pady=5)
+
+    def on_ask() -> None:
+        question = entry.get()
+        if not question:
+            return
+        answer = get_answer(question)
+        chat_box.config(state=tk.NORMAL)
+        chat_box.insert(tk.END, f"Q: {question}\n")
+        chat_box.insert(tk.END, f"A: {answer}\n\n")
+        chat_box.config(state=tk.DISABLED)
+        entry.delete(0, tk.END)
+
+    button = tk.Button(root, text="Ask", command=on_ask, bg=ACCENT_PURPLE, fg=LIGHT_FG)
+    button.pack(pady=5)
+
+    root.mainloop()
+
+
+__all__ = ["get_answer", "run_simple_chat"]

--- a/run.py
+++ b/run.py
@@ -67,6 +67,11 @@ def main() -> None:
         help="Run lightweight CustomPyGPT CLI",
     )
     parser.add_argument(
+        "--simple-chat",
+        action="store_true",
+        help="Run simple chat demonstration GUI",
+    )
+    parser.add_argument(
         "--version",
         action="store_true",
         help="Print pygpt_net version and exit",
@@ -75,6 +80,11 @@ def main() -> None:
 
     if args.minimal:
         minimal_run()
+        return
+    if args.simple_chat:
+        from monkey_head.simple_chat_gui import run_simple_chat
+
+        run_simple_chat()
         return
 
     from monkey_head.core.system_checks import check_os_support, check_python_version

--- a/tests/test_simple_chat_gui.py
+++ b/tests/test_simple_chat_gui.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+
+from monkey_head.simple_chat_gui import get_answer, run_simple_chat
+
+
+def test_get_answer_known():
+    assert get_answer("What is the capital of France?") == "The capital of France is Paris."
+
+
+def test_get_answer_unknown():
+    assert "Sorry" in get_answer("Who is John Galt?")
+
+
+def test_run_simple_chat(monkeypatch):
+    events = {}
+
+    class DummyRoot:
+        def configure(self, **kwargs):
+            pass
+
+        def title(self, t):
+            events["title"] = t
+
+        def mainloop(self):
+            events["ran"] = True
+
+    class DummyWidget:
+        def __init__(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            pass
+
+        def config(self, *a, **k):
+            pass
+
+        def insert(self, *a, **k):
+            pass
+
+        def delete(self, *a, **k):
+            pass
+
+        def get(self):
+            return ""
+
+    dummy_tk = SimpleNamespace(
+        Tk=lambda: DummyRoot(),
+        Entry=DummyWidget,
+        Button=lambda *a, **k: DummyWidget(),
+        NORMAL="normal",
+        DISABLED="disabled",
+        END="end",
+    )
+    dummy_scrolled = SimpleNamespace(ScrolledText=lambda *a, **k: DummyWidget())
+
+    monkeypatch.setattr("monkey_head.simple_chat_gui.tk", dummy_tk)
+    monkeypatch.setattr("monkey_head.simple_chat_gui.scrolledtext", dummy_scrolled)
+    monkeypatch.setattr("monkey_head.simple_chat_gui.apply_scaling", lambda *a, **k: events.update({"scaled": True}))
+
+    run_simple_chat()
+    assert events.get("ran") is True
+    assert events.get("scaled") is True


### PR DESCRIPTION
## Summary
- replace `mini-chat-gui.py` with new module `simple_chat_gui`
- support running the chat demo from `run.py` via `--simple-chat`
- document the new option in README and headless docs
- test the chat helper logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for tensorflow, distro, PIL, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684b30083b5c832b8f3876aff32f5c4b