### PR TITLE
Add data analysis utilities with new libraries

### DIFF
--- a/monkey_head/ai_processor.py
+++ b/monkey_head/ai_processor.py
@@ -6,6 +6,16 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.08.2025
 # ==================================================
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from sklearn.linear_model import LinearRegression
+import seaborn as sns
+import requests
+
+
 class AIProcessor:
     """Simple processor used in examples and unit tests."""
 
@@ -29,3 +39,38 @@ class AIProcessor:
 
         analysis_result = {"length": len(data)}
         return analysis_result
+
+    def compute_mean(self, numbers: list[float]) -> float:
+        """Return the arithmetic mean of ``numbers`` using NumPy."""
+
+        array = np.array(numbers, dtype=float)
+        return float(np.mean(array))
+
+    def dataframe_summary(self, data: list[dict]) -> pd.DataFrame:
+        """Convert ``data`` to a DataFrame and return ``describe()`` result."""
+
+        df = pd.DataFrame(data)
+        return df.describe()
+
+    def train_linear_model(self, X: list[list[float]], y: list[float]) -> tuple:
+        """Fit a simple linear regression model and return coefficients."""
+
+        model = LinearRegression().fit(X, y)
+        return (float(model.coef_[0]), float(model.intercept_))
+
+    def plot_histogram(self, data: list[float], filename: str) -> str:
+        """Plot ``data`` as a histogram using seaborn and save to ``filename``."""
+
+        sns.histplot(data, kde=True)
+        plt.tight_layout()
+        plt.savefig(filename)
+        plt.close()
+        return filename
+
+    def fetch_todo_title(self, todo_id: int) -> str:
+        """Fetch a sample TODO item and return its title."""
+
+        url = f"https://jsonplaceholder.typicode.com/todos/{todo_id}"
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        return response.json()["title"]

--- a/tests/test_misc_modules.py
+++ b/tests/test_misc_modules.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+from pathlib import Path
 
 
 from monkey_head.ai_processor import AIProcessor
@@ -17,6 +18,33 @@ def test_ai_processor():
     proc = AIProcessor()
     assert proc.process_data("abc") == "ABC"
     assert proc.analyze_data("123")["length"] == 3
+
+    assert proc.compute_mean([1, 2, 3]) == 2.0
+
+    summary = proc.dataframe_summary([
+        {"a": 1, "b": 2},
+        {"a": 3, "b": 4},
+    ])
+    assert summary.loc["mean", "a"] == 2.0
+
+    coef, intercept = proc.train_linear_model([[0], [1]], [0, 1])
+    assert round(coef, 5) == 1.0 and round(intercept, 5) == 0.0
+
+    plot = proc.plot_histogram([1, 2, 3], str(tmp_path / "plot.png"))
+    assert Path(plot).is_file()
+
+    class DummyResp:
+        def __init__(self):
+            self.status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"title": "foo"}
+
+    with patch("requests.get", return_value=DummyResp()):
+        assert proc.fetch_todo_title(1) == "foo"
 
 
 def test_process_and_check_core_data():


### PR DESCRIPTION
## Summary
- integrate numpy, pandas, matplotlib, scikit-learn, seaborn, and requests in `AIProcessor`
- extend `test_misc_modules` to exercise new analysis features

## Testing
- `pytest tests/test_misc_modules.py::test_ai_processor -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_684c73cf7470832bac20e440e9690dd8