### PR TITLE
Enable Docker and K8s options in run.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ The `scripts/` directory contains helper scripts for container management:
 ./scripts/k8s_setup.sh       # apply manifests in k8s/
 ./scripts/k8s_cleanup.sh     # remove Kubernetes resources
 ```
+You can also manage containers directly through `run.py`:
+
+```bash
+python run.py --docker-compose  # start the Docker Compose stack
+python run.py --kubernetes      # deploy the Kubernetes manifests
+```
 
 Programmatic helpers for Kubernetes lives in
 `monkey_head.services.container_management`. Functions like

--- a/run.md
+++ b/run.md
@@ -10,6 +10,8 @@ This guide explains the different ways to launch and test the project.
 - `python run.py --simple-chat` – open a simple Tkinter demo.
 - `python run.py --module package.module[:func]` – execute a module's callable.
 - `python run.py --system-check` – perform environment checks and exit.
+- `python run.py --docker-compose` – build and start the Docker Compose stack.
+- `python run.py --kubernetes` – deploy manifests from the `k8s/` directory.
 
 ## Helper Scripts
 

--- a/run.py
+++ b/run.py
@@ -122,6 +122,16 @@ def main() -> None:
         help="Run environment checks and exit",
     )
     parser.add_argument(
+        "--docker-compose",
+        action="store_true",
+        help="Build image and start Docker Compose stack",
+    )
+    parser.add_argument(
+        "--kubernetes",
+        action="store_true",
+        help="Deploy resources using manifests in k8s/",
+    )
+    parser.add_argument(
         "--workdir",
         type=str,
         help="Set the working directory (default: project directory)",
@@ -158,6 +168,18 @@ def main() -> None:
         from monkey_head.core.system_checks import system_check
 
         system_check()
+        return
+
+    if args.docker_compose:
+        from monkey_head.services.container_management import manage_containers
+
+        manage_containers()
+        return
+
+    if args.kubernetes:
+        from monkey_head.services.container_management import deploy_kubernetes
+
+        deploy_kubernetes()
         return
 
     from monkey_head.core.system_checks import check_os_support, check_python_version

--- a/tests/test_run_container_opts.py
+++ b/tests/test_run_container_opts.py
@@ -1,0 +1,33 @@
+from run import main
+
+
+def test_run_docker_compose(monkeypatch):
+    called = {}
+
+    def fake_manage():
+        called['docker'] = True
+
+    monkeypatch.setattr('monkey_head.services.container_management.manage_containers', fake_manage)
+    monkeypatch.setattr('monkey_head.core.system_checks.check_os_support', lambda: None)
+    monkeypatch.setattr('monkey_head.core.system_checks.check_python_version', lambda: None)
+    monkeypatch.setattr('run.launch_gui', lambda: None)
+    monkeypatch.setattr('run._load_cli', lambda: lambda: None)
+    monkeypatch.setattr('sys.argv', ['run.py', '--docker-compose'])
+    main()
+    assert called.get('docker') is True
+
+
+def test_run_kubernetes(monkeypatch):
+    called = {}
+
+    def fake_deploy():
+        called['k8s'] = True
+
+    monkeypatch.setattr('monkey_head.services.container_management.deploy_kubernetes', fake_deploy)
+    monkeypatch.setattr('monkey_head.core.system_checks.check_os_support', lambda: None)
+    monkeypatch.setattr('monkey_head.core.system_checks.check_python_version', lambda: None)
+    monkeypatch.setattr('run.launch_gui', lambda: None)
+    monkeypatch.setattr('run._load_cli', lambda: lambda: None)
+    monkeypatch.setattr('sys.argv', ['run.py', '--kubernetes'])
+    main()
+    assert called.get('k8s') is True


### PR DESCRIPTION
## Summary
- add `--docker-compose` and `--kubernetes` options to `run.py`
- document new options in `run.md`
- document container commands in README
- add tests for new run options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4e74ce80832b9b3c501a216aa247