### PR TITLE
Improve pygpt-MHP launch and integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ the submodule and local packages import correctly.
 
 Once copied, prefer importing modules from the project root instead of the `repo/pygpt-MHP` path. The installer performs the submodule update and installation with `pip install -e repo/pygpt-MHP` automatically.
 
+The `run.py` launcher now detects when the mirrored `src` directory or installed
+package is missing and will automatically use `repo/pygpt-MHP/src` instead. This
+lets you try the project right after cloning, even before syncing or installing
+the submodule.
+
 ### Running Tests
 
 ```bash

--- a/run.py
+++ b/run.py
@@ -53,9 +53,20 @@ def run_module(target: str) -> None:
 
 
 def _load_cli() -> "callable":
-    """Import and return the standard CLI runner."""
-    sys.path.insert(0, str((Path(__file__).parent / "src").resolve()))
-    from pygpt_net.app import run as cli_run
+    """Import and return the standard CLI runner.
+
+    Falls back to the ``repo/pygpt-MHP`` submodule if the mirrored ``src``
+    directory or installed package is missing.
+    """
+    src_dir = Path(__file__).parent / "src"
+    sys.path.insert(0, str(src_dir.resolve()))
+    try:
+        from pygpt_net.app import run as cli_run
+    except Exception:  # pragma: no cover - fallback to submodule
+        sub_dir = Path(__file__).parent / "repo" / "pygpt-MHP" / "src"
+        if sub_dir.exists() and str(sub_dir.resolve()) not in sys.path:
+            sys.path.insert(0, str(sub_dir.resolve()))
+        from pygpt_net.app import run as cli_run
 
     return cli_run
 


### PR DESCRIPTION
## Summary
- fallback to pygpt-MHP submodule when `pygpt_net` isn't installed
- document new fallback behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd64900ac832b85373312cb06b15a