### PR TITLE
Add reinstall source option

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,11 +85,15 @@ sudo python uninstaller.py  # Linux/macOS
 python uninstaller.py       # Windows
 ```
 
-The `fresh_install.py` script first runs the uninstaller and then reinstalls everything:
+The `fresh_install.py` script first runs the uninstaller and then reinstalls
+everything. Pass `--source github` to clone a new copy from GitHub or omit the
+option to reinstall from local files:
 
 ```bash
-sudo python fresh_install.py  # Linux/macOS
-python fresh_install.py       # Windows
+sudo python fresh_install.py --source github  # Linux/macOS from GitHub
+sudo python fresh_install.py                  # Linux/macOS from local
+python fresh_install.py --source github       # Windows from GitHub
+python fresh_install.py                       # Windows from local
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -453,11 +453,16 @@ The script calls OS-specific cleanup scripts to delete the virtual environment, 
 
 ### Fresh Installation
 
-To completely reset the environment and reinstall everything, run the fresh installer. It first executes the uninstaller and then launches the regular installer:
+To completely reset the environment and reinstall everything, run the fresh
+installer. It first executes the uninstaller and then reinstalls the project.
+Use `--source github` to clone a new copy from GitHub or omit the option to use
+the current files:
 
 ```bash
-sudo python fresh_install.py  # Linux/macOS
-python fresh_install.py       # Windows
+sudo python fresh_install.py --source github  # Linux/macOS from GitHub
+sudo python fresh_install.py                  # Linux/macOS from local
+python fresh_install.py --source github       # Windows from GitHub
+python fresh_install.py                       # Windows from local
 ```
 
 

--- a/fresh_install.py
+++ b/fresh_install.py
@@ -2,14 +2,46 @@
 """Run a clean reinstall of the Monkey Head Project."""
 from __future__ import annotations
 
+import argparse
 import sys
 
 import installer
+import repair
 import uninstaller
 
 
-def run_fresh_install() -> int:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line options."""
+    parser = argparse.ArgumentParser(
+        description="Clean reinstall the Monkey Head Project",
+    )
+    parser.add_argument(
+        "--source",
+        choices=["local", "github"],
+        help="Install from local files or clone from GitHub",
+    )
+    parser.add_argument(
+        "--repo",
+        default=repair.REPO_URL,
+        help="Repository URL when using --source github",
+    )
+    return parser.parse_args(argv)
+
+
+def _prompt_source() -> str:
+    """Interactively prompt for reinstall source."""
+    choice = input("Reinstall from local files or GitHub clone? [l/g]: ").strip().lower()
+    return "github" if choice.startswith("g") else "local"
+
+
+def run_fresh_install(source: str | None = None, repo_url: str = repair.REPO_URL) -> int:
     """Remove existing files and perform a new installation."""
+    if source is None:
+        source = _prompt_source()
+    if source == "github":
+        # repair.run_repair handles uninstallation internally
+        return repair.run_repair(repo_url)
+
     print("Starting fresh installation...")
     uninstall_rc = uninstaller.run_uninstaller()
     if uninstall_rc != 0:
@@ -18,5 +50,10 @@ def run_fresh_install() -> int:
     return installer.run_installer()
 
 
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return run_fresh_install(args.source, args.repo)
+
+
 if __name__ == "__main__":
-    sys.exit(run_fresh_install())
+    sys.exit(main())

--- a/launcher.py
+++ b/launcher.py
@@ -10,6 +10,7 @@ import run
 import installer
 import uninstaller
 import fresh_install
+import repair
 from monkey_head.core.system_checks import system_check
 
 
@@ -22,7 +23,18 @@ def main(argv: list[str] | None = None) -> None:
     sub.add_parser("run", help="Launch the application")
     sub.add_parser("install", help="Run installer")
     sub.add_parser("uninstall", help="Run uninstaller")
-    sub.add_parser("fresh-install", help="Uninstall then reinstall")
+    fresh_parser = sub.add_parser("fresh-install", help="Uninstall then reinstall")
+    fresh_parser.add_argument(
+        "--source",
+        choices=["local", "github"],
+        default="local",
+        help="Install from local files or clone from GitHub",
+    )
+    fresh_parser.add_argument(
+        "--repo",
+        default=repair.REPO_URL,
+        help="Repository URL when using --source github",
+    )
     sub.add_parser("system-check", help="Run environment verification")
 
     args, remainder = parser.parse_known_args(argv)
@@ -33,7 +45,7 @@ def main(argv: list[str] | None = None) -> None:
     if cmd == "uninstall":
         sys.exit(uninstaller.run_uninstaller())
     if cmd == "fresh-install":
-        sys.exit(fresh_install.run_fresh_install())
+        sys.exit(fresh_install.run_fresh_install(args.source, args.repo))
     if cmd == "system-check":
         system_check()
         return

--- a/tests/test_fresh_install.py
+++ b/tests/test_fresh_install.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+import fresh_install
+
+
+def test_fresh_install_local_success():
+    with patch("uninstaller.run_uninstaller", return_value=0) as uninst, patch(
+        "installer.run_installer", return_value=0
+    ) as inst:
+        rc = fresh_install.run_fresh_install("local")
+        assert rc == 0
+        uninst.assert_called_once()
+        inst.assert_called_once()
+
+
+def test_fresh_install_uninstall_fail():
+    with patch("uninstaller.run_uninstaller", return_value=5):
+        assert fresh_install.run_fresh_install("local") == 5
+
+
+def test_fresh_install_github_calls_repair():
+    with patch("repair.run_repair", return_value=0) as rep:
+        rc = fresh_install.run_fresh_install("github", "repo-url")
+        assert rc == 0
+        rep.assert_called_once_with("repo-url")


### PR DESCRIPTION
## Summary
- allow fresh installer to reinstall from local or GitHub repo
- pass reinstall options through launcher
- document reinstall sources in README and INSTALL guides
- test fresh install logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850bdd29088832bb73b5be265de1827