### PR TITLE
Improve OS detection fallback

### DIFF
--- a/monkey_head/core/system_checks.py
+++ b/monkey_head/core/system_checks.py
@@ -68,18 +68,24 @@ def check_os_support() -> None:
                 ver_str,
             )
     elif system == "Linux":
-        if distro is None:
-            logger.warning("distro module not available; skipping distribution check")
+        if distro is not None:
+            dist_id = distro.id()
+            codename = str(distro.codename()).lower()
         else:
-            if distro.id() != "debian" or distro.codename().lower() not in {
-                "trixie",
-                "testing",
-            }:
-                logger.warning(
-                    "Unsupported Linux distribution detected (%s %s). Debian Trixie/testing is required.",
-                    distro.id(),
-                    distro.codename(),
-                )
+            release_info = {}
+            if hasattr(platform, "freedesktop_os_release"):
+                try:  # pragma: no cover - platform API may fail
+                    release_info = platform.freedesktop_os_release()
+                except Exception:
+                    release_info = {}
+            dist_id = release_info.get("ID", "").lower()
+            codename = release_info.get("VERSION_CODENAME", "").lower()
+        if dist_id != "debian" or codename not in {"trixie", "testing"}:
+            logger.warning(
+                "Unsupported Linux distribution detected (%s %s). Debian Trixie/testing is required.",
+                dist_id,
+                codename,
+            )
     else:
         logger.warning("Unsupported operating system detected: %s", system)
 

--- a/tests/test_os_check_fallback.py
+++ b/tests/test_os_check_fallback.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+
+from monkey_head.core.system_checks import check_os_support
+
+
+def test_linux_fallback_no_warning():
+    with patch("platform.system", return_value="Linux"), patch(
+        "monkey_head.core.system_checks.distro", None
+    ), patch(
+        "platform.freedesktop_os_release",
+        return_value={"ID": "debian", "VERSION_CODENAME": "trixie"},
+    ), patch("monkey_head.core.system_checks.logger") as log:
+        check_os_support()
+        log.warning.assert_not_called()


### PR DESCRIPTION
## Summary
- better Linux distro detection without distro module
- test freedesktop fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506bf1bbc4832b866ed39ffd7e6e29