### PR TITLE
Add module run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ headless server), the launcher automatically falls
 back to the command-line interface. You can also force CLI mode with
 `python run.py --cli`. For an even lighter headless run you can launch the
 minimal echo chatbot with `python run.py --minimal`. A basic Tkinter chat demo
-is still available via `python run.py --simple-chat`.
+is still available via `python run.py --simple-chat`. To run individual modules
+directly, use `python run.py --module package.module[:func]`.
 
 The GUI now checks whether you've accepted the license on startup and
 offers a **Tools** menu. From there you can reopen the license dialog or

--- a/run.md
+++ b/run.md
@@ -8,6 +8,7 @@ This guide explains the different ways to launch and test the project.
 - `python run.py --cli` – force command‑line mode if no GUI is available.
 - `python run.py --minimal` – run the lightweight echo chatbot.
 - `python run.py --simple-chat` – open a simple Tkinter demo.
+- `python run.py --module package.module[:func]` – execute a module's callable.
 
 ## Helper Scripts
 

--- a/run.py
+++ b/run.py
@@ -18,6 +18,7 @@
 # ================================================== #
 
 import argparse
+import importlib
 import os
 import sys
 from pathlib import Path
@@ -29,6 +30,26 @@ def minimal_run() -> None:
     from monkey_head.pygpt_custom_cli import CustomPyGPT
 
     CustomPyGPT().run_cli()
+
+
+def run_module(target: str) -> None:
+    """Import ``module[:func]`` and execute the callable.
+
+    Parameters
+    ----------
+    target : str
+        Module path optionally followed by ``:func``. ``func`` defaults to
+        ``"main"`` when omitted.
+    """
+    module_name, _, func_name = target.partition(":")
+    if not func_name:
+        func_name = "main"
+    mod = importlib.import_module(module_name)
+    try:
+        func = getattr(mod, func_name)
+    except AttributeError as exc:  # pragma: no cover - invalid func
+        raise ImportError(f"Function {func_name} not found in {module_name}") from exc
+    func()
 
 
 def _load_cli() -> "callable":
@@ -67,11 +88,20 @@ def main() -> None:
         help="Run simple chat demonstration GUI",
     )
     parser.add_argument(
+        "--module",
+        type=str,
+        help="Run specified module optionally with :func",
+    )
+    parser.add_argument(
         "--version",
         action="store_true",
         help="Print pygpt_net version and exit",
     )
     args = parser.parse_args()
+
+    if args.module:
+        run_module(args.module)
+        return
 
     if args.minimal:
         minimal_run()

--- a/tests/dummy_module.py
+++ b/tests/dummy_module.py
@@ -1,0 +1,2 @@
+def main():
+    print("dummy module executed")

--- a/tests/test_run_module_option.py
+++ b/tests/test_run_module_option.py
@@ -1,0 +1,10 @@
+import sys
+from run import main
+
+
+def test_run_module_option(monkeypatch, capsys):
+    test_args = ["prog", "--module", "tests.dummy_module"]
+    monkeypatch.setattr(sys, "argv", test_args)
+    main()
+    captured = capsys.readouterr().out.strip()
+    assert captured == "dummy module executed"


### PR DESCRIPTION
## Summary
- enhance `run.py` with `--module` to run specific module functions
- document new usage in `run.md` and `README.md`
- add tests for module execution

## Testing
- `pytest tests/test_run_module_option.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: tensorflow, fitz, PIL, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684dc00946fc832b8bc14e93abbec867