### PR TITLE
Add workdir option for run.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ is still available via `python run.py --simple-chat`. To run individual modules
 directly, use `python run.py --module package.module[:func]`.
 You can also perform a quick environment check with
 `python run.py --system-check`.
+To use a different working directory pass `--workdir /path/to/dir`.
 
 The GUI now checks whether you've accepted the license on startup and
 offers a **Tools** menu. From there you can reopen the license dialog or

--- a/run.py
+++ b/run.py
@@ -118,7 +118,18 @@ def main() -> None:
         action="store_true",
         help="Run environment checks and exit",
     )
+    parser.add_argument(
+        "--workdir",
+        type=str,
+        help="Set the working directory (default: project directory)",
+    )
     args = parser.parse_args()
+
+    # determine working directory
+    if args.workdir:
+        os.environ["PYGPT_WORKDIR"] = os.path.abspath(args.workdir)
+    elif "PYGPT_WORKDIR" not in os.environ:
+        os.environ["PYGPT_WORKDIR"] = str(Path(__file__).parent.resolve())
 
     if args.module:
         run_module(args.module)


### PR DESCRIPTION
## Summary
- allow overriding the working directory via `--workdir`
- mention `--workdir` option in README

## Testing
- `bash run-tests.sh --no-cov` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1694bda0832bb73796cb4f5e85ff