### PR TITLE
Ensure pip is upgraded with Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ cd Monkey-Head-Project
 python3 -m venv venv
 source venv/bin/activate  # Linux/macOS
 venv\Scripts\activate     # Windows
+python -m pip install --upgrade pip
 pip install -r requirements.txt
 git submodule update --init --recursive
 pip install -e repo/pygpt-MHP

--- a/docs/README.md
+++ b/docs/README.md
@@ -199,7 +199,7 @@ Operating System: Supports **Windows 10**, **Windows 11**, or **macOS Ventura** 
 
 ### Software Requirements
 
-- Python 3.12+ with `pip`
+ - Python 3.12+ with `pip` (run `python -m pip install --upgrade pip` after creating your virtual environment)
 - Git
 - Docker and Docker Compose
 - Kubernetes (`kubectl` CLI)

--- a/monkey_head/services/environment_setup.py
+++ b/monkey_head/services/environment_setup.py
@@ -36,6 +36,13 @@ def setup_python_env(dest: str = "~/Source/repo") -> None:
         run_command(["python3", "-m", "venv", venv_path])
 
     pip_path = os.path.join(venv_path, "bin", "pip")
+    # Ensure the newest pip version compatible with Python 3.12 is installed
+    run_command([
+        pip_path,
+        "install",
+        "--upgrade",
+        "pip",
+    ], cwd=repo_path)
     run_command(
         [pip_path, "install", "-r", "requirements.txt"],
         cwd=repo_path,


### PR DESCRIPTION
## Summary
- upgrade pip inside `environment_setup.py`
- update README manual install steps to upgrade pip
- mention pip upgrade in docs

## Testing
- `bash run-tests.sh` *(fails: Virtual environment not found)*
- `pytest -q` *(fails: multiple ModuleNotFoundError errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c7856fa80832b816c9b2ac592ef57