### PR TITLE
Add GIF conversion utility

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -31,6 +31,10 @@ try:
     from .convert_mkv_to_mp4 import convert_mkv_to_mp4
 except Exception:  # pragma: no cover - optional dependency
     convert_mkv_to_mp4 = None
+try:
+    from .convert_video_to_gif import convert_video_to_gif
+except Exception:  # pragma: no cover - optional dependency
+    convert_video_to_gif = None
 
 try:
     from .pdf_pre_digestion import pdf_pre_digestion
@@ -84,6 +88,7 @@ __all__ = [
     "get_logger",
     "convert_png_to_jpeg",
     "convert_mkv_to_mp4",
+    "convert_video_to_gif",
     "pdf_pre_digestion",
     "convert_audio",
     "convert_video",

--- a/monkey_head/convert_video_to_gif.py
+++ b/monkey_head/convert_video_to_gif.py
@@ -1,0 +1,65 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.11.2025
+# ==================================================
+"""Utility to convert video files to GIF using ffmpeg."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+
+def convert_video_to_gif(video_file: str, output_file: str, fps: int = 10) -> None:
+    """Convert a video file to GIF.
+
+    Parameters
+    ----------
+    video_file : str
+        Path to the input video file.
+    output_file : str
+        Path where the GIF will be saved.
+    fps : int, optional
+        Frames per second for the resulting GIF.
+    """
+    if not os.path.exists(video_file):
+        raise FileNotFoundError(f"Video file '{video_file}' not found.")
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        video_file,
+        "-vf",
+        f"fps={fps},scale=320:-1:flags=lanczos",
+        output_file,
+    ]
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.decode("utf-8", "ignore"))
+
+    print(f"Video converted to GIF and saved to '{output_file}'")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Convert a video to GIF.")
+    parser.add_argument("video_file", help="Path to the input video file.")
+    parser.add_argument("output_file", help="Path to the output GIF file.")
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=10,
+        help="Frames per second for the GIF.",
+    )
+    args = parser.parse_args()
+
+    try:
+        convert_video_to_gif(args.video_file, args.output_file, args.fps)
+    except Exception as e:  # pragma: no cover - CLI exception handling
+        print(f"Error: {e}")

--- a/monkey_head/media_conversion.py
+++ b/monkey_head/media_conversion.py
@@ -101,7 +101,11 @@ def convert_media(
     elif src_ext in AUDIO_EXTENSIONS:
         convert_audio(src, dst, bitrate=bitrate)
     elif src_ext in VIDEO_EXTENSIONS:
-        convert_video(src, dst, codec=codec)
+        if dst_ext == ".gif":
+            from .convert_video_to_gif import convert_video_to_gif  # local import
+            convert_video_to_gif(src, dst)
+        else:
+            convert_video(src, dst, codec=codec)
     elif src_ext in IMAGE_EXTENSIONS and dst_ext in IMAGE_EXTENSIONS:
         shutil.copyfile(src, dst)
     else:

--- a/tests/test_convert_video_to_gif.py
+++ b/tests/test_convert_video_to_gif.py
@@ -1,0 +1,57 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.11.2025
+# ==================================================
+import subprocess
+import shutil
+from pathlib import Path
+import importlib.util
+import pytest
+
+if shutil.which("ffmpeg") is None:
+    pytest.skip("ffmpeg not installed", allow_module_level=True)
+
+module_path = (
+    Path(__file__).resolve().parents[1]
+    / "monkey_head"
+    / "convert_video_to_gif.py"
+)
+spec = importlib.util.spec_from_file_location("cvg", module_path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+convert_video_to_gif = module.convert_video_to_gif
+
+
+def _make_mp4(path: Path) -> None:
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=green:s=16x16:d=1",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=d=1",
+            "-shortest",
+            str(path),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def test_convert_video_to_gif(tmp_path: Path) -> None:
+    src = tmp_path / "clip.mp4"
+    dst = tmp_path / "clip.gif"
+    _make_mp4(src)
+    convert_video_to_gif(str(src), str(dst))
+    assert dst.exists() and dst.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add `convert_video_to_gif` helper with CLI
- expose the helper in `monkey_head.__init__`
- support GIF output in `convert_media`
- test GIF conversion

## Testing
- `flake8`
- `pytest -k "video_to_gif or convert_mkv_to_mp4 or convert_png_to_jpeg" -q`
- `pytest tests/test_convert_video_to_gif.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_6851b6d05b34832b859829ef84ae11f6