### PR TITLE
Add configuration toggles GUI

### DIFF
--- a/gui/main_ui.py
+++ b/gui/main_ui.py
@@ -41,6 +41,7 @@ from monkey_head.scripts.preload_data import preload_all
 from monkey_head.gui_scaling import apply_scaling
 from monkey_head.simple_chat_gui import run_simple_chat
 from monkey_head.ai_tools_gui import run_ai_tools
+from monkey_head.config_toggle_gui import run_config_toggle_gui
 from monkey_head.services.container_management import (
     build_docker_image,
     cleanup_images,
@@ -191,6 +192,7 @@ class MainUI:
         tools_menu.add_command(label="License", command=self.show_license)
         tools_menu.add_command(label="Data Summary", command=self.show_data_summary)
         tools_menu.add_command(label="Convert Media", command=self.convert_media_prompt)
+        tools_menu.add_command(label="Config Toggles", command=self.show_config_toggles)
         menu_bar.add_cascade(label="Tools", menu=tools_menu)
 
         ai_menu = tk.Menu(menu_bar, tearoff=0, bg=DARK_BG, fg=LIGHT_FG)
@@ -365,6 +367,11 @@ class MainUI:
         messagebox.showinfo(
             "Data Summary", f"Prompts: {prompts}\nMemory files: {memory_files}"
         )
+
+    def show_config_toggles(self):
+        """Open the configuration toggles window in a thread."""
+        self.log_message("Opening config toggles...")
+        self._submit_task(run_config_toggle_gui)
 
     def _run_container_func(self, func, *args):
         try:

--- a/monkey_head/config_toggle_gui.py
+++ b/monkey_head/config_toggle_gui.py
@@ -1,0 +1,92 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.12.2025
+# ==================================================
+"""Simple GUI for toggling common configuration options."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+try:  # pragma: no cover - optional dependency
+    import tkinter as tk
+    from tkinter import messagebox
+except Exception:  # pragma: no cover - can't import GUI libs
+    tk = None
+    messagebox = None
+
+from .config_manager import ConfigManager
+from .gui_scaling import apply_scaling
+from .license_gui import DARK_BG, LIGHT_FG, ACCENT_PURPLE
+
+DEFAULT_CONFIG = "config/pygpt_net/config.json"
+
+TOGGLE_FIELDS = {
+    "access.voice_control": "Voice Control",
+    "access.audio.event.speech": "Speech Synthesis",
+    "access.microphone.notify": "Microphone Notify",
+    "access.audio.notify.execute": "Audio Execute",
+    "access.audio.use_cache": "Use Audio Cache",
+}
+
+
+def update_toggle_settings(config_path: str | Path, settings: dict[str, bool]) -> None:
+    """Update boolean settings in ``config_path``."""
+    manager = ConfigManager(str(config_path))
+    manager.update_settings(settings)
+
+
+def run_config_toggle_gui(config_path: str | Path = DEFAULT_CONFIG) -> None:
+    """Display a window with checkboxes for common toggles."""
+    if tk is None:
+        raise RuntimeError("tkinter is not available")
+
+    manager = ConfigManager(str(config_path))
+
+    root = tk.Tk()
+    apply_scaling(root, os.environ.get("SCREEN_MODE", "1080p"))
+    root.title("Config Toggles")
+    root.configure(bg=DARK_BG)
+
+    vars: dict[str, tk.BooleanVar] = {}
+    for key, label in TOGGLE_FIELDS.items():
+        var = tk.BooleanVar(value=bool(manager.get_setting(key, False)))
+        chk = tk.Checkbutton(
+            root,
+            text=label,
+            variable=var,
+            bg=DARK_BG,
+            fg=LIGHT_FG,
+            selectcolor=ACCENT_PURPLE,
+            activebackground=DARK_BG,
+            activeforeground=LIGHT_FG,
+        )
+        chk.pack(anchor="w", padx=10, pady=5)
+        vars[key] = var
+
+    def on_save() -> None:
+        data = {k: v.get() for k, v in vars.items()}
+        update_toggle_settings(config_path, data)
+        if messagebox is not None:
+            messagebox.showinfo("Config", "Settings saved.")
+        root.destroy()
+
+    tk.Button(
+        root,
+        text="Save",
+        command=on_save,
+        bg=ACCENT_PURPLE,
+        fg=LIGHT_FG,
+        activebackground=ACCENT_PURPLE,
+        activeforeground=LIGHT_FG,
+    ).pack(pady=10)
+
+    root.mainloop()
+
+
+__all__ = ["run_config_toggle_gui", "update_toggle_settings"]

--- a/tests/test_config_toggle_gui.py
+++ b/tests/test_config_toggle_gui.py
@@ -1,0 +1,10 @@
+import json
+from monkey_head.config_toggle_gui import update_toggle_settings
+
+
+def test_update_toggle_settings(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text("{}")
+    update_toggle_settings(cfg, {"foo": True})
+    data = json.loads(cfg.read_text())
+    assert data["foo"] is True


### PR DESCRIPTION
## Summary
- add `config_toggle_gui` module providing Tk toggle GUI for common booleans
- integrate toggle GUI with main menu
- test updating config toggles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685069a88200832ba5d9058ec490070a