### PR TITLE
Add function registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,22 @@ to newest:
 python monkey_head/utils/list_by_mtime.py path/to/dir
 ```
 
+### Function Registry
+
+Decorate any standalone function with `register_function` to have it
+automatically added to a global registry. Call `list_functions()` to see
+all registered names:
+
+```python
+from monkey_head.function_registry import register_function, list_functions
+
+@register_function
+def hello(name: str) -> str:
+    return f"Hello {name}"
+
+print(list_functions())  # ["hello", ...]
+```
+
 ---
 
 ## 🔬 Test Hardware

--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -9,6 +9,7 @@
 """Utilities exposed for convenient imports."""
 
 from .formatter import format_text
+from .function_registry import register_function, list_functions, get_functions
 from .gencore import generate_core_data
 from .logging_setup import configure_logging
 import os
@@ -41,6 +42,7 @@ from .media_conversion import (
 from .utils.sorting import list_files_by_mtime, natural_sort
 from .pdf_utils import list_available_pdfs
 from .storage_management import StorageManager
+
 try:
     from .pdf_chat import load_pdf_pages, answer_question, chat_with_pdf
 except Exception:  # pragma: no cover - optional dependency
@@ -85,4 +87,7 @@ __all__ = [
     "load_pdf_pages",
     "answer_question",
     "chat_with_pdf",
+    "register_function",
+    "list_functions",
+    "get_functions",
 ]

--- a/monkey_head/formatter.py
+++ b/monkey_head/formatter.py
@@ -6,6 +6,10 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.08.2025
 # ==================================================
+from .function_registry import register_function
+
+
+@register_function
 def format_text(text, line_length=80):
     """
     Formats a text string to a specified line length.

--- a/monkey_head/function_registry.py
+++ b/monkey_head/function_registry.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+_FUNCTIONS: Dict[str, Callable] = {}
+
+
+def register_function(func: Callable) -> Callable:
+    """Register ``func`` in the global function registry."""
+    _FUNCTIONS[func.__name__] = func
+    return func
+
+
+def list_functions() -> List[str]:
+    """Return a sorted list of registered function names."""
+    return sorted(_FUNCTIONS)
+
+
+def get_functions() -> Dict[str, Callable]:
+    """Return a copy of the function registry."""
+    return dict(_FUNCTIONS)
+
+
+__all__ = ["register_function", "list_functions", "get_functions"]

--- a/monkey_head/pdf_utils.py
+++ b/monkey_head/pdf_utils.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
 import os
+from .function_registry import register_function
 
 
+@register_function
 def list_available_pdfs(pdf_dir: Optional[str | Path] = None) -> List[str]:
     """Return a sorted list of PDF filenames in ``pdf_dir``.
 
@@ -28,6 +30,7 @@ def list_available_pdfs(pdf_dir: Optional[str | Path] = None) -> List[str]:
     return sorted(p.name for p in path.glob("*.pdf"))
 
 
+@register_function
 def find_pdf(filename: str, pdf_dir: Optional[str | Path] = None) -> Optional[Path]:
     """Return the path to ``filename`` within ``pdf_dir`` if it exists."""
     if pdf_dir is None:

--- a/scripts/list_registered_functions.py
+++ b/scripts/list_registered_functions.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Print functions registered in ``monkey_head.function_registry``."""
+
+from monkey_head.function_registry import list_functions
+
+
+def main() -> None:
+    for name in list_functions():
+        print(name)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI utility
+    main()

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -1,0 +1,15 @@
+from monkey_head.function_registry import (
+    register_function,
+    list_functions,
+    get_functions,
+)
+
+
+@register_function
+def _dummy():
+    return "ok"
+
+
+def test_registry():
+    assert "_dummy" in list_functions()
+    assert get_functions()["_dummy"]() == "ok"


### PR DESCRIPTION
## Summary
- provide a simple function registry and registration decorator
- expose registry helpers via `monkey_head.__init__`
- register `format_text`, `list_available_pdfs`, and `find_pdf`
- document usage of `register_function`
- include helper script and tests

## Testing
- `black monkey_head/__init__.py monkey_head/formatter.py monkey_head/pdf_utils.py monkey_head/function_registry.py scripts/list_registered_functions.py tests/test_function_registry.py`
- `flake8 monkey_head/__init__.py monkey_head/formatter.py monkey_head/pdf_utils.py monkey_head/function_registry.py scripts/list_registered_functions.py tests/test_function_registry.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68505973b27c832baa9918398e3c4730