### PR TITLE
Improve run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,15 +9,70 @@ set -euo pipefail
 # Updated:   06.09.2025
 # ==================================================
 # This script is used to run the tests using the virtual environment
-if [ ! -f "venv/bin/activate" ]; then
-  echo "Virtual environment not found. Please run install.sh first." >&2
-  exit 1
-fi
+usage() {
+    cat <<EOF
+Usage: $0 [options]
 
-LOG_DIR="logs"
-LOG_FILE="$LOG_DIR/test_results.log"
-mkdir -p "$LOG_DIR"
-echo "Test run started at $(date)" | tee "$LOG_FILE"
+Options:
+  -h, --help            Show this help message and exit
+  -l, --log FILE        Write test results to FILE
+  -m, --module MODULE   Run tests only for the given module or file
+      --no-cov          Run tests without coverage reporting
+EOF
+}
 
-source ./venv/bin/activate
-pytest -vv --cov=monkey_head --cov-report=term | tee -a "$LOG_FILE"
+parse_args() {
+    MODULE=""
+    COV_ARGS=(--cov=monkey_head --cov-report=term)
+    LOG_FILE="logs/test_results.log"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -l|--log)
+                LOG_FILE="$2"
+                shift 2
+                ;;
+            -m|--module)
+                MODULE="$2"
+                shift 2
+                ;;
+            --no-cov)
+                COV_ARGS=()
+                shift
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                usage >&2
+                exit 1
+                ;;
+        esac
+    done
+}
+
+check_venv() {
+    if [ ! -f "venv/bin/activate" ]; then
+      echo "Virtual environment not found. Please run install.sh first." >&2
+      exit 1
+    fi
+}
+
+run_tests() {
+    LOG_DIR="$(dirname "$LOG_FILE")"
+    mkdir -p "$LOG_DIR"
+    echo "Test run started at $(date)" | tee "$LOG_FILE"
+
+    source ./venv/bin/activate
+    local args=(pytest -vv)
+    if [ -n "$MODULE" ]; then
+        args+=("$MODULE")
+    fi
+    args+=("${COV_ARGS[@]}")
+    "${args[@]}" | tee -a "$LOG_FILE"
+}
+
+parse_args "$@"
+check_venv
+run_tests


### PR DESCRIPTION
## Summary
- add usage and argument parsing helpers
- support logging to custom file, running specific modules, and disabling coverage

## Testing
- `bash run-tests.sh --no-cov -m tests/test_cli_print.py`
- `bash run-tests.sh --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_684de0bb1a54832b9df0f970f5c8d618