### PR TITLE
Implement git clone fallback

### DIFF
--- a/monkey_head/services/environment_setup.py
+++ b/monkey_head/services/environment_setup.py
@@ -20,11 +20,24 @@ DEFAULT_REPO_URL = "https://github.com/DylanLRPollock/Monkey-Head-Project.git"
 def clone_repository(
     repo_url: str = DEFAULT_REPO_URL, dest: str = "~/Source/repo"
 ) -> None:
-    """Clone the repository to the given destination."""
+    """Clone the repository to the given destination.
+
+    If cloning fails but the destination already contains a ``.git``
+    directory, the existing repository is used as a fallback.
+    """
     logger.info("Cloning repository...")
     dest_path = os.path.expanduser(dest)
     os.makedirs(os.path.dirname(dest_path), exist_ok=True)
-    run_command(["git", "clone", repo_url, dest_path], check=True)
+    try:
+        run_command(["git", "clone", repo_url, dest_path], check=True)
+    except Exception as exc:  # pragma: no cover - network or git failure
+        git_dir = os.path.join(dest_path, ".git")
+        if os.path.isdir(git_dir):
+            logger.warning(
+                "Clone failed (%s). Using existing repository at %s", exc, dest_path
+            )
+        else:
+            raise
 
 
 def setup_python_env(dest: str = "~/Source/repo") -> None:

--- a/tests/test_environment_setup_git.py
+++ b/tests/test_environment_setup_git.py
@@ -1,9 +1,11 @@
 from monkey_head.services.environment_setup import (
+    clone_repository,
     checkout_branch,
     pull_latest,
     commit_and_push,
 )
 from unittest.mock import patch
+import pytest
 
 
 def test_checkout_branch():
@@ -25,3 +27,38 @@ def test_commit_and_push():
         run.assert_any_call(["git", "add", "."], cwd="/tmp/repo")
         run.assert_any_call(["git", "commit", "-m", "msg"], cwd="/tmp/repo")
         run.assert_any_call(["git", "push", "origin", "main"], cwd="/tmp/repo")
+
+
+def test_clone_repository_fallback():
+    """Clone should fall back to existing repo on failure."""
+    with patch(
+        "monkey_head.services.environment_setup.run_command",
+        side_effect=RuntimeError("git error"),
+    ) as run, patch(
+        "monkey_head.services.environment_setup.os.path.isdir",
+        side_effect=lambda p: p.endswith(".git"),
+    ) as isdir, patch(
+        "monkey_head.services.environment_setup.logger.warning"
+    ) as warn, patch(
+        "monkey_head.services.environment_setup.os.makedirs"
+    ):
+        clone_repository(dest="/tmp/repo")
+        run.assert_called_once()
+        isdir.assert_called()
+        warn.assert_called_once()
+
+
+def test_clone_repository_error():
+    """Clone should raise if repo absent on failure."""
+    with patch(
+        "monkey_head.services.environment_setup.run_command",
+        side_effect=RuntimeError("git error"),
+    ) as run, patch(
+        "monkey_head.services.environment_setup.os.path.isdir",
+        return_value=False,
+    ), patch(
+        "monkey_head.services.environment_setup.os.makedirs"
+    ):
+        with pytest.raises(RuntimeError):
+            clone_repository(dest="/tmp/repo")
+        run.assert_called_once()


### PR DESCRIPTION
## Summary
- add fallback handling to `clone_repository`
- test fallback logic in `test_environment_setup_git`

## Testing
- `pip install flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4668add8832b822940fb9275cf17