### PR TITLE
Use PyGPT UI and add Monkey Manager tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,14 +186,14 @@ The GUI is now the primary way to install and control the project. Simply run:
 python run.py
 ```
 
-This launches a Tkinter window where you can install, update, or run the
-application. The correct setup script is chosen automatically. A "Run" button
-lets you start the program without opening a terminal. If the GUI cannot be
-displayed (for example on a headless server), the launcher automatically falls
+This opens the PyGPT-based Qt interface with integrated Monkey Head tools for
+installation, updates, running the application, and managing Docker or
+Kubernetes resources. If the GUI cannot be displayed (for example on a
+headless server), the launcher automatically falls
 back to the command-line interface. You can also force CLI mode with
 `python run.py --cli`. For an even lighter headless run you can launch the
 minimal echo chatbot with `python run.py --minimal`. A basic Tkinter chat demo
-is also available via `python run.py --simple-chat`.
+is still available via `python run.py --simple-chat`.
 
 The GUI now checks whether you've accepted the license on startup and
 offers a **Tools** menu. From there you can reopen the license dialog or
@@ -297,7 +297,8 @@ After selecting your hardware and any optional software packages, the script cal
 6. Displays the license agreement via a small Tkinter window.
 7. Preloads bundled data for faster first run.
 
-When installation finishes, change to the install directory and launch the GUI:
+When installation finishes, change to the install directory and launch the
+PyGPT interface:
 
 ```bash
 python run.py

--- a/monkey_head/pygpt_net/tools/manager/__init__.py
+++ b/monkey_head/pygpt_net/tools/manager/__init__.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+import platform
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+from PySide6.QtGui import QAction
+
+from pygpt_net.tools.base import BaseTool
+from pygpt_net.utils import trans
+
+from ...services import container_management
+
+
+class MonkeyManager(BaseTool):
+    """Expose Monkey Head management tasks in the PyGPT UI."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.id = "monkey_manager"
+        self.install_path: Path | None = None
+        self.update_path: Path | None = None
+        self.run_path: Path | None = None
+        self._setup_paths()
+
+    def _setup_paths(self) -> None:
+        root = Path(__file__).resolve().parents[4]
+        setup_dir = root / "setup"
+        system = platform.system()
+        if system == "Linux":
+            self.install_path = setup_dir / "Debian13" / "install.sh"
+            self.update_path = setup_dir / "Debian13" / "update.sh"
+            self.run_path = root / "run.sh"
+        elif system == "Darwin":
+            self.install_path = setup_dir / "macOS" / "install.sh"
+            self.update_path = setup_dir / "Debian13" / "update.sh"
+            self.run_path = root / "run.sh"
+        elif system == "Windows":
+            self.install_path = setup_dir / "Windows11" / "01-FULL.bat"
+            self.update_path = setup_dir / "Windows11" / "01-FULL.bat"
+            self.run_path = root / "run.bat"
+
+    def _run_script(self, script: Path | None) -> None:
+        if script is None or not script.exists():
+            print(f"Script not found: {script}")
+            return
+        try:
+            if script.suffix == ".bat":
+                cmd = ["cmd", "/c", str(script)]
+            else:
+                cmd = ["bash", str(script)]
+            subprocess.run(cmd, check=False)
+        except Exception as exc:  # pragma: no cover - subprocess failures
+            print(f"Error running {script}: {exc}")
+
+    def install(self) -> None:
+        self._run_script(self.install_path)
+
+    def update(self) -> None:
+        self._run_script(self.update_path)
+
+    def run_app(self) -> None:
+        self._run_script(self.run_path)
+
+    def setup_menu(self) -> Dict[str, QAction]:
+        actions: Dict[str, QAction] = {}
+        actions["monkey.install"] = QAction(trans("Monkey Install"), self.window)
+        actions["monkey.install"].triggered.connect(self.install)
+
+        actions["monkey.run"] = QAction(trans("Monkey Run"), self.window)
+        actions["monkey.run"].triggered.connect(self.run_app)
+
+        actions["monkey.update"] = QAction(trans("Monkey Update"), self.window)
+        actions["monkey.update"].triggered.connect(self.update)
+
+        actions["monkey.docker.build"] = QAction(trans("Build Docker Image"), self.window)
+        actions["monkey.docker.build"].triggered.connect(container_management.build_docker_image)
+
+        actions["monkey.docker.start"] = QAction(trans("Start Containers"), self.window)
+        actions["monkey.docker.start"].triggered.connect(container_management.manage_containers)
+
+        actions["monkey.docker.stop"] = QAction(trans("Stop Containers"), self.window)
+        actions["monkey.docker.stop"].triggered.connect(container_management.stop_containers)
+
+        actions["monkey.docker.clean"] = QAction(trans("Cleanup Images"), self.window)
+        actions["monkey.docker.clean"].triggered.connect(container_management.cleanup_images)
+
+        actions["monkey.docker.volumes"] = QAction(trans("Manage Volumes"), self.window)
+        actions["monkey.docker.volumes"].triggered.connect(container_management.manage_volumes)
+
+        actions["monkey.docker.networks"] = QAction(trans("Manage Networks"), self.window)
+        actions["monkey.docker.networks"].triggered.connect(container_management.manage_networks)
+
+        actions["monkey.k8s.deploy"] = QAction(trans("Deploy Kubernetes"), self.window)
+        actions["monkey.k8s.deploy"].triggered.connect(container_management.deploy_kubernetes)
+
+        actions["monkey.k8s.cleanup"] = QAction(trans("Cleanup Kubernetes"), self.window)
+        actions["monkey.k8s.cleanup"].triggered.connect(container_management.cleanup_kubernetes)
+
+        actions["monkey.k8s.scale"] = QAction(trans("Scale Deployment"), self.window)
+        actions["monkey.k8s.scale"].triggered.connect(
+            lambda: container_management.scale_deployment("deployment", 1)
+        )
+
+        return actions
+

--- a/run.py
+++ b/run.py
@@ -40,16 +40,11 @@ def _load_cli() -> "callable":
 
 
 def launch_gui() -> None:
-    """Start the Tkinter GUI."""
-    try:
-        import tkinter as tk
-        from gui.main_ui import MainUI
-    except Exception as exc:
-        raise RuntimeError(f"Unable to load GUI modules: {exc}") from exc
+    """Start the PyGPT GUI with Monkey Head extensions."""
+    from pygpt_net.app import run as pygpt_run
+    from monkey_head.pygpt_net.tools.manager import MonkeyManager
 
-    root = tk.Tk()
-    app = MainUI(root)
-    root.mainloop()
+    pygpt_run(tools=[MonkeyManager()])
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- switch `run.py` to start the PyGPT Qt GUI
- expose install, update and container management commands via new `MonkeyManager` tool
- document new PyGPT interface in README

## Testing
- `pytest -q` *(fails: tensorflow & PIL not installed)*
- `flake8` *(fails: numerous style issues)*


------
https://chatgpt.com/codex/tasks/task_e_684b3e902120832b8bd75c64b4336630