### PR TITLE
Sync pygpt repo during install

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -101,6 +101,10 @@ def update_submodules() -> None:
         subprocess.run(
             ["git", "submodule", "update", "--init", "--recursive"], check=True
         )
+        subprocess.run(
+            [sys.executable, "sync_pygpt_structure.py"],
+            check=True,
+        )
     except subprocess.CalledProcessError as exc:
         print(f"Failed to update submodules: {exc.returncode}")
         raise


### PR DESCRIPTION
## Summary
- ensure pygpt files are mirrored when installer updates submodules

## Testing
- `pip install Pillow`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_e_684cbb00bbec832b8a2608056015b3ea