### PR TITLE
Improve Kubernetes config

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ Programmatic helpers for Kubernetes lives in
 Python interface for scaling deployments, retrieving pod logs, and cleaning up
 resources.
 
+Kubernetes manifests are stored in the `k8s/` directory. Both the helper
+scripts and the GUI use `k8s/deployment.yaml` by default, so update that file
+to configure your cluster.
+
 Additional helpers now include `build_docker_image`, `stop_containers`,
 `cleanup_images`, and `manage_networks` for end-to-end Docker lifecycle
 management.

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: monkey-head
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: monkey-head
@@ -16,8 +16,23 @@ spec:
       containers:
       - name: monkey-head
         image: monkey-head-project:latest
+        env:
+        - name: APP_ENV
+          value: "production"
         ports:
         - containerPort: 8000
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 20
 ---
 apiVersion: v1
 kind: Service
@@ -30,3 +45,4 @@ spec:
   - port: 8000
     targetPort: 8000
   type: ClusterIP
+

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: monkey-head
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: monkey-head
@@ -16,8 +16,23 @@ spec:
       containers:
       - name: monkey-head
         image: monkey-head-project:latest
+        env:
+        - name: APP_ENV
+          value: "production"
         ports:
         - containerPort: 8000
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8000
+          initialDelaySeconds: 15
+          periodSeconds: 20
 ---
 apiVersion: v1
 kind: Service
@@ -30,3 +45,4 @@ spec:
   - port: 8000
     targetPort: 8000
   type: ClusterIP
+

--- a/monkey_head/services/container_management.py
+++ b/monkey_head/services/container_management.py
@@ -44,11 +44,15 @@ def manage_volumes():
     check_error(prune_volumes, "Prune Docker Volumes")
 
 
-def deploy_kubernetes():
+K8S_MANIFEST = "k8s/deployment.yaml"
+
+
+def deploy_kubernetes() -> None:
+    """Apply the project's Kubernetes manifests."""
     logger.info("Deploying with Kubernetes...")
     os.chdir(os.path.expanduser("~/Source/repo"))
     deploy = subprocess.run(
-        ["kubectl", "apply", "-f", "deployment.yaml"],
+        ["kubectl", "apply", "-f", K8S_MANIFEST],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
@@ -73,7 +77,7 @@ def kubernetes_management():
     check_error(get_services, "Get Kubernetes Services")
 
 
-def cleanup_kubernetes(manifest: str = "deployment.yaml") -> None:
+def cleanup_kubernetes(manifest: str = K8S_MANIFEST) -> None:
     """Delete resources defined in the given manifest."""
     logger.info("Cleaning up Kubernetes resources...")
     os.chdir(os.path.expanduser("~/Source/repo"))

--- a/tests/test_container_management_new.py
+++ b/tests/test_container_management_new.py
@@ -32,7 +32,7 @@ def test_get_pod_logs():
 def test_cleanup_kubernetes():
     with patch("subprocess.run", return_value=DummyCompleted()):
         with patch("os.chdir"):
-            cleanup_kubernetes("deployment.yaml")
+            cleanup_kubernetes("k8s/deployment.yaml")
 
 
 def test_build_docker_image():


### PR DESCRIPTION
## Summary
- expand Kubernetes deployment with healthchecks and replicas
- point container management scripts to manifests in `k8s/`
- update docs about the new manifest location
- adjust test path for Kubernetes cleanup

## Testing
- `pip install Pillow`
- `pip install PyMuPDF`
- `pip install distro`
- `pytest -q tests/test_container_management_new.py tests/test_run_minimal.py`

------
https://chatgpt.com/codex/tasks/task_e_684c73e3aae0832ba1cc0ec55dbab07c