### PR TITLE
Use pypdf for PDF processing

### DIFF
--- a/monkey_head/convert_pdf_to_text.py
+++ b/monkey_head/convert_pdf_to_text.py
@@ -7,7 +7,7 @@
 # Updated: 06.08.2025
 # ==================================================
 import os
-from PyPDF2 import PdfReader
+from pypdf import PdfReader
 
 
 def convert_pdf_to_text(pdf_file, output_file):

--- a/monkey_head/scripts/convert_pdf_to_text.py
+++ b/monkey_head/scripts/convert_pdf_to_text.py
@@ -7,7 +7,7 @@
 # Updated: 06.09.2025
 # ==================================================
 import os
-import PyPDF2
+from pypdf import PdfReader
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from ..logging_setup import configure_logging
@@ -20,7 +20,7 @@ configure_logging()
 def convert_pdf_to_text(path):
     try:
         with open(path, "rb") as file:
-            reader = PyPDF2.PdfReader(file)
+            reader = PdfReader(file)
             text = ""
             for page in reader.pages:
                 extracted = page.extract_text()

--- a/repo/pygpt-MHP/src/pygpt_net/core/attachments/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/attachments/__init__.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 from typing import Optional, List, Dict
 
-import PyPDF2
+from pypdf import PdfReader
 
 from packaging.version import Version
 
@@ -519,7 +519,7 @@ class Attachments:
             if not txt_path.exists():
                 try:
                     with open(abs_path, "rb") as f:
-                        reader = PyPDF2.PdfReader(f)
+                        reader = PdfReader(f)
                         text = ""
                         for page in reader.pages:
                             extracted = page.extract_text()

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "google-auth==2.40.3",
         "elasticsearch==9.0.2",
         "pyyaml==6.0.2",
+        "pypdf>=5.1.0,<6.0.0",
         "pygpt-net>=0.1.0",
     ],
     extras_require={


### PR DESCRIPTION
## Summary
- use `pypdf` instead of `PyPDF2` for PDF reading
- add `pypdf` runtime dependency

## Testing
- `pytest tests/test_convert_pdf_to_text.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow', 'PIL', ...)*

------
https://chatgpt.com/codex/tasks/task_e_684c780992e0832bab89dcc059ba6db9