### PR TITLE
Add GPU enable option

### DIFF
--- a/repo/pygpt-MHP/INSTALL.md
+++ b/repo/pygpt-MHP/INSTALL.md
@@ -188,6 +188,12 @@ and to force disable OpenGL:
 python3 run.py --disable-gpu=1
 ```
 
+and to force enable OpenGL:
+
+``` ini
+python3 run.py --enable-gpu=1
+```
+
 You can also manualy enable legacy mode by editing config file - open the `%WORKDIR%/config.json` config file in editor and set the following options:
 
 ``` json

--- a/repo/pygpt-MHP/README.md
+++ b/repo/pygpt-MHP/README.md
@@ -313,6 +313,12 @@ and to force disable OpenGL hardware acceleration:
 python3 run.py --disable-gpu=1
 ```
 
+and to force enable OpenGL hardware acceleration:
+
+``` ini
+python3 run.py --enable-gpu=1
+```
+
 You can also manualy enable legacy mode by editing config file - open the `%WORKDIR%/config.json` config file in editor and set the following options:
 
 ``` json
@@ -3414,6 +3420,12 @@ and to force disable OpenGL hardware acceleration:
 
 ``` ini
 python3 run.py --disable-gpu=1
+```
+
+and to force enable OpenGL hardware acceleration:
+
+``` ini
+python3 run.py --enable-gpu=1
 ```
 
 You can also manualy enable legacy mode by editing config file - open the `%WORKDIR%/config.json` config file in editor and set the following options:

--- a/repo/pygpt-MHP/docs/source/debug.rst
+++ b/repo/pygpt-MHP/docs/source/debug.rst
@@ -41,6 +41,12 @@ and to force disable OpenGL hardware acceleration:
 
     python3 run.py --disable-gpu=1
 
+and to force enable OpenGL hardware acceleration:
+
+.. code-block:: console
+
+    python3 run.py --enable-gpu=1
+
 You can also manualy enable legacy mode by editing config file - open the ``%WORKDIR%/config.json`` config file in editor and set the following options:
 
 .. code-block:: json

--- a/repo/pygpt-MHP/docs/source/requirements.rst
+++ b/repo/pygpt-MHP/docs/source/requirements.rst
@@ -265,6 +265,12 @@ and to force disable OpenGL hardware acceleration:
 
     $ python3 run.py --disable-gpu=1
 
+and to force enable OpenGL hardware acceleration:
+
+.. code-block:: console
+
+    $ python3 run.py --enable-gpu=1
+
 
 You can also manualy enable legacy mode by editing config file - open the ``%WORKDIR%/config.json`` config file in editor and set the following options:
 

--- a/repo/pygpt-MHP/src/pygpt_net/launcher.py
+++ b/repo/pygpt-MHP/src/pygpt_net/launcher.py
@@ -43,6 +43,7 @@ class Launcher:
         self.debug = False
         self.force_legacy = False
         self.force_disable_gpu = False
+        self.force_enable_gpu = False
         self.shortcut_filter = None
         self.workdir = None
 
@@ -70,6 +71,12 @@ class Launcher:
             "--disable-gpu",
             required=False,
             help="force disable OpenGL (1=disabled, 0=enabled)",
+        )
+        parser.add_argument(
+            "-g",
+            "--enable-gpu",
+            required=False,
+            help="force enable OpenGL (1=enabled, 0=disabled)",
         )
         parser.add_argument(
             "-w",
@@ -100,6 +107,11 @@ class Launcher:
         if "disable-gpu" in args and args["disable-gpu"] == "1":
             print("** Force disable GPU enabled")
             self.force_disable_gpu = True
+
+        # force enable GPU
+        if "enable-gpu" in args and args["enable-gpu"] == "1":
+            print("** Force enable GPU enabled")
+            self.force_enable_gpu = True
 
         # force set workdir
         if "workdir" in args and args["workdir"] is not None:

--- a/repo/pygpt-MHP/src/pygpt_net/ui/main.py
+++ b/repo/pygpt-MHP/src/pygpt_net/ui/main.py
@@ -105,6 +105,8 @@ class MainWindow(QMainWindow, QtStyleTools):
                 self.core.config.set("render.engine", "legacy")
             if "disable-gpu" in self.args and self.args["disable-gpu"] == "1":
                 self.core.config.set("render.open_gl", False)
+            if "enable-gpu" in self.args and self.args["enable-gpu"] == "1":
+                self.core.config.set("render.open_gl", True)
 
         # from log level
         if self.core.config.get("log.level") in ["debug", "info"]:


### PR DESCRIPTION
## Summary
- add `--enable-gpu` flag to launcher to enable OpenGL
- support new argument in UI
- document hardware acceleration enablement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f29f31b20832bbfff88a5f8dbeb22