### PR TITLE
Allow custom config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ You can also perform a quick environment check with
 `python run.py --system-check`.
 For the installer-style program manager launch `python run.py --manager-ui`.
 To use a different working directory pass `--workdir /path/to/dir`.
+Specify an alternative logging configuration with
+`--config path/to/CONFIG.txt`.
 
 The GUI now checks whether you've accepted the license on startup and
 offers a **Tools** menu. From there you can reopen the license dialog or

--- a/monkey_head/logging_setup.py
+++ b/monkey_head/logging_setup.py
@@ -32,7 +32,17 @@ class CriticalErrorHandler(logging.Handler):
 
 
 def configure_logging(config_path=None):
-    """Configure root logger using settings from CONFIG.txt."""
+    """Configure root logger using settings from CONFIG.txt.
+
+    Parameters
+    ----------
+    config_path : str | None
+        Optional path to the configuration file. When omitted the
+        ``MONKEY_HEAD_CONFIG`` environment variable is consulted. If that
+        is not set, ``config/CONFIG.txt`` under the project root is used.
+    """
+    if config_path is None:
+        config_path = os.environ.get("MONKEY_HEAD_CONFIG")
     if config_path is None:
         base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         config_path = os.path.join(base_dir, "config", "CONFIG.txt")

--- a/run.py
+++ b/run.py
@@ -173,11 +173,19 @@ def main() -> None:
         help="Execute system command and exit",
     )
     parser.add_argument(
+        "--config",
+        type=str,
+        help="Path to CONFIG.txt for logging",
+    )
+    parser.add_argument(
         "--workdir",
         type=str,
         help="Set the working directory (default: project directory)",
     )
     args = parser.parse_args()
+
+    if args.config:
+        os.environ["MONKEY_HEAD_CONFIG"] = os.path.abspath(args.config)
 
     # determine working directory
     if args.workdir:

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,5 +1,4 @@
 import logging
-from pathlib import Path
 
 from monkey_head.logging_setup import configure_logging
 
@@ -8,9 +7,10 @@ def test_configure_logging_creates_log(tmp_path):
     cfg = tmp_path / "cfg.ini"
     log_file = tmp_path / "app.log"
     cfg.write_text(
-        "[logging]\nlog_level = INFO\nlog_file = {}\nlog_max_bytes = 1024\nlog_backup_count = 1\n".format(
-            log_file
-        )
+        (
+            "[logging]\nlog_level = INFO\nlog_file = {}\nlog_max_bytes = 1024\n"
+            "log_backup_count = 1\n"
+        ).format(log_file)
     )
     root_logger = logging.getLogger()
     for h in list(root_logger.handlers):
@@ -43,9 +43,10 @@ def test_critical_error_triggers_gui(monkeypatch, tmp_path):
     cfg = tmp_path / "cfg.ini"
     log_file = tmp_path / "app.log"
     cfg.write_text(
-        "[logging]\nlog_level = INFO\nlog_file = {}\nlog_max_bytes = 1024\nlog_backup_count = 1\n".format(
-            log_file
-        )
+        (
+            "[logging]\nlog_level = INFO\nlog_file = {}\nlog_max_bytes = 1024\n"
+            "log_backup_count = 1\n"
+        ).format(log_file)
     )
     root_logger = logging.getLogger()
     for h in list(root_logger.handlers):
@@ -63,3 +64,21 @@ def test_critical_error_triggers_gui(monkeypatch, tmp_path):
     logger.critical("boom")
     assert dummy_tk.created
     assert calls and "boom" in calls[0][1]
+
+
+def test_env_var_overrides_path(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.ini"
+    log_file = tmp_path / "app.log"
+    cfg.write_text(
+        (
+            "[logging]\nlog_level = INFO\nlog_file = {}\nlog_max_bytes = 1024\n"
+            "log_backup_count = 1\n"
+        ).format(log_file)
+    )
+    root_logger = logging.getLogger()
+    for h in list(root_logger.handlers):
+        root_logger.removeHandler(h)
+    monkeypatch.setenv("MONKEY_HEAD_CONFIG", str(cfg))
+    logger = configure_logging()
+    logger.info("check")
+    assert log_file.exists()

--- a/tests/test_run_config_path.py
+++ b/tests/test_run_config_path.py
@@ -1,0 +1,25 @@
+from run import main
+import os
+
+
+def test_run_sets_config_env(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.ini"
+    cfg.write_text(
+        (
+            "[logging]\nlog_level = INFO\nlog_file = {}/app.log\nlog_max_bytes = 1024\n"
+            "log_backup_count = 1\n"
+        ).format(tmp_path)
+    )
+    monkeypatch.setattr('run.launch_gui', lambda: None)
+    monkeypatch.setattr('run._load_cli', lambda: lambda: None)
+    monkeypatch.setattr('monkey_head.core.system_checks.check_os_support', lambda: None)
+    monkeypatch.setattr(
+        'monkey_head.core.system_checks.check_python_version',
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        'sys.argv',
+        ['run.py', '--config', str(cfg)],
+    )
+    main()
+    assert os.environ.get('MONKEY_HEAD_CONFIG') == str(cfg)


### PR DESCRIPTION
## Summary
- allow overriding CONFIG.txt location through environment variable or `--config`
- expose `--config` in `run.py`
- document new option in README
- test environment variable and CLI argument

## Testing
- `flake8 run.py monkey_head/logging_setup.py tests/test_logging_setup.py tests/test_run_config_path.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850bae8ea80832bb0e1575144252bb4