### PR TITLE
Integrate manager UI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ is still available via `python run.py --simple-chat`. To run individual modules
 directly, use `python run.py --module package.module[:func]`.
 You can also perform a quick environment check with
 `python run.py --system-check`.
+For the installer-style program manager launch `python run.py --manager-ui`.
 To use a different working directory pass `--workdir /path/to/dir`.
 
 The GUI now checks whether you've accepted the license on startup and

--- a/run.py
+++ b/run.py
@@ -82,6 +82,19 @@ def launch_gui() -> None:
     pygpt_run(tools=[MonkeyManager()])
 
 
+def launch_manager_ui() -> None:
+    """Start the Tkinter program manager."""
+    from gui.main_ui import MainUI
+    try:
+        import tkinter as tk
+    except Exception as exc:  # pragma: no cover - missing tkinter
+        raise RuntimeError("tkinter is not available") from exc
+
+    root = tk.Tk()
+    MainUI(root)
+    root.mainloop()
+
+
 def main() -> None:
     """Launch the GUI by default with an optional CLI mode."""
 
@@ -132,6 +145,11 @@ def main() -> None:
         help="Deploy resources using manifests in k8s/",
     )
     parser.add_argument(
+        "--manager-ui",
+        action="store_true",
+        help="Launch the Tkinter program manager",
+    )
+    parser.add_argument(
         "--workdir",
         type=str,
         help="Set the working directory (default: project directory)",
@@ -180,6 +198,10 @@ def main() -> None:
         from monkey_head.services.container_management import deploy_kubernetes
 
         deploy_kubernetes()
+        return
+
+    if args.manager_ui:
+        launch_manager_ui()
         return
 
     from monkey_head.core.system_checks import check_os_support, check_python_version

--- a/tests/test_run_manager_ui.py
+++ b/tests/test_run_manager_ui.py
@@ -1,0 +1,17 @@
+from run import main
+
+
+def test_manager_ui(monkeypatch):
+    called = {}
+
+    def fake_manager():
+        called['manager'] = True
+
+    monkeypatch.setattr('run.launch_manager_ui', fake_manager)
+    monkeypatch.setattr('run.launch_gui', lambda: None)
+    monkeypatch.setattr('run._load_cli', lambda: lambda: None)
+    monkeypatch.setattr('monkey_head.core.system_checks.check_os_support', lambda: None)
+    monkeypatch.setattr('monkey_head.core.system_checks.check_python_version', lambda: None)
+    monkeypatch.setattr('sys.argv', ['run.py', '--manager-ui'])
+    main()
+    assert called.get('manager') is True


### PR DESCRIPTION
## Summary
- allow launching the Tkinter program manager from `run.py`
- document the new `--manager-ui` flag
- test manager UI CLI option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f541b3bf4832b86a06fbf77cb90fc