### PR TITLE
Expand Docker diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ Python interface for scaling deployments, retrieving pod logs, and cleaning up
 resources.
 
 Additional helpers now include `build_docker_image`, `stop_containers`,
-`cleanup_images`, and `manage_networks` for end-to-end Docker lifecycle
-management.
+`cleanup_images`, `manage_networks`, `list_containers`, and `get_container_logs`
+for end-to-end Docker lifecycle management and diagnostics.
 
 ### Linux (Debian 13) Installation
 

--- a/monkey_head/services/container_management.py
+++ b/monkey_head/services/container_management.py
@@ -158,3 +158,25 @@ def manage_networks() -> None:
         stderr=subprocess.PIPE,
     )
     check_error(prune_networks, "Prune Docker Networks")
+
+
+def list_containers() -> str:
+    """Return a list of running Docker containers."""
+    logger.info("Listing running containers...")
+    list_containers_cmd = subprocess.run(
+        ["docker", "ps"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    check_error(list_containers_cmd, "List Docker Containers")
+    return list_containers_cmd.stdout.decode()
+
+
+def get_container_logs(container_name: str) -> str:
+    """Return logs for the specified Docker container."""
+    logger.info("Fetching logs for container %s...", container_name)
+    logs = subprocess.run(
+        ["docker", "logs", container_name],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    check_error(logs, "Get Container Logs")
+    return logs.stdout.decode()

--- a/tests/test_container_management_new.py
+++ b/tests/test_container_management_new.py
@@ -8,6 +8,8 @@ from monkey_head.services.container_management import (
     stop_containers,
     cleanup_images,
     manage_networks,
+    list_containers,
+    get_container_logs,
 )
 
 
@@ -54,3 +56,15 @@ def test_cleanup_images():
 def test_manage_networks():
     with patch("subprocess.run", return_value=DummyCompleted()):
         manage_networks()
+
+
+def test_list_containers():
+    with patch("subprocess.run", return_value=DummyCompleted(stdout=b"list")):
+        output = list_containers()
+        assert output == "list"
+
+
+def test_get_container_logs():
+    with patch("subprocess.run", return_value=DummyCompleted(stdout=b"logs")):
+        logs = get_container_logs("monkey-head")
+        assert logs == "logs"


### PR DESCRIPTION
## Summary
- extend container_management with `list_containers` and `get_container_logs`
- document the new helpers in README
- expand unit tests for Docker management

## Testing
- `MONKEY_HEAD_LIGHT_IMPORTS=1 pytest tests/test_container_management_new.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684c73b3f660832ba516a898a04a973c