### PR TITLE
Improve GUI startup

### DIFF
--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -7,10 +7,17 @@
 # Updated: 06.11.2025
 # ==================================================
 import os
+
+os.environ.setdefault("MONKEY_HEAD_LIGHT_IMPORTS", "1")
 import platform
 import subprocess
 import threading
 from pathlib import Path
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 try:  # pragma: no cover - optional dependency
     import tkinter as tk

--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -21,7 +21,11 @@ if not os.environ.get("MONKEY_HEAD_LIGHT_IMPORTS"):
 else:
     subos_manager = None
 from .utils.logger import get_logger
-from .convert_png_to_jpeg import convert_png_to_jpeg
+
+try:
+    from .convert_png_to_jpeg import convert_png_to_jpeg
+except Exception:  # pragma: no cover - optional dependency
+    convert_png_to_jpeg = None
 
 try:
     from .pdf_pre_digestion import pdf_pre_digestion

--- a/monkey_head/core/system_checks.py
+++ b/monkey_head/core/system_checks.py
@@ -12,7 +12,10 @@ import platform
 import subprocess
 import sys
 
-import distro
+try:
+    import distro
+except Exception:  # pragma: no cover - optional dependency
+    distro = None
 from ..logging_setup import configure_logging
 
 configure_logging()
@@ -65,15 +68,18 @@ def check_os_support() -> None:
                 ver_str,
             )
     elif system == "Linux":
-        if distro.id() != "debian" or distro.codename().lower() not in {
-            "trixie",
-            "testing",
-        }:
-            logger.warning(
-                "Unsupported Linux distribution detected (%s %s). Debian Trixie/testing is required.",
-                distro.id(),
-                distro.codename(),
-            )
+        if distro is None:
+            logger.warning("distro module not available; skipping distribution check")
+        else:
+            if distro.id() != "debian" or distro.codename().lower() not in {
+                "trixie",
+                "testing",
+            }:
+                logger.warning(
+                    "Unsupported Linux distribution detected (%s %s). Debian Trixie/testing is required.",
+                    distro.id(),
+                    distro.codename(),
+                )
     else:
         logger.warning("Unsupported operating system detected: %s", system)
 
@@ -97,7 +103,9 @@ def system_check():
     # Check for Debian version
     with open("/etc/os-release") as f:
         content = f.read().lower()
-        if "debian" not in content or not any(x in content for x in ("trixie", "testing")):
+        if "debian" not in content or not any(
+            x in content for x in ("trixie", "testing")
+        ):
             error_message = "Debian Trixie/Testing Check failed"
             log_error(error_message)
             raise RuntimeError(error_message)

--- a/monkey_head/logging_setup.py
+++ b/monkey_head/logging_setup.py
@@ -62,6 +62,13 @@ def configure_logging(config_path=None):
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
 
+    log_dir = os.path.dirname(log_file)
+    if log_dir and not os.path.exists(log_dir):  # pragma: no cover - fs access
+        try:
+            os.makedirs(log_dir, exist_ok=True)
+        except Exception:
+            log_file = os.path.basename(log_file)
+
     file_handler = logging.handlers.RotatingFileHandler(
         log_file, maxBytes=max_bytes, backupCount=backup_count
     )


### PR DESCRIPTION
## Summary
- ensure optional GUI dependencies don't break imports
- adjust GUI launcher to use repo root
- make distro and log directory optional

## Testing
- `pytest tests/test_gui.py::test_check_license_calls_gui -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*


------
https://chatgpt.com/codex/tasks/task_e_684cb86cd73c832ba252cd28a54acbc8