### PR TITLE
Add general sorting utilities

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -38,6 +38,7 @@ from .media_conversion import (
     extract_audio,
     convert_media,
 )
+from .utils.sorting import list_files_by_mtime, natural_sort
 
 if os.environ.get("MONKEY_HEAD_LIGHT_IMPORTS"):
     train_from_chat_and_pdfs = None
@@ -61,6 +62,8 @@ __all__ = [
     "convert_file",
     "extract_audio",
     "convert_media",
+    "list_files_by_mtime",
+    "natural_sort",
     "train_from_chat_and_pdfs",
     "train_from_project_sources",
 ]

--- a/monkey_head/utils/list_by_mtime.py
+++ b/monkey_head/utils/list_by_mtime.py
@@ -4,18 +4,15 @@
 # GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
 # License:   https://opensource.org/license/gpl-3-0
 # Overseen By:   Dylan L.R. Pollock
-# Updated: 06.08.2025
+# Updated: 06.11.2025
 # ==================================================
-import os
-from typing import List
+"""Backward-compatible wrapper for :mod:`monkey_head.utils.sorting`."""
 
+from __future__ import annotations
 
-def list_files_by_mtime(directory: str) -> List[str]:
-    """Return file paths sorted by modification time (oldest first)."""
-    entries = [os.path.join(directory, f) for f in os.listdir(directory)]
-    entries = [e for e in entries if os.path.isfile(e)]
-    entries.sort(key=lambda p: os.path.getmtime(p))
-    return entries
+from .sorting import list_files_by_mtime
+
+__all__ = ["list_files_by_mtime"]
 
 
 if __name__ == "__main__":

--- a/monkey_head/utils/sorting.py
+++ b/monkey_head/utils/sorting.py
@@ -1,0 +1,40 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.11.2025
+# ==================================================
+"""General sorting utilities."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Iterable, List
+
+__all__ = ["list_files_by_mtime", "natural_sort"]
+
+
+def list_files_by_mtime(directory: str, reverse: bool = False) -> List[str]:
+    """Return file paths sorted by modification time.
+
+    Parameters
+    ----------
+    directory:
+        Path of the directory to scan.
+    reverse:
+        When ``True`` sort newest first instead of oldest first.
+    """
+    entries = [os.path.join(directory, f) for f in os.listdir(directory)]
+    entries = [e for e in entries if os.path.isfile(e)]
+    entries.sort(key=lambda p: os.path.getmtime(p), reverse=reverse)
+    return entries
+
+
+def natural_sort(items: Iterable[str]) -> List[str]:
+    """Return ``items`` sorted in natural order."""
+    convert = lambda text: int(text) if text.isdigit() else text.lower()
+    alphanum_key = lambda key: [convert(c) for c in re.split(r"([0-9]+)", key)]
+    return sorted(list(items), key=alphanum_key)

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -4,11 +4,11 @@
 # GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
 # License:   https://opensource.org/license/gpl-3-0
 # Overseen By:   Dylan L.R. Pollock
-# Updated: 06.09.2025
+# Updated: 06.11.2025
 # ==================================================
 import time
 
-from monkey_head.utils.list_by_mtime import list_files_by_mtime
+from monkey_head.utils.sorting import list_files_by_mtime, natural_sort
 
 
 def test_list_files_by_mtime(tmp_path):
@@ -19,3 +19,9 @@ def test_list_files_by_mtime(tmp_path):
     f2.write_text("b")
     expected = [str(f1), str(f2)]
     assert list_files_by_mtime(str(tmp_path)) == expected
+    assert list_files_by_mtime(str(tmp_path), reverse=True) == expected[::-1]
+
+
+def test_natural_sort():
+    items = ["file10", "file2", "file1"]
+    assert natural_sort(items) == ["file1", "file2", "file10"]


### PR DESCRIPTION
## Summary
- add new `sorting` module with list by mtime and natural sort helpers
- update wrapper and tests to use new module
- export sorting functions at package level

## Testing
- `MONKEY_HEAD_LIGHT_IMPORTS=1 pytest tests/test_file_sorter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc220ad60832b8377bcfa0e88c648