### PR TITLE
Improve GUI screen mode options

### DIFF
--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -117,14 +117,36 @@ class MainUI:
     def choose_screen_mode(self) -> str:
         """Ask the user which display mode to use or read from ``SCREEN_MODE``."""
         env_mode = os.environ.get("SCREEN_MODE")
-        if env_mode in {"1080p", "4k"}:
+        if env_mode in {"1080p", "4k", "custom"}:
             return env_mode
-        if messagebox is not None:
-            resp = messagebox.askquestion(
+
+        if simpledialog is not None:
+            mode = simpledialog.askstring(
                 "Display Mode",
-                "Use 4K display scaling?",
+                "Choose display mode: 1080p, 4k, or custom",
+                initialvalue="1080p",
             )
-            return "4k" if resp == "yes" else "1080p"
+            if mode and mode.lower() in {"1080p", "4k", "custom"}:
+                mode = mode.lower()
+                if mode == "custom":
+                    if simpledialog is not None:
+                        factor = simpledialog.askfloat(
+                            "Scaling Factor",
+                            "Enter scaling factor",
+                            minvalue=0.5,
+                            maxvalue=5.0,
+                        )
+                        if factor is not None:
+                            os.environ["SCREEN_FACTOR"] = str(factor)
+                        font = simpledialog.askinteger(
+                            "Font Size",
+                            "Enter base font size",
+                            minvalue=6,
+                            maxvalue=24,
+                        )
+                        if font is not None:
+                            os.environ["SCREEN_FONT_SIZE"] = str(font)
+                return mode
         return "1080p"
 
     def setup_paths(self):

--- a/monkey_head/gui_scaling.py
+++ b/monkey_head/gui_scaling.py
@@ -1,5 +1,7 @@
 """Utilities for scaling Tkinter GUIs on high-DPI displays."""
 
+import os
+
 try:
     import tkinter as tk  # pragma: no cover - optional dependency
     from tkinter import font as tkfont
@@ -16,8 +18,9 @@ def apply_scaling(root: "tk.Tk", mode: str = "4k") -> None:
     root: tk.Tk
         The root window instance.
     mode: str, optional
-        ``"1080p"`` or ``"4k"`` to adjust scaling appropriately. Defaults to
-        ``"4k"``.
+        ``"1080p"``, ``"4k"`` or ``"custom"`` to adjust scaling
+        appropriately. ``"custom"`` reads ``SCREEN_FACTOR`` and
+        ``SCREEN_FONT_SIZE`` from the environment. Defaults to ``"4k"``.
     """
     if tk is None or tkfont is None:
         return
@@ -26,6 +29,15 @@ def apply_scaling(root: "tk.Tk", mode: str = "4k") -> None:
     if mode == "1080p":
         factor = 1.0
         font_size = 10
+    elif mode == "custom":
+        try:
+            factor = float(os.environ.get("SCREEN_FACTOR", 1.5))
+        except Exception:
+            factor = 1.5
+        try:
+            font_size = int(float(os.environ.get("SCREEN_FONT_SIZE", 12)))
+        except Exception:
+            font_size = 12
     else:
         factor = 2.0
         font_size = 14

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -30,19 +30,41 @@ def test_show_data_summary_displays_info():
 def test_choose_screen_mode_env(monkeypatch):
     ui = MainUI.__new__(MainUI)
     monkeypatch.setenv("SCREEN_MODE", "1080p")
-    with patch("gui.main_ui.messagebox.askquestion") as ask:
+    with patch("gui.main_ui.simpledialog.askstring") as ask:
         mode = MainUI.choose_screen_mode(ui)
         ask.assert_not_called()
         assert mode == "1080p"
 
 
+def test_choose_screen_mode_env_custom(monkeypatch):
+    ui = MainUI.__new__(MainUI)
+    monkeypatch.setenv("SCREEN_MODE", "custom")
+    with patch("gui.main_ui.simpledialog.askstring") as ask:
+        mode = MainUI.choose_screen_mode(ui)
+        ask.assert_not_called()
+        assert mode == "custom"
+
+
 def test_choose_screen_mode_prompt():
     ui = MainUI.__new__(MainUI)
     with patch.dict("os.environ", {}, clear=True), patch(
-        "gui.main_ui.messagebox.askquestion", return_value="yes"
+        "gui.main_ui.simpledialog.askstring", return_value="4k"
     ):
         mode = MainUI.choose_screen_mode(ui)
         assert mode == "4k"
+
+
+def test_choose_screen_mode_prompt_custom(monkeypatch):
+    ui = MainUI.__new__(MainUI)
+    with patch.dict("os.environ", {}, clear=True), patch(
+        "gui.main_ui.simpledialog.askstring", return_value="custom"
+    ), patch("gui.main_ui.simpledialog.askfloat", return_value=1.5) as askf, patch(
+        "gui.main_ui.simpledialog.askinteger", return_value=12
+    ) as aski:
+        mode = MainUI.choose_screen_mode(ui)
+        assert mode == "custom"
+        askf.assert_called_once()
+        aski.assert_called_once()
 
 
 def test_build_image_calls_runner():

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -36,3 +36,12 @@ def test_apply_scaling_4k(monkeypatch):
     root = DummyRoot()
     apply_scaling(root, mode="4k")
     assert root.tk.args == ("tk", "scaling", 2.0)
+
+
+def test_apply_scaling_custom(monkeypatch):
+    monkeypatch.setattr("monkey_head.gui_scaling.tkfont", DummyFontModule())
+    monkeypatch.setenv("SCREEN_FACTOR", "1.5")
+    monkeypatch.setenv("SCREEN_FONT_SIZE", "12")
+    root = DummyRoot()
+    apply_scaling(root, mode="custom")
+    assert root.tk.args == ("tk", "scaling", 1.5)


### PR DESCRIPTION
## Summary
- support a custom scaling setting in gui_scaling
- prompt for 1080p/4k/custom screen mode in main GUI
- add tests for custom screen mode selection and scaling

## Testing
- `pytest -vv tests/test_gui.py tests/test_scaling.py`

------
https://chatgpt.com/codex/tasks/task_e_684cd3f34398832bbe07bdc4550d1470