### PR TITLE
Add selectable Debian release

### DIFF
--- a/GenCore.sh
+++ b/GenCore.sh
@@ -24,8 +24,9 @@ function ensure_root() {
 }
 
 function update_system() {
-    echo "Updating system to Debian Trixie..."
-    python3 "$(dirname "$0")/scripts/update_sources_to_trixie.py" || true
+    local codename="${DEBIAN_CODENAME:-trixie}"
+    echo "Updating system to Debian ${codename}..."
+    python3 "$(dirname "$0")/scripts/update_sources_to_trixie.py" "$codename" || true
     apt-get update -y
     apt-get upgrade -y
 }

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A hierarchical adaptive OS divided into specialized layers:
 * **SubOS:** Operational resource allocation, task management, and dynamic adaptability, inspired by biological resilience and technological redundancy.
 * **NanoOS:** Real-time precision control at the hardware interaction level, optimizing immediate responsiveness and reliability.
 * **HostOS Environment:** Runs on either **Windows 10**, **Windows 11**, or **macOS Ventura** (or newer), providing a familiar desktop operating system for overall system control.
-* **SubOS Environment:** A **Debian Trixie** installation with **Python 3.12** preloaded, handling mid-level coordination and task scheduling.
+* **SubOS Environment:** A **Debian Trixie** (or **Testing**) installation with **Python 3.12** preloaded, handling mid-level coordination and task scheduling.
 * **NanoOS Environment:** A lightweight **Python 3.12** runtime used for granular execution of hardware-level tasks.
 * **Desktop Environment:** Both GenCore and SubOS use the lightweight **MATE** desktop, providing a consistent interface across layers.
 
@@ -281,7 +281,7 @@ Next you'll choose the software profile. Selecting **auto** installs all default
 packages, while **manual** lets you pick specific packages and programs to
 install.
 
-This invokes `setup/Debian13/install.sh`, which updates `/etc/apt/sources.list` to Debian **Trixie**, installs Git, Node.js, Python 3, and Docker, then creates a virtual environment and preloads bundled data. Accept the license agreement when prompted. The project files are copied to `/opt/monkey_head`.
+This invokes `setup/Debian13/install.sh`, which updates `/etc/apt/sources.list` to the chosen release (either **Trixie** or **Testing**), installs Git, Node.js, Python 3, and Docker, then creates a virtual environment and preloads bundled data. Accept the license agreement when prompted. The project files are copied to `/opt/monkey_head`.
 
 
 ### macOS Installation

--- a/docker/HostOS/HostOS.py
+++ b/docker/HostOS/HostOS.py
@@ -28,8 +28,9 @@ def system_check():
     logger.info("Performing system checks for HostOS...")
     # Check for Debian version
     with open("/etc/os-release") as f:
-        if "Debian GNU/Linux 13" not in f.read():
-            error_message = "Debian Trixie Check failed"
+        content = f.read().lower()
+        if "debian" not in content or not any(x in content for x in ("trixie", "testing")):
+            error_message = "Debian Trixie/Testing Check failed"
             logger.error(error_message)
             raise RuntimeError(error_message)
 

--- a/docker/NanoOS/NanoOS.py
+++ b/docker/NanoOS/NanoOS.py
@@ -28,8 +28,9 @@ def system_check():
     logger.info("Performing system checks for NanoOS...")
     # Check for Debian version
     with open("/etc/os-release") as f:
-        if "Debian GNU/Linux 13" not in f.read():
-            error_message = "Debian Trixie Check failed"
+        content = f.read().lower()
+        if "debian" not in content or not any(x in content for x in ("trixie", "testing")):
+            error_message = "Debian Trixie/Testing Check failed"
             logger.error(error_message)
             raise RuntimeError(error_message)
 

--- a/docker/SubOS/Dockerfile
+++ b/docker/SubOS/Dockerfile
@@ -1,5 +1,6 @@
-# Use Debian Trixie slim as the base image for a lightweight container
-FROM debian:trixie-slim
+# Use Debian slim base image; release can be overridden at build time
+ARG DEBIAN_RELEASE=trixie
+FROM debian:${DEBIAN_RELEASE}-slim
 
 # Define maintainer or author of the Dockerfile
 LABEL maintainer="admin@subos.com"

--- a/docker/SubOS/SubOS.py
+++ b/docker/SubOS/SubOS.py
@@ -28,8 +28,9 @@ def system_check():
     logger.info("Performing system checks for SubOS...")
     # Check for Debian version
     with open("/etc/os-release") as f:
-        if "Debian GNU/Linux 13" not in f.read():
-            error_message = "Debian Trixie Check failed"
+        content = f.read().lower()
+        if "debian" not in content or not any(x in content for x in ("trixie", "testing")):
+            error_message = "Debian Trixie/Testing Check failed"
             logger.error(error_message)
             raise RuntimeError(error_message)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -215,7 +215,7 @@ Allocate Resources: Dedicate full processor capabilities to HostOS for optimal p
 
 Virtual Environment Setups
 
-SubOS: A **Debian Trixie** environment with **Python 3.12** preinstalled. Requires 128GB storage and 8GB RAM per instance, suitable for running isolated, specialized tasks alongside the primary AIOS environment.
+SubOS: A **Debian Trixie** or **Testing** environment with **Python 3.12** preinstalled. Requires 128GB storage and 8GB RAM per instance, suitable for running isolated, specialized tasks alongside the primary AIOS environment.
 
 NanoOS: A lightweight **Python 3.12** environment used for granular hardware interaction. It can run in Docker containers or Python virtual environments, allocating fractional core processing power for minimal overhead.
 

--- a/monkey_head/core/system_checks.py
+++ b/monkey_head/core/system_checks.py
@@ -96,8 +96,9 @@ def system_check():
     logger.info("Performing system checks...")
     # Check for Debian version
     with open("/etc/os-release") as f:
-        if "Debian GNU/Linux 13" not in f.read():
-            error_message = "Debian Trixie Check failed"
+        content = f.read().lower()
+        if "debian" not in content or not any(x in content for x in ("trixie", "testing")):
+            error_message = "Debian Trixie/Testing Check failed"
             log_error(error_message)
             raise RuntimeError(error_message)
 

--- a/scripts/update_sources_to_trixie.py
+++ b/scripts/update_sources_to_trixie.py
@@ -7,7 +7,12 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated:   06.09.2025
 # ==================================================
-"""Utility to update /etc/apt/sources.list to Debian Trixie."""
+"""Utility to update /etc/apt/sources.list to a specified Debian release.
+
+By default the script switches all repository entries to ``trixie`` but a
+different release codename (e.g. ``testing``) may be supplied as the first
+command line argument.
+"""
 
 import os
 import re
@@ -17,24 +22,26 @@ import sys
 SOURCE_FILE = "/etc/apt/sources.list"
 BACKUP_FILE = SOURCE_FILE + ".bak"
 
+DEFAULT_RELEASE = "trixie"
+
 APT_LINE_RE = re.compile(r"^(\s*deb(?:-src)?(?:\s+\[.*?\])?\s+\S+\s+)(\S+)(.*)$")
 
 
-def convert_line(line: str) -> str:
-    """Replace the distribution name in a sources.list line with 'trixie'."""
+def convert_line(line: str, release: str) -> str:
+    """Replace the distribution name in a sources.list line with ``release``."""
     if line.lstrip().startswith("#"):
         return line
     m = APT_LINE_RE.match(line)
     if not m:
         return line
     prefix, dist, rest = m.groups()
-    if dist.startswith("trixie"):
+    if dist.startswith(release):
         return line
     if "-" in dist:
         _, suffix = dist.split("-", 1)
-        new_dist = f"trixie-{suffix}"
+        new_dist = f"{release}-{suffix}"
     else:
-        new_dist = "trixie"
+        new_dist = release
     return f"{prefix}{new_dist}{rest}"
 
 
@@ -50,13 +57,15 @@ def main() -> None:
     print(f"Creating backup: {BACKUP_FILE}")
     shutil.copyfile(SOURCE_FILE, BACKUP_FILE)
 
+    release = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_RELEASE
+
     with open(SOURCE_FILE, "r", encoding="utf-8") as fh:
-        lines = [convert_line(line) for line in fh]
+        lines = [convert_line(line, release) for line in fh]
 
     with open(SOURCE_FILE, "w", encoding="utf-8") as fh:
         fh.writelines(lines)
 
-    print("sources.list updated to Trixie")
+    print(f"sources.list updated to {release}")
 
 
 if __name__ == "__main__":

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -42,9 +42,18 @@ function copy_project_files {
     fi
 }
 
+DEBIAN_CODENAME=${DEBIAN_CODENAME:-trixie}
+
+function prompt_debian_codename {
+    read -rp "Select Debian release for SubOS (trixie/testing) [${DEBIAN_CODENAME}]: " input
+    if [[ $input =~ ^(trixie|testing)$ ]]; then
+        DEBIAN_CODENAME=$input
+    fi
+}
+
 function update_system {
-    echo "Updating apt sources to Debian Trixie..."
-    python3 "$PROJECT_ROOT/scripts/update_sources_to_trixie.py" || error_exit "Failed to update sources list."
+    echo "Updating apt sources to Debian ${DEBIAN_CODENAME}..."
+    python3 "$PROJECT_ROOT/scripts/update_sources_to_trixie.py" "$DEBIAN_CODENAME" || error_exit "Failed to update sources list."
     echo "Updating system..."
     apt-get update -y || error_exit "apt-get update failed."
     apt-get upgrade -y || error_exit "apt-get upgrade failed."
@@ -88,6 +97,7 @@ function update_submodules {
 }
 
 ensure_root
+prompt_debian_codename
 copy_project_files
 update_system
 install_selected_packages


### PR DESCRIPTION
## Summary
- allow `update_sources_to_trixie.py` to accept a release argument
- prompt for trixie/testing in Debian installer
- make Docker SubOS base image configurable
- relax OS checks to allow trixie or testing
- document that SubOS can run on Debian Trixie or Testing

## Testing
- `bash run-tests.sh` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c81185814832badf95c1de5f563e7