### PR TITLE
Enhance git utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,25 @@ package is missing and will automatically use `repo/pygpt-MHP/src` instead. This
 lets you try the project right after cloning, even before syncing or installing
 the submodule.
 
+### Git Utilities
+
+Several helper functions in `monkey_head.services.environment_setup` make it
+easier to keep your local clone up to date. You can programmatically switch
+branches, pull the latest changes, and push commits:
+
+```python
+from monkey_head.services.environment_setup import (
+    checkout_branch, pull_latest, commit_and_push
+)
+
+checkout_branch("develop")      # git fetch && git checkout develop
+pull_latest()                    # git pull --ff-only
+commit_and_push("update", branch="develop")
+```
+
+These utilities rely on `git` being available on your system and are useful for
+automating common version control tasks in scripts.
+
 ### Running Tests
 
 ```bash

--- a/monkey_head/main.py
+++ b/monkey_head/main.py
@@ -11,7 +11,19 @@
 from monkey_head.utils.logger import get_logger
 from flask import Flask, jsonify
 import argparse
-from pygpt_net import __version__ as pygpt_version
+try:
+    from pygpt_net import __version__ as pygpt_version
+except Exception:  # pragma: no cover - optional dependency
+    import os
+    import sys
+
+    fallback = os.path.join(os.path.dirname(__file__), "..", "repo", "pygpt-MHP", "src")
+    if fallback not in sys.path:
+        sys.path.append(fallback)
+    try:  # pragma: no cover - best effort
+        from pygpt_net import __version__ as pygpt_version
+    except Exception:
+        pygpt_version = "unknown"
 from .core.system_checks import system_check, ensure_admin, check_python_version
 from .modules.updates import update_system, update_python_packages
 from .core.installations import (

--- a/monkey_head/services/environment_setup.py
+++ b/monkey_head/services/environment_setup.py
@@ -101,3 +101,32 @@ def update_env_variables():
     if line not in content:
         with open(bashrc_path, "a") as bashrc:
             bashrc.write(f"\n{line}\n")
+
+
+def checkout_branch(branch: str = "main", dest: str = "~/Source/repo") -> None:
+    """Fetch and checkout the given branch in the local repository."""
+    logger.info("Checking out branch %s", branch)
+    repo_path = os.path.expanduser(dest)
+    run_command(["git", "fetch"], cwd=repo_path)
+    run_command(["git", "checkout", branch], cwd=repo_path)
+
+
+def pull_latest(dest: str = "~/Source/repo") -> None:
+    """Pull the latest changes from the tracked remote."""
+    logger.info("Pulling latest changes...")
+    repo_path = os.path.expanduser(dest)
+    run_command(["git", "pull", "--ff-only"], cwd=repo_path)
+
+
+def commit_and_push(
+    message: str,
+    dest: str = "~/Source/repo",
+    remote: str = "origin",
+    branch: str = "main",
+) -> None:
+    """Commit all changes and push them to the remote branch."""
+    logger.info("Committing and pushing changes to %s/%s", remote, branch)
+    repo_path = os.path.expanduser(dest)
+    run_command(["git", "add", "."], cwd=repo_path)
+    run_command(["git", "commit", "-m", message], cwd=repo_path)
+    run_command(["git", "push", remote, branch], cwd=repo_path)

--- a/tests/test_environment_setup_git.py
+++ b/tests/test_environment_setup_git.py
@@ -1,0 +1,27 @@
+from monkey_head.services.environment_setup import (
+    checkout_branch,
+    pull_latest,
+    commit_and_push,
+)
+from unittest.mock import patch
+
+
+def test_checkout_branch():
+    with patch("monkey_head.services.environment_setup.run_command") as run:
+        checkout_branch("dev", dest="/tmp/repo")
+        run.assert_any_call(["git", "fetch"], cwd="/tmp/repo")
+        run.assert_any_call(["git", "checkout", "dev"], cwd="/tmp/repo")
+
+
+def test_pull_latest():
+    with patch("monkey_head.services.environment_setup.run_command") as run:
+        pull_latest(dest="/tmp/repo")
+        run.assert_called_once_with(["git", "pull", "--ff-only"], cwd="/tmp/repo")
+
+
+def test_commit_and_push():
+    with patch("monkey_head.services.environment_setup.run_command") as run:
+        commit_and_push("msg", dest="/tmp/repo", remote="origin", branch="main")
+        run.assert_any_call(["git", "add", "."], cwd="/tmp/repo")
+        run.assert_any_call(["git", "commit", "-m", "msg"], cwd="/tmp/repo")
+        run.assert_any_call(["git", "push", "origin", "main"], cwd="/tmp/repo")


### PR DESCRIPTION
## Summary
- add checkout_branch, pull_latest, and commit_and_push helpers
- allow monkey_head.main to fall back to bundled pygpt submodule if pygpt_net isn't installed
- document new git utilities in README
- test new git helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0b245160832b805e4807add67d9f