### PR TITLE
Improve program loading via lazy imports

### DIFF
--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -12,6 +12,7 @@ os.environ.setdefault("MONKEY_HEAD_LIGHT_IMPORTS", "1")
 import platform
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
+import threading
 from pathlib import Path
 import sys
 
@@ -334,19 +335,19 @@ class MainUI:
         self.log_message("Starting installation...")
         self.status_label.config(text="Status: Installing")
         self.progress.start()
-        self.executor.submit(self.run_script, self.install_path)
+        self._submit(self.run_script, self.install_path)
 
     def run(self):
         self.log_message("Launching application...")
         self.status_label.config(text="Status: Running")
         self.progress.start()
-        self.executor.submit(self.run_script, self.run_path)
+        self._submit(self.run_script, self.run_path)
 
     def update(self):
         self.log_message("Starting update...")
         self.status_label.config(text="Status: Updating")
         self.progress.start()
-        self.executor.submit(self.run_script, self.update_path)
+        self._submit(self.run_script, self.update_path)
 
     def check_license(self):
         """Display the license agreement if not yet accepted."""
@@ -365,6 +366,13 @@ class MainUI:
             "Data Summary", f"Prompts: {prompts}\nMemory files: {memory_files}"
         )
 
+    def _submit(self, func, *args):
+        """Run *func* asynchronously using the executor or a fallback thread."""
+        if getattr(self, "executor", None) is not None:
+            self.executor.submit(func, *args)
+        else:  # pragma: no cover - used in tests without __init__
+            threading.Thread(target=func, args=args).start()
+
     def _run_container_func(self, func, *args):
         try:
             func(*args)
@@ -379,49 +387,49 @@ class MainUI:
         self.log_message("Building Docker image...")
         self.status_label.config(text="Status: Building")
         self.progress.start()
-        self.executor.submit(self._run_container_func, build_docker_image)
+        self._submit(self._run_container_func, build_docker_image)
 
     def start_containers(self):
         self.log_message("Starting containers...")
         self.status_label.config(text="Status: Starting")
         self.progress.start()
-        self.executor.submit(self._run_container_func, manage_containers)
+        self._submit(self._run_container_func, manage_containers)
 
     def stop_containers(self):
         self.log_message("Stopping containers...")
         self.status_label.config(text="Status: Stopping")
         self.progress.start()
-        self.executor.submit(self._run_container_func, stop_containers)
+        self._submit(self._run_container_func, stop_containers)
 
     def cleanup_images(self):
         self.log_message("Pruning images...")
         self.status_label.config(text="Status: Cleaning")
         self.progress.start()
-        self.executor.submit(self._run_container_func, cleanup_images)
+        self._submit(self._run_container_func, cleanup_images)
 
     def manage_volumes(self):
         self.log_message("Managing volumes...")
         self.status_label.config(text="Status: Volumes")
         self.progress.start()
-        self.executor.submit(self._run_container_func, manage_volumes)
+        self._submit(self._run_container_func, manage_volumes)
 
     def manage_networks(self):
         self.log_message("Managing networks...")
         self.status_label.config(text="Status: Networks")
         self.progress.start()
-        self.executor.submit(self._run_container_func, manage_networks)
+        self._submit(self._run_container_func, manage_networks)
 
     def deploy_kubernetes(self):
         self.log_message("Deploying Kubernetes resources...")
         self.status_label.config(text="Status: Deploying")
         self.progress.start()
-        self.executor.submit(self._run_container_func, deploy_kubernetes)
+        self._submit(self._run_container_func, deploy_kubernetes)
 
     def cleanup_kubernetes(self):
         self.log_message("Cleaning Kubernetes resources...")
         self.status_label.config(text="Status: Cleaning")
         self.progress.start()
-        self.executor.submit(self._run_container_func, cleanup_kubernetes)
+        self._submit(self._run_container_func, cleanup_kubernetes)
 
     def scale_deployment_prompt(self):
         name = simpledialog.askstring("Deployment", "Deployment name:")
@@ -433,7 +441,7 @@ class MainUI:
         self.log_message(f"Scaling {name} to {replicas}...")
         self.status_label.config(text="Status: Scaling")
         self.progress.start()
-        self.executor.submit(self._run_container_func, scale_deployment, name, replicas)
+        self._submit(self._run_container_func, scale_deployment, name, replicas)
 
     def get_pod_logs_prompt(self):
         pod = simpledialog.askstring("Pod", "Pod name:")
@@ -442,7 +450,7 @@ class MainUI:
         self.log_message(f"Fetching logs for {pod}...")
         self.status_label.config(text="Status: Logs")
         self.progress.start()
-        self.executor.submit(self._get_logs, pod)
+        self._submit(self._get_logs, pod)
 
     def convert_media_prompt(self):
         if filedialog is None:
@@ -461,7 +469,7 @@ class MainUI:
         self.log_message(f"Converting {src} -> {dst}...")
         self.status_label.config(text="Status: Converting")
         self.progress.start()
-        self.executor.submit(self._convert_media_thread, src, dst, bitrate, codec)
+        self._submit(self._convert_media_thread, src, dst, bitrate, codec)
 
     def _convert_media_thread(self, src, dst, bitrate, codec):
         try:
@@ -487,12 +495,12 @@ class MainUI:
     def launch_simple_chat(self):
         """Open the simple chat demo in a background thread."""
         self.log_message("Launching simple chat demo...")
-        self.executor.submit(run_simple_chat)
+        self._submit(run_simple_chat)
 
     def launch_ai_tools(self):
         """Open the AI tools window in a background thread."""
         self.log_message("Launching AI tools...")
-        self.executor.submit(run_ai_tools)
+        self._submit(run_ai_tools)
 
     def on_close(self):
         """Shutdown the executor and close the UI."""

--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -11,54 +11,62 @@
 from .formatter import format_text
 from .gencore import generate_core_data
 from .logging_setup import configure_logging
+from .utils.logger import get_logger
+from .utils.sorting import list_files_by_mtime, natural_sort
+import importlib
 import os
 
-if not os.environ.get("MONKEY_HEAD_LIGHT_IMPORTS"):
-    try:
-        from . import subos_manager
-    except Exception:  # pragma: no cover - optional dependency
-        subos_manager = None
-else:
-    subos_manager = None
-from .utils.logger import get_logger
+LIGHT_IMPORTS = bool(os.environ.get("MONKEY_HEAD_LIGHT_IMPORTS"))
 
-try:
-    from .convert_png_to_jpeg import convert_png_to_jpeg
-except Exception:  # pragma: no cover - optional dependency
-    convert_png_to_jpeg = None
+_lazy_modules = {
+    "subos_manager": "monkey_head.subos_manager",
+}
 
-try:
-    from .pdf_pre_digestion import pdf_pre_digestion
-except Exception:  # pragma: no cover - optional dependency
-    pdf_pre_digestion = None
-from .media_conversion import (
-    convert_audio,
-    convert_video,
-    convert_file,
-    extract_audio,
-    convert_media,
-)
-from .utils.sorting import list_files_by_mtime, natural_sort
-from .pdf_utils import list_available_pdfs
-try:
-    from .pdf_chat import load_pdf_pages, answer_question, chat_with_pdf
-except Exception:  # pragma: no cover - optional dependency
-    load_pdf_pages = None
-    answer_question = None
-    chat_with_pdf = None
+_lazy_functions = {
+    "convert_png_to_jpeg": ("monkey_head.convert_png_to_jpeg", "convert_png_to_jpeg"),
+    "pdf_pre_digestion": ("monkey_head.pdf_pre_digestion", "pdf_pre_digestion"),
+    "convert_audio": ("monkey_head.media_conversion", "convert_audio"),
+    "convert_video": ("monkey_head.media_conversion", "convert_video"),
+    "convert_file": ("monkey_head.media_conversion", "convert_file"),
+    "extract_audio": ("monkey_head.media_conversion", "extract_audio"),
+    "convert_media": ("monkey_head.media_conversion", "convert_media"),
+    "list_available_pdfs": ("monkey_head.pdf_utils", "list_available_pdfs"),
+    "load_pdf_pages": ("monkey_head.pdf_chat", "load_pdf_pages"),
+    "answer_question": ("monkey_head.pdf_chat", "answer_question"),
+    "chat_with_pdf": ("monkey_head.pdf_chat", "chat_with_pdf"),
+    "train_from_chat_and_pdfs": ("monkey_head.chat_learning", "train_from_chat_and_pdfs"),
+    "train_from_project_sources": ("monkey_head.tensorflow_feed", "train_from_project_sources"),
+}
 
-if os.environ.get("MONKEY_HEAD_LIGHT_IMPORTS"):
-    train_from_chat_and_pdfs = None
-    train_from_project_sources = None
-else:
-    try:  # pragma: no cover - optional dependency
-        from .chat_learning import train_from_chat_and_pdfs
-    except Exception:
-        train_from_chat_and_pdfs = None
-    try:  # pragma: no cover - optional dependency
-        from .tensorflow_feed import train_from_project_sources
-    except Exception:
-        train_from_project_sources = None
+_light_skip = {"subos_manager", "train_from_chat_and_pdfs", "train_from_project_sources"}
+
+
+def __getattr__(name: str):
+    """Lazy-load optional modules and functions."""
+    if name in _lazy_modules:
+        if LIGHT_IMPORTS and name in _light_skip:
+            return None
+        try:
+            module = importlib.import_module(_lazy_modules[name])
+        except Exception:  # pragma: no cover - optional dependency
+            value = None
+        else:
+            value = module
+        globals()[name] = value
+        return value
+    if name in _lazy_functions:
+        if LIGHT_IMPORTS and name in _light_skip:
+            return None
+        module_name, attr = _lazy_functions[name]
+        try:
+            module = importlib.import_module(module_name)
+            value = getattr(module, attr)
+        except Exception:  # pragma: no cover - optional dependency
+            value = None
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # Initialize project-wide logging as soon as the package is imported
 configure_logging()


### PR DESCRIPTION
## Summary
- lazily import heavy optional modules in `monkey_head.__init__`
- import `threading` in `gui.main_ui` and provide `_submit` helper
- use `_submit` to fall back to threads when `ThreadPoolExecutor` isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f400d751c832bb34e7da9f128e6f6