### PR TITLE
Add connectivity verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ python sync_pygpt_structure.py  # copy entire pygpt tree
 # python sync_pygpt_structure.py --depth 2  # limit recursion if desired
 ```
 
+Run `python scripts/check_inter_program_connectivity.py` to verify that
+the submodule and local packages import correctly.
+
 Once copied, prefer importing modules from the project root instead of the `repo/pygpt-MHP` path. The installer performs the submodule update and installation with `pip install -e repo/pygpt-MHP` automatically.
 
 ### Running Tests

--- a/scripts/check_inter_program_connectivity.py
+++ b/scripts/check_inter_program_connectivity.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.12.2025
+# ==================================================
+"""Verify that monkey_head and pygpt_net modules import successfully."""
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def check_inter_program_connectivity() -> bool:
+    """Return ``True`` if required packages can be imported."""
+    try:
+        importlib.import_module("monkey_head")
+    except Exception:
+        return False
+
+    try:
+        importlib.import_module("pygpt_net")
+    except Exception:
+        root = Path(__file__).resolve().parents[1]
+        submodule = root / "repo" / "pygpt-MHP" / "src"
+        if submodule.exists() and str(submodule) not in sys.path:
+            sys.path.append(str(submodule))
+        try:
+            importlib.import_module("pygpt_net")
+        except Exception:
+            return False
+    return True
+
+
+def main() -> None:
+    if check_inter_program_connectivity():
+        print("Inter-program connectivity verified")
+        sys.exit(0)
+    print("Inter-program connectivity failed", file=sys.stderr)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -100,6 +100,11 @@ function setup_python_env {
     pip install -r requirements.txt || error_exit "Failed to install dependencies."
     echo "Installing local pygpt-MHP package..."
     pip install -e repo/pygpt-MHP || error_exit "Failed to install pygpt-MHP."
+    echo "Synchronizing submodule files..."
+    python sync_pygpt_structure.py || error_exit "Failed to sync submodule files."
+    echo "Checking inter-program connectivity..."
+    python scripts/check_inter_program_connectivity.py || \
+        error_exit "Inter-program connectivity failed."
 }
 
 function show_license_gui {

--- a/setup/Windows11/01-FULL.bat
+++ b/setup/Windows11/01-FULL.bat
@@ -134,6 +134,10 @@ pip install -r requirements.txt
 call :checkError "Install Python Requirements"
 pip install -e repo\pygpt-MHP
 call :checkError "Install pygpt-MHP"
+python sync_pygpt_structure.py
+call :checkError "Sync submodule"
+python scripts\check_inter_program_connectivity.py
+call :checkError "Inter-program connectivity"
 goto :eof
 
 :: Function to configure Git

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -68,6 +68,10 @@ function setup_python_env() {
     pip install -r requirements.txt
     echo "Installing local pygpt-MHP package..."
     pip install -e repo/pygpt-MHP
+    echo "Synchronizing submodule files..."
+    python sync_pygpt_structure.py || exit 1
+    echo "Checking inter-program connectivity..."
+    python scripts/check_inter_program_connectivity.py || exit 1
 }
 
 function show_license_gui() {

--- a/tests/test_inter_program_connectivity.py
+++ b/tests/test_inter_program_connectivity.py
@@ -1,0 +1,7 @@
+from scripts.check_inter_program_connectivity import (
+    check_inter_program_connectivity,
+)
+
+
+def test_check_inter_program_connectivity():
+    assert check_inter_program_connectivity() is True


### PR DESCRIPTION
## Summary
- add `check_inter_program_connectivity.py` utility
- call connectivity check from install scripts
- mirror submodule during installation
- document verification step in README
- test new connectivity function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_684cba38d60c832baafd6b964025dd49