### PR TITLE
Add sys code command

### DIFF
--- a/run.py
+++ b/run.py
@@ -22,6 +22,7 @@ import importlib
 import os
 import sys
 from pathlib import Path
+import subprocess
 
 
 def minimal_run() -> None:
@@ -30,6 +31,22 @@ def minimal_run() -> None:
     from monkey_head.pygpt_custom_cli import CustomPyGPT
 
     CustomPyGPT().run_cli()
+
+
+def run_sys_code(cmd: str) -> None:
+    """Execute a system command and print output."""
+    result = subprocess.run(
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.stdout:
+        print(result.stdout.decode(), end="")
+    if result.stderr:
+        print(result.stderr.decode(), end="", file=sys.stderr)
+    if result.returncode != 0:
+        raise RuntimeError(f"Command failed with exit code {result.returncode}")
 
 
 def run_module(target: str) -> None:
@@ -150,6 +167,12 @@ def main() -> None:
         help="Launch the Tkinter program manager",
     )
     parser.add_argument(
+        "--sys-code",
+        type=str,
+        metavar="CMD",
+        help="Execute system command and exit",
+    )
+    parser.add_argument(
         "--workdir",
         type=str,
         help="Set the working directory (default: project directory)",
@@ -202,6 +225,9 @@ def main() -> None:
 
     if args.manager_ui:
         launch_manager_ui()
+        return
+    if args.sys_code:
+        run_sys_code(args.sys_code)
         return
 
     from monkey_head.core.system_checks import check_os_support, check_python_version

--- a/tests/test_run_sys_code.py
+++ b/tests/test_run_sys_code.py
@@ -1,0 +1,25 @@
+from run import main
+import sys
+
+
+def test_run_sys_code(monkeypatch):
+    called = {}
+
+    class FakeProcess:
+        def __init__(self):
+            self.returncode = 0
+            self.stdout = b"output"
+            self.stderr = b""
+
+    def fake_run(cmd, shell=True, stdout=None, stderr=None):
+        called['cmd'] = cmd
+        return FakeProcess()
+
+    monkeypatch.setattr('subprocess.run', fake_run)
+    monkeypatch.setattr('run.launch_gui', lambda: None)
+    monkeypatch.setattr('run._load_cli', lambda: lambda: None)
+    monkeypatch.setattr('monkey_head.core.system_checks.check_os_support', lambda: None)
+    monkeypatch.setattr('monkey_head.core.system_checks.check_python_version', lambda: None)
+    monkeypatch.setattr(sys, 'argv', ['run.py', '--sys-code', 'echo hi'])
+    main()
+    assert called.get('cmd') == 'echo hi'


### PR DESCRIPTION
## Summary
- add `run_sys_code` helper in run.py for executing system commands
- expose new `--sys-code` CLI argument
- test running CLI with the new option

## Testing
- `pytest tests/test_run_sys_code.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68506fa1ca6c832ba34933fbe49f69ef