### PR TITLE
Add timestamp to Docker logs

### DIFF
--- a/docker/GenCore/GenCore.py
+++ b/docker/GenCore/GenCore.py
@@ -15,7 +15,10 @@ import logging
 import subprocess
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 

--- a/docker/HostOS/HostOS.py
+++ b/docker/HostOS/HostOS.py
@@ -11,7 +11,10 @@ import logging
 import subprocess
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 

--- a/docker/NanoOS/NanoOS.py
+++ b/docker/NanoOS/NanoOS.py
@@ -11,7 +11,10 @@ import logging
 import subprocess
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 

--- a/docker/SubOS/SubOS.py
+++ b/docker/SubOS/SubOS.py
@@ -11,7 +11,10 @@ import logging
 import subprocess
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- include timestamps in logging for Docker helper scripts

## Testing
- `bash run-tests.sh --no-cov` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8547bfe4832b908190c2e19c2a05