### PR TITLE
Add PDF chat utility

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -40,6 +40,12 @@ from .media_conversion import (
 )
 from .utils.sorting import list_files_by_mtime, natural_sort
 from .pdf_utils import list_available_pdfs
+try:
+    from .pdf_chat import load_pdf_pages, answer_question, chat_with_pdf
+except Exception:  # pragma: no cover - optional dependency
+    load_pdf_pages = None
+    answer_question = None
+    chat_with_pdf = None
 
 if os.environ.get("MONKEY_HEAD_LIGHT_IMPORTS"):
     train_from_chat_and_pdfs = None
@@ -74,4 +80,7 @@ __all__ = [
     "train_from_chat_and_pdfs",
     "train_from_project_sources",
     "list_available_pdfs",
+    "load_pdf_pages",
+    "answer_question",
+    "chat_with_pdf",
 ]

--- a/monkey_head/pdf_chat.py
+++ b/monkey_head/pdf_chat.py
@@ -1,0 +1,79 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.12.2025
+# ==================================================
+"""Interactive utility for chatting with a PDF document."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List
+
+try:  # pragma: no cover - optional dependency
+    from pypdf import PdfReader
+except Exception:  # pragma: no cover - missing optional dep
+    PdfReader = None  # type: ignore
+
+from .formatter import format_text
+
+
+def load_pdf_pages(pdf_file: str | Path) -> List[str]:
+    """Return the text of each page in ``pdf_file`` as a list."""
+    if PdfReader is None:  # pragma: no cover - optional dependency
+        raise RuntimeError("pypdf is required to load PDFs")
+    path = Path(pdf_file)
+    if not path.is_file():
+        raise FileNotFoundError(pdf_file)
+    reader = PdfReader(str(path))
+    pages = []
+    for page in reader.pages:
+        text = page.extract_text() or ""
+        pages.append(text)
+    return pages
+
+
+def answer_question(pages: List[str], question: str) -> str:
+    """Return a sentence from ``pages`` matching ``question``."""
+    words = re.findall(r"\w+", question.lower())
+    best_sentence = None
+    best_score = 0
+    for page in pages:
+        for sentence in re.split(r"[.!?]\s+", page):
+            tokens = re.findall(r"\w+", sentence.lower())
+            score = sum(1 for w in words if w in tokens)
+            if score > best_score:
+                best_score = score
+                best_sentence = sentence
+    if best_sentence:
+        return format_text(best_sentence.strip())
+    return "I could not find an answer in the document."
+
+
+def chat_with_pdf(pdf_file: str) -> None:
+    """Start an interactive Q&A session using ``pdf_file``."""
+    pages = load_pdf_pages(pdf_file)
+    print(f"Loaded {len(pages)} pages from {pdf_file}")
+    while True:
+        try:
+            question = input("Ask about the PDF ('quit' to exit): ")
+        except EOFError:  # pragma: no cover - interactive mode
+            break
+        if question.lower().strip() in {"quit", "exit"}:
+            break
+        answer = answer_question(pages, question)
+        print(answer)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Conversation with a PDF file")
+    parser.add_argument("pdf", help="Path to the PDF document")
+    args = parser.parse_args()
+
+    chat_with_pdf(args.pdf)

--- a/tests/test_pdf_chat.py
+++ b/tests/test_pdf_chat.py
@@ -1,0 +1,29 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.12.2025
+# ==================================================
+import importlib
+from pathlib import Path
+import pytest
+
+pytest.importorskip("pypdf")
+
+pdf_chat = importlib.import_module("monkey_head.pdf_chat")
+
+
+def test_load_pdf_pages():
+    pdf_path = Path("memory/PDF/Linux_on_PlayStation_3.pdf")
+    pages = pdf_chat.load_pdf_pages(str(pdf_path))
+    assert isinstance(pages, list)
+    assert pages and isinstance(pages[0], str)
+
+
+def test_answer_question():
+    pdf_path = Path("memory/PDF/Linux_on_PlayStation_3.pdf")
+    pages = pdf_chat.load_pdf_pages(str(pdf_path))
+    answer = pdf_chat.answer_question(pages, "PlayStation")
+    assert "PlayStation" in answer


### PR DESCRIPTION
## Summary
- add `pdf_chat` module to load PDF pages and answer questions
- expose new PDF chat helpers in `__init__`
- test PDF chat functionality

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e09d50344832b8cd2371f9485f5c4