### PR TITLE
Add strict mode to bash scripts

### DIFF
--- a/GenCore.sh
+++ b/GenCore.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca
@@ -33,7 +34,7 @@ function update_system() {
 
 function install_packages() {
     echo "Installing required packages: $DEFAULT_PACKAGES"
-    apt-get install -y $DEFAULT_PACKAGES
+    apt-get install -y "$DEFAULT_PACKAGES"
 }
 
 function clone_repo() {

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/repo/pygpt-MHP/bin/build.sh
+++ b/repo/pygpt-MHP/bin/build.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/repo/pygpt-MHP/bin/clean.sh
+++ b/repo/pygpt-MHP/bin/clean.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/repo/pygpt-MHP/bin/resources.sh
+++ b/repo/pygpt-MHP/bin/resources.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/repo/pygpt-MHP/bin/sort_locale.sh
+++ b/repo/pygpt-MHP/bin/sort_locale.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/repo/pygpt-MHP/install.sh
+++ b/repo/pygpt-MHP/install.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/repo/pygpt-MHP/run-tests.sh
+++ b/repo/pygpt-MHP/run-tests.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/repo/pygpt-MHP/run.sh
+++ b/repo/pygpt-MHP/run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/repo/pygpt-MHP/shortcut.sh
+++ b/repo/pygpt-MHP/shortcut.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/repo/pygpt-MHP/snaprun.sh
+++ b/repo/pygpt-MHP/snaprun.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/scripts/docker_cleanup.sh
+++ b/scripts/docker_cleanup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/scripts/k8s_cleanup.sh
+++ b/scripts/k8s_cleanup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/scripts/k8s_setup.sh
+++ b/scripts/k8s_setup.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/setup/Debian13/install.sh
+++ b/setup/Debian13/install.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca
@@ -69,7 +70,7 @@ function install_selected_packages {
         packages="$DEFAULT_PACKAGES"
     fi
     echo "Installing packages: $packages..."
-    apt-get install -y $packages || error_exit "Failed to install packages."
+    apt-get install -y "$packages" || error_exit "Failed to install packages."
 }
 
 # Remove Firefox and install Microsoft Edge Dev

--- a/setup/Debian13/uninstall.sh
+++ b/setup/Debian13/uninstall.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/setup/Debian13/update.sh
+++ b/setup/Debian13/update.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/setup/macOS/uninstall.sh
+++ b/setup/macOS/uninstall.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/shortcut.sh
+++ b/shortcut.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/snaprun.sh
+++ b/snaprun.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca


### PR DESCRIPTION
## Summary
- enforce consistent bash shebang
- enable `set -euo pipefail` across shell scripts for safer execution
- quote package variable in Debian install script
- quote default package list in GenCore

## Testing
- `bash -n $(git ls-files '*.sh')`
- `pytest tests/test_placeholder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684dde1208f4832b8d62396db2fa35a5