### PR TITLE
Add Home Assistant integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ Additional helpers now include `build_docker_image`, `stop_containers`,
 `cleanup_images`, `manage_networks`, `list_containers`, and `get_container_logs`
 for end-to-end Docker lifecycle management and diagnostics.
 
+Home automation is now supported through `monkey_head.services.home_assistant`.
+These helpers allow the project to call Home Assistant services and query entity
+state via its REST API.
+
 ### Linux (Debian 13) Installation
 
 Run the cross-platform installer with root privileges:

--- a/monkey_head/services/__init__.py
+++ b/monkey_head/services/__init__.py
@@ -1,1 +1,44 @@
+from .container_management import (
+    build_docker_image,
+    cleanup_images,
+    cleanup_kubernetes,
+    get_container_logs,
+    get_pod_logs,
+    list_containers,
+    manage_containers,
+    manage_networks,
+    manage_volumes,
+    scale_deployment,
+    stop_containers,
+)
+from .environment_setup import (
+    checkout_branch,
+    clone_repository,
+    commit_and_push,
+    configure_git,
+    pull_latest,
+    setup_python_env,
+)
+from .home_assistant import call_service, get_state
 
+__all__ = [
+    "build_docker_image",
+    "cleanup_images",
+    "cleanup_kubernetes",
+    "get_container_logs",
+    "get_pod_logs",
+    "list_containers",
+    "manage_containers",
+    "manage_networks",
+    "manage_volumes",
+    "scale_deployment",
+    "stop_containers",
+    "checkout_branch",
+    "clone_repository",
+    "commit_and_push",
+    "configure_git",
+    "pull_latest",
+    "setup_python_env",
+    "call_service",
+    "get_state",
+]

--- a/monkey_head/services/home_assistant.py
+++ b/monkey_head/services/home_assistant.py
@@ -1,0 +1,54 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.12.2025
+# ==================================================
+"""Home Assistant API integration helpers."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Mapping
+
+import requests
+
+DEFAULT_BASE_URL = os.environ.get("HASS_URL", "http://localhost:8123")
+DEFAULT_TOKEN = os.environ.get("HASS_TOKEN", "")
+
+
+def _build_headers(token: str | None = None) -> dict[str, str]:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def call_service(
+    domain: str,
+    service: str,
+    data: Mapping[str, Any] | None = None,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    token: str = DEFAULT_TOKEN,
+) -> Any:
+    """Call a Home Assistant service and return the JSON response."""
+    url = f"{base_url}/api/services/{domain}/{service}"
+    resp = requests.post(url, headers=_build_headers(token), json=data or {})
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_state(
+    entity_id: str,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    token: str = DEFAULT_TOKEN,
+) -> Any:
+    """Return state data for ``entity_id`` via the REST API."""
+    url = f"{base_url}/api/states/{entity_id}"
+    resp = requests.get(url, headers=_build_headers(token))
+    resp.raise_for_status()
+    return resp.json()

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from monkey_head.services.home_assistant import call_service, get_state
+
+
+class DummyResp:
+    def __init__(self, payload=None):
+        self.status_code = 200
+        self._payload = payload or {}
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+def test_call_service():
+    with patch("requests.post", return_value=DummyResp({"ok": True})) as post:
+        result = call_service("light", "toggle", {"entity_id": "light.kitchen"}, base_url="http://hass", token="abc")
+        post.assert_called_once()
+        assert result == {"ok": True}
+
+
+def test_get_state():
+    with patch("requests.get", return_value=DummyResp({"state": "on"})) as get:
+        result = get_state("light.kitchen", base_url="http://hass", token="abc")
+        get.assert_called_once()
+        assert result == {"state": "on"}


### PR DESCRIPTION
## Summary
- integrate Home Assistant via REST API
- expose helpers from services package
- test Home Assistant calls
- document Home Assistant integration

## Testing
- `bash ./run-tests.sh` *(fails: Virtual environment not found)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f693aecb0832ba628f884fcbaa2dd