### PR TITLE
Fix tests by adding pygpt_net symlink

### DIFF
--- a/pygpt_net
+++ b/pygpt_net
@@ -1,0 +1,1 @@
+repo/pygpt-MHP/src/pygpt_net


### PR DESCRIPTION
## Summary
- add missing `pygpt_net` symlink so local package imports succeed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0a25e550832b9ee84dfdb92b7dbb