### PR TITLE
Add command-line support for auto-sort utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ env/
 .DS_Store
 Thumbs.db
 desktop.ini
+
+# Raw input directory
+raw/

--- a/README.md
+++ b/README.md
@@ -499,6 +499,21 @@ to newest:
 python monkey_head/utils/list_by_mtime.py path/to/dir
 ```
 
+`auto-sort.py` organizes files dropped into a `raw` folder at the project root,
+moving them into `memory` subfolders according to file type. Run it without
+arguments to operate on the default directories:
+
+```bash
+python auto-sort.py
+```
+
+Pass a custom base directory if you maintain separate `raw` and `memory`
+folders elsewhere:
+
+```bash
+python auto-sort.py /path/to/base
+```
+
 ---
 
 ## 🔬 Test Hardware

--- a/auto-sort.py
+++ b/auto-sort.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.11.2025
+# ==================================================
+"""Utility to organize files from ``raw`` into ``memory``."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+RAW_DIR = BASE_DIR / "raw"
+MEMORY_DIR = BASE_DIR / "memory"
+
+# map common extensions to existing subfolders
+EXT_MAP = {
+    "jpg": "JPEG",
+    "jpeg": "JPEG",
+    "png": "PNG",
+    "pdf": "PDF",
+    "json": "JSON",
+    "zip": "ZIP",
+    "txt": "TXT",
+}
+
+
+def _unique_move(src: Path, dst_dir: Path) -> Path:
+    """Move ``src`` into ``dst_dir`` ensuring the filename is unique."""
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    dest = dst_dir / src.name
+    if dest.exists():
+        stem, suffix = src.stem, src.suffix
+        count = 1
+        while dest.exists():
+            dest = dst_dir / f"{stem}_{count}{suffix}"
+            count += 1
+    shutil.move(str(src), dest)
+    return dest
+
+
+def sort_raw_files(base_dir: Path | None = None) -> None:
+    """Move files from ``raw`` to ``memory`` categorized by extension."""
+    if base_dir is None:
+        base_dir = BASE_DIR
+    raw = base_dir / "raw"
+    mem = base_dir / "memory"
+    raw.mkdir(exist_ok=True)
+    mem.mkdir(exist_ok=True)
+
+    for item in raw.iterdir():
+        if not item.is_file():
+            continue
+        ext = item.suffix.lower().lstrip(".")
+        folder_name = EXT_MAP.get(ext, ext.upper() if ext else "MISC")
+        _unique_move(item, mem / folder_name)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Sort files from 'raw' into 'memory' by extension"
+    )
+    parser.add_argument(
+        "base",
+        nargs="?",
+        default=BASE_DIR,
+        type=Path,
+        help="Directory containing 'raw' and 'memory' folders",
+    )
+    args = parser.parse_args()
+    sort_raw_files(args.base)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_auto_sort.py
+++ b/tests/test_auto_sort.py
@@ -1,0 +1,36 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.11.2025
+# ==================================================
+from pathlib import Path
+import importlib.util
+
+spec = importlib.util.spec_from_file_location(
+    "auto_sort", Path(__file__).resolve().parents[1] / "auto-sort.py"
+)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)  # type: ignore
+sort_raw_files = module.sort_raw_files
+
+
+def test_auto_sort(tmp_path: Path) -> None:
+    base = tmp_path
+    raw = base / "raw"
+    raw.mkdir()
+    mem = base / "memory"
+    mem.mkdir()
+
+    (raw / "file.txt").write_text("data")
+    (raw / "img.jpg").write_text("image")
+    (raw / "doc.PDF").write_text("pdf")
+
+    sort_raw_files(base)
+
+    assert not any(raw.iterdir())
+    assert (mem / "TXT" / "file.txt").is_file()
+    assert (mem / "JPEG" / "img.jpg").is_file()
+    assert (mem / "PDF" / "doc.PDF").is_file()


### PR DESCRIPTION
## Summary
- expose CLI in `auto-sort.py` for flexible sorting
- document usage of the auto-sort utility in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f70880f18832ba1e5a36fbfb49c55