### PR TITLE
Add Docker dev environment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ The `scripts/` directory contains helper scripts for container management:
 ```bash
 ./scripts/docker_setup.sh    # build image and start compose stack
 ./scripts/docker_cleanup.sh  # stop containers and prune resources
+./scripts/docker_dev_setup.sh # build image and start dev compose stack
 ./scripts/k8s_setup.sh       # apply manifests in k8s/
 ./scripts/k8s_cleanup.sh     # remove Kubernetes resources
 ```
@@ -465,6 +466,8 @@ For day-to-day development it is recommended to work in a Python virtual environ
 Create one with `python -m venv venv` and install dependencies using
 `pip install -r requirements.txt`. Docker users can spin up
 `docker-compose up` for an isolated environment that mirrors production.
+For a more complete stack with PostgreSQL and extra development tooling,
+use `./scripts/docker_dev_setup.sh` (or run `docker compose -f compose-dev.yaml up -d`).
 When adding new modules, format the code with `black` and run
 `flake8` and `pytest` before opening a pull request.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,12 +67,16 @@ To set up your development environment, follow these steps:
 
 3. **Run Docker:**
    - Build the Docker image:
+   ```bash
+    docker build -t monkey-head-project .
+    ```
+  - Run the Docker container:
+    ```bash
+    docker run -p 8000:8000 monkey-head-project
+    ```
+   - Or start the development stack with PostgreSQL:
      ```bash
-     docker build -t monkey-head-project .
-     ```
-   - Run the Docker container:
-     ```bash
-     docker run -p 8000:8000 monkey-head-project
+     ./scripts/docker_dev_setup.sh
      ```
 
 4. **Run Tests:**

--- a/scripts/docker_dev_setup.sh
+++ b/scripts/docker_dev_setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated:   06.11.2025
+# ==================================================
+set -e
+
+# Build Docker image
+docker build -t monkey-head-project:latest .
+
+# Start services using compose-dev.yaml
+if [ -f compose-dev.yaml ]; then
+    docker compose -f compose-dev.yaml up -d
+fi
+
+docker ps


### PR DESCRIPTION
## Summary
- add `docker_dev_setup.sh` script to spin up compose-dev stack
- document dev environment script in README
- mention dev stack in contributing guide

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f4d7f84e4832b8ca2e5f3bf1583a6