### PR TITLE
Fix CLI startup when GUI deps missing

### DIFF
--- a/run.py
+++ b/run.py
@@ -66,7 +66,10 @@ def _load_cli() -> "callable":
         sub_dir = Path(__file__).parent / "repo" / "pygpt-MHP" / "src"
         if sub_dir.exists() and str(sub_dir.resolve()) not in sys.path:
             sys.path.insert(0, str(sub_dir.resolve()))
-        from pygpt_net.app import run as cli_run
+        try:
+            from pygpt_net.app import run as cli_run
+        except Exception:  # pragma: no cover - missing GUI deps
+            return minimal_run
 
     return cli_run
 

--- a/tests/test_load_cli.py
+++ b/tests/test_load_cli.py
@@ -1,0 +1,15 @@
+import builtins
+import run
+
+
+def test_load_cli_fallback(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name.startswith("pygpt_net"):
+            raise ModuleNotFoundError
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    loader = run._load_cli()
+    assert loader is run.minimal_run


### PR DESCRIPTION
## Summary
- fallback to `minimal_run` when GUI dependencies like `PySide6` are missing
- add test ensuring `_load_cli` returns `minimal_run` when `pygpt_net` can't import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f470f3dd0832bac24de3bc8138a52