### PR TITLE
Add PDF listing utility

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -39,6 +39,7 @@ from .media_conversion import (
     convert_media,
 )
 from .utils.sorting import list_files_by_mtime, natural_sort
+from .pdf_utils import list_available_pdfs
 
 if os.environ.get("MONKEY_HEAD_LIGHT_IMPORTS"):
     train_from_chat_and_pdfs = None
@@ -72,4 +73,5 @@ __all__ = [
     "natural_sort",
     "train_from_chat_and_pdfs",
     "train_from_project_sources",
+    "list_available_pdfs",
 ]

--- a/monkey_head/pdf_utils.py
+++ b/monkey_head/pdf_utils.py
@@ -1,0 +1,20 @@
+"""Utilities for handling project PDF documents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+
+def list_available_pdfs(pdf_dir: str | Path = Path("memory") / "PDF") -> List[str]:
+    """Return a sorted list of PDF filenames in ``pdf_dir``.
+
+    Parameters
+    ----------
+    pdf_dir:
+        Directory to scan for ``.pdf`` files.
+    """
+    path = Path(pdf_dir)
+    if not path.is_dir():
+        return []
+    return sorted(p.name for p in path.glob("*.pdf"))

--- a/monkey_head/pygpt_custom_cli.py
+++ b/monkey_head/pygpt_custom_cli.py
@@ -42,6 +42,13 @@ class CustomPyGPT:
                 user_input = input("You: ")
             except EOFError:
                 break
+            if user_input.lower().strip() == "list pdfs":
+                from .pdf_utils import list_available_pdfs
+
+                print("Available PDFs:")
+                for pdf in list_available_pdfs():
+                    print(f"- {pdf}")
+                continue
             if user_input.lower() in {"exit", "quit"}:
                 break
             self.memory.add_user_message(user_input)

--- a/run.py
+++ b/run.py
@@ -97,6 +97,11 @@ def main() -> None:
         action="store_true",
         help="Print pygpt_net version and exit",
     )
+    parser.add_argument(
+        "--list-pdfs",
+        action="store_true",
+        help="List PDF files available to the application",
+    )
     args = parser.parse_args()
 
     if args.module:
@@ -110,6 +115,13 @@ def main() -> None:
         from monkey_head.simple_chat_gui import run_simple_chat
 
         run_simple_chat()
+        return
+
+    if args.list_pdfs:
+        from monkey_head.pdf_utils import list_available_pdfs
+
+        for pdf in list_available_pdfs():
+            print(pdf)
         return
 
     from monkey_head.core.system_checks import check_os_support, check_python_version

--- a/tests/test_list_available_pdfs.py
+++ b/tests/test_list_available_pdfs.py
@@ -1,0 +1,6 @@
+from monkey_head.pdf_utils import list_available_pdfs
+
+
+def test_list_available_pdfs():
+    pdfs = list_available_pdfs("memory/PDF")
+    assert "Linux_on_PlayStation_3.pdf" in pdfs


### PR DESCRIPTION
## Summary
- add a helper to list available PDFs
- export `list_available_pdfs` from package
- print PDFs via new `--list-pdfs` option in `run.py`
- allow `list pdfs` command in the minimal CLI
- test the PDF listing helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd4cb7890832b9f1a18bd5deeae00