### PR TITLE
Add extra agent options

### DIFF
--- a/repo/pygpt-MHP/src/pygpt_net/controller/agent/common.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/agent/common.py
@@ -66,6 +66,40 @@ class Common:
         else:
             self.enable_continue()
 
+    def enable_goal_notify(self):
+        """Enable goal notify"""
+        self.window.core.config.set('agent.goal.notify', True)
+        self.window.core.config.save()
+
+    def disable_goal_notify(self):
+        """Disable goal notify"""
+        self.window.core.config.set('agent.goal.notify', False)
+        self.window.core.config.save()
+
+    def toggle_goal_notify(self, state: bool):
+        """Toggle goal notify"""
+        if not state:
+            self.disable_goal_notify()
+        else:
+            self.enable_goal_notify()
+
+    def enable_llama_verbose(self):
+        """Enable llama verbose mode"""
+        self.window.core.config.set('agent.llama.verbose', True)
+        self.window.core.config.save()
+
+    def disable_llama_verbose(self):
+        """Disable llama verbose mode"""
+        self.window.core.config.set('agent.llama.verbose', False)
+        self.window.core.config.save()
+
+    def toggle_llama_verbose(self, state: bool):
+        """Toggle llama verbose"""
+        if not state:
+            self.disable_llama_verbose()
+        else:
+            self.enable_llama_verbose()
+
     def is_infinity_loop(self, mode: str) -> bool:
         """
         Check if infinity loop is active

--- a/repo/pygpt-MHP/src/pygpt_net/controller/agent/legacy.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/agent/legacy.py
@@ -64,6 +64,7 @@ class Legacy:
         """Setup agent controller"""
         # register hooks
         self.window.ui.add_hook("update.global.agent.iterations", self.hook_update)
+        self.window.ui.add_hook("update.global.agent.goal.notify", self.hook_update)
         self.reload()  # restore config
 
     def reload(self):
@@ -79,6 +80,12 @@ class Legacy:
             self.window.ui.config['global']['agent.continue'].setChecked(True)
         else:
             self.window.ui.config['global']['agent.continue'].setChecked(False)
+
+        # goal notify checkbox
+        if self.window.core.config.get('agent.goal.notify'):
+            self.window.ui.config['global']['agent.goal.notify'].setChecked(True)
+        else:
+            self.window.ui.config['global']['agent.goal.notify'].setChecked(False)
 
         # iterations slider
         self.window.controller.config.apply_value(
@@ -396,3 +403,6 @@ class Legacy:
             self.window.core.config.set(key, int(value))  # cast to int, if from text input
             self.window.core.config.save()
             self.update()
+        elif key == 'agent.goal.notify':
+            self.window.core.config.set(key, bool(value))
+            self.window.core.config.save()

--- a/repo/pygpt-MHP/src/pygpt_net/controller/agent/llama.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/agent/llama.py
@@ -37,12 +37,23 @@ class Llama:
                 "value": 75,
                 "multiplier": 1,
             },
+            "agent.llama.max_eval": {
+                "type": "int",
+                "slider": True,
+                "label": "agent.llama.max_eval",
+                "min": 0,
+                "max": 100,
+                "step": 1,
+                "value": 3,
+                "multiplier": 1,
+            },
         }
 
     def setup(self):
         """Setup agent controller"""
         # register hooks
         self.window.ui.add_hook("update.global.agent.llama.loop.score", self.hook_update)
+        self.window.ui.add_hook("update.global.agent.llama.max_eval", self.hook_update)
         self.reload()  # restore config
 
     def reload(self):
@@ -59,6 +70,14 @@ class Llama:
             key="agent.llama.loop.score",
             option=self.options["agent.llama.loop.score"],
             value=self.window.core.config.get('agent.llama.loop.score'),
+        )
+
+        # max evaluation slider
+        self.window.controller.config.apply_value(
+            parent_id="global",
+            key="agent.llama.max_eval",
+            option=self.options["agent.llama.max_eval"],
+            value=self.window.core.config.get('agent.llama.max_eval'),
         )
 
     def reset_eval_step(self):
@@ -149,6 +168,10 @@ class Llama:
         if self.window.core.config.get(key) == value:
             return
         if key == 'agent.llama.loop.score':
+            self.window.core.config.set(key, int(value))
+            self.window.core.config.save()
+            self.update()
+        elif key == 'agent.llama.max_eval':
             self.window.core.config.set(key, int(value))
             self.window.core.config.save()
             self.update()

--- a/repo/pygpt-MHP/src/pygpt_net/data/locale/locale.en.ini
+++ b/repo/pygpt-MHP/src/pygpt_net/data/locale/locale.en.ini
@@ -1224,9 +1224,12 @@ tip.toolbox.prompt = The current system prompt can be modified in real-time. To 
 toolbox.agent.auto_stop.label = Auto-stop
 toolbox.agent.continue.label = Always continue...
 toolbox.agent.iterations.label = Max run steps (iterations, 0 = infinity)
+toolbox.agent.goal.notify.label = Goal notification
 toolbox.agent.llama.loop.enabled.label = Loop
 toolbox.agent.llama.loop.label = Loop / evaluate (until score, 0%% = infinity)
 toolbox.agent.llama.loop.score.tooltip = Required score to finish, 0%% = infinity loop
+toolbox.agent.llama.max_eval.label = Max evaluation steps
+toolbox.agent.llama.verbose.label = Verbose
 toolbox.agents.label = Agents
 toolbox.assistants.label = Assistants
 toolbox.experts.label = Experts

--- a/repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox/agent.py
+++ b/repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox/agent.py
@@ -61,10 +61,20 @@ class Agent:
         )
         self.window.ui.config['global']['agent.continue'] = self.window.ui.nodes['agent.continue']
 
+        # goal notify
+        self.window.ui.nodes['agent.goal.notify'] = ToggleLabel(trans("toolbox.agent.goal.notify.label"))
+        self.window.ui.nodes['agent.goal.notify'].box.stateChanged.connect(
+            lambda:
+            self.window.controller.agent.common.toggle_goal_notify(
+                self.window.ui.config['global']['agent.goal.notify'].box.isChecked())
+        )
+        self.window.ui.config['global']['agent.goal.notify'] = self.window.ui.nodes['agent.goal.notify']
+
         # options
         cols = QHBoxLayout()
         cols.addWidget(self.window.ui.config['global']['agent.auto_stop'])
         cols.addWidget(self.window.ui.config['global']['agent.continue'])
+        cols.addWidget(self.window.ui.config['global']['agent.goal.notify'])
 
         # rows
         rows = QVBoxLayout()

--- a/repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox/agent_llama.py
+++ b/repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox/agent_llama.py
@@ -54,6 +54,26 @@ class AgentLlama:
         )
         self.window.ui.config['global']['agent.llama.loop.enabled'] = self.window.ui.nodes['agent.llama.loop.enabled']
 
+        # max eval
+        option = self.window.controller.agent.llama.options["agent.llama.max_eval"]
+        self.window.ui.nodes['agent.llama.max_eval.label'] = QLabel(trans("toolbox.agent.llama.max_eval.label"))
+        self.window.ui.nodes['agent.llama.max_eval'] = OptionSlider(
+            self.window,
+            'global',
+            'agent.llama.max_eval',
+            option,
+        )
+        self.window.ui.config['global']['agent.llama.max_eval'] = self.window.ui.nodes['agent.llama.max_eval']
+
+        # verbose
+        self.window.ui.nodes['agent.llama.verbose'] = ToggleLabel(trans("toolbox.agent.llama.verbose.label"))
+        self.window.ui.nodes['agent.llama.verbose'].box.stateChanged.connect(
+            lambda:
+            self.window.controller.agent.common.toggle_llama_verbose(
+                self.window.ui.config['global']['agent.llama.verbose'].box.isChecked())
+        )
+        self.window.ui.config['global']['agent.llama.verbose'] = self.window.ui.nodes['agent.llama.verbose']
+
         # label
         self.window.ui.nodes['agent.llama.loop.label'] = QLabel(trans("toolbox.agent.llama.loop.label"))
 
@@ -62,10 +82,16 @@ class AgentLlama:
         cols.addWidget(self.window.ui.config['global']['agent.llama.loop.enabled'])
         cols.addWidget(self.window.ui.config['global']['agent.llama.loop.score'])
 
+        cols2 = QHBoxLayout()
+        cols2.addWidget(self.window.ui.config['global']['agent.llama.max_eval'])
+        cols2.addWidget(self.window.ui.config['global']['agent.llama.verbose'])
+
         # rows
         rows = QVBoxLayout()
         rows.addWidget(self.window.ui.nodes['agent.llama.loop.label'])
         rows.addLayout(cols)
+        rows.addWidget(self.window.ui.nodes['agent.llama.max_eval.label'])
+        rows.addLayout(cols2)
 
         self.window.ui.nodes['agent_llama.options'] = QWidget()
         self.window.ui.nodes['agent_llama.options'].setLayout(rows)


### PR DESCRIPTION
## Summary
- add toggles for goal notifications and llama verbose mode
- add max evaluation slider for llama agent
- update controllers to handle new agent options
- extend English locale with new labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de4ad4b6c832b8dbc337d231c2ce5