### PR TITLE
Add run guide and link from install docs

### DIFF
--- a/install.md
+++ b/install.md
@@ -71,6 +71,11 @@ Activate the virtual environment and execute:
 ```
 Results are stored in `logs/test_results.log`.
 
+## Next Steps
+
+With the environment ready, you can start the application using the launch
+scripts described in [run.md](run.md).
+
 ## Uninstallation and Fresh Install
 
 To remove the project, use the cross-platform uninstaller:

--- a/run.md
+++ b/run.md
@@ -1,0 +1,29 @@
+# Running the Monkey Head Project
+
+This guide explains the different ways to launch and test the project.
+
+## Launching the Application
+
+- `python run.py` – start the graphical interface.
+- `python run.py --cli` – force command‑line mode if no GUI is available.
+- `python run.py --minimal` – run the lightweight echo chatbot.
+- `python run.py --simple-chat` – open a simple Tkinter demo.
+
+## Helper Scripts
+
+Two wrapper scripts simplify starting the project:
+
+- `run.sh` (Linux/macOS) activates the virtual environment and runs `run.py`.
+- `run.bat` (Windows) does the same on Windows systems.
+
+## Running Tests
+
+After installation you can run the built‑in test suite:
+
+```bash
+./run-tests.sh
+```
+
+The script runs `pytest` with coverage reporting and stores the results in `logs/test_results.log`.
+
+Make sure the project is installed as described in [install.md](install.md) before using these commands.


### PR DESCRIPTION
## Summary
- create `run.md` with instructions for launching and testing the project
- reference the new guide from `install.md`

## Testing
- `MONKEY_HEAD_LIGHT_IMPORTS=1 pytest tests/test_run_minimal.py::test_minimal_run tests/test_cli_print.py::test_print_message_invalid -q`

------
https://chatgpt.com/codex/tasks/task_e_684cb93b24d8832b9843214bf937bd4f