### PR TITLE
Fix unused imports

### DIFF
--- a/monkey_head/license_cli.py
+++ b/monkey_head/license_cli.py
@@ -7,8 +7,6 @@
 # Updated: 06.11.2025
 # ==================================================
 from pathlib import Path
-from typing import Optional
-
 from .config_manager import ConfigManager
 from .error_handler import ErrorHandler
 

--- a/monkey_head/tensorflow_feed.py
+++ b/monkey_head/tensorflow_feed.py
@@ -15,8 +15,6 @@ import json
 from pathlib import Path
 from typing import List
 
-import fitz  # PyMuPDF
-
 from .chat_learning import train_from_chat_and_pdfs
 
 

--- a/repair.py
+++ b/repair.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
 
-import installer
 import uninstaller
 
 REPO_URL = "https://github.com/DylanLRPollock/Monkey-Head-Project.git"


### PR DESCRIPTION
## Summary
- clean up unused imports in TensorFlow feed utilities, repair helper and license CLI

## Testing
- `bash run-tests.sh --no-cov` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507358d7a0832ba241fe3b8e2ac6a9