### PR TITLE
Add integrity utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,18 @@ file or directory with `--format` specifying the target type (e.g.
 `JPEG`, `PNG`). Converted files are saved alongside the originals or in a
 specified output directory.
 
+### File Integrity Checks
+
+Use `monkey_head.utils.integrity` to verify that important files have not been
+modified. Create a JSON manifest mapping each path to its SHA-256 digest and run
+
+```bash
+python -m monkey_head.utils.integrity manifest.json
+```
+
+The command prints any files that fail verification or `All files verified` if
+every digest matches.
+
 ### Docker and Kubernetes Utilities
 
 The `scripts/` directory contains helper scripts for container management:

--- a/monkey_head/utils/integrity.py
+++ b/monkey_head/utils/integrity.py
@@ -1,0 +1,66 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.11.2025
+# ==================================================
+"""Utilities for verifying file integrity."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+def sha256_digest(file_path: str | Path) -> str:
+    """Return the SHA-256 hex digest of a file."""
+    path = Path(file_path)
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify_checksums(checksums: Mapping[str | Path, str]) -> list[str]:
+    """Check each path against its expected digest.
+
+    Parameters
+    ----------
+    checksums:
+        Mapping of file paths to expected SHA-256 digests.
+
+    Returns
+    -------
+    list[str]
+        A list of file paths that failed verification. The list is empty when
+        all files match their expected digests.
+    """
+    failed: list[str] = []
+    for path, expected in checksums.items():
+        actual = sha256_digest(path)
+        if actual != expected:
+            failed.append(str(path))
+    return failed
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(description="Verify file checksums")
+    parser.add_argument("manifest", help="JSON file of path -> sha256")
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    data = json.loads(manifest_path.read_text())
+    failures = verify_checksums(data)
+    if failures:
+        print("Integrity check failed:")
+        for f in failures:
+            print(f" - {f}")
+    else:
+        print("All files verified")

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,18 @@
+import hashlib
+from monkey_head.utils.integrity import sha256_digest, verify_checksums
+
+
+def test_sha256_digest(tmp_path):
+    file = tmp_path / "data.txt"
+    content = b"hello world"
+    file.write_bytes(content)
+    assert sha256_digest(file) == hashlib.sha256(content).hexdigest()
+
+
+def test_verify_checksums(tmp_path):
+    file = tmp_path / "data.txt"
+    file.write_text("data")
+    good = {str(file): hashlib.sha256(b"data").hexdigest()}
+    assert verify_checksums(good) == []
+    bad = {str(file): "deadbeef"}
+    assert verify_checksums(bad) == [str(file)]


### PR DESCRIPTION
## Summary
- add `integrity` module with SHA-256 checksum helpers
- document integrity check usage
- test `sha256_digest` and `verify_checksums`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3c5e54e0832bb172ee8aee61c6be