### PR TITLE
Add log clearing option

### DIFF
--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -179,6 +179,7 @@ class MainUI:
         file_menu.add_command(label="Install", command=self.install)
         file_menu.add_command(label="Run", command=self.run)
         file_menu.add_command(label="Update", command=self.update)
+        file_menu.add_command(label="Clear Log", command=self.clear_log)
         file_menu.add_separator()
         file_menu.add_command(label="Exit", command=self.root.quit)
         menu_bar.add_cascade(label="File", menu=file_menu)
@@ -278,9 +279,24 @@ class MainUI:
         )
         self.update_button.pack(side=tk.LEFT, padx=10, pady=10)
 
+        self.clear_button = tk.Button(
+            self.root,
+            text="Clear Log",
+            command=self.clear_log,
+            bg=ACCENT_PURPLE,
+            fg=LIGHT_FG,
+            activebackground=ACCENT_PURPLE,
+            activeforeground=LIGHT_FG,
+        )
+        self.clear_button.pack(side=tk.LEFT, padx=10, pady=10)
+
     def log_message(self, message):
         self.log_text.insert(tk.END, message + "\n")
         self.log_text.see(tk.END)
+
+    def clear_log(self) -> None:
+        """Remove all text from the log window."""
+        self.log_text.delete("1.0", tk.END)
 
     def run_script(self, script_path):
         if script_path is None or not Path(script_path).exists():

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -161,3 +161,13 @@ def test_launch_ai_tools_runs_thread():
         )
         MainUI.launch_ai_tools(ui)
         run_tools.assert_called_once()
+
+
+def test_clear_log_invokes_delete():
+    ui = MainUI.__new__(MainUI)
+    dummy_log = SimpleNamespace(delete=lambda *a, **k: None)
+    ui.log_text = dummy_log
+    with patch("gui.main_ui.tk", SimpleNamespace(END="end")):
+        with patch.object(dummy_log, "delete") as delete:
+            MainUI.clear_log(ui)
+            delete.assert_called_once_with("1.0", "end")


### PR DESCRIPTION
## Summary
- provide a new **Clear Log** entry in the Program Manager GUI
- add a matching button to the main window
- implement `clear_log` method
- test that log clearing calls the underlying widget

## Testing
- `pytest tests/test_gui.py::test_clear_log_invokes_delete -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684f163050fc832ba81f20de08f6db69