### PR TITLE
Improve error handling and add tests

### DIFF
--- a/huey/memory/PY/error_handler.py
+++ b/huey/memory/PY/error_handler.py
@@ -6,13 +6,27 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.09.2025
 # ==================================================
+"""Lightweight error handling helpers used across the project."""
+
+from __future__ import annotations
+
 import logging
+from typing import Optional
+
 from .logging_setup import configure_logging
 
 
 class ErrorHandler:
-    def __init__(self, log_file="memory/LOGS/app.log"):
-        # Initialize logging if not already configured
+    """Wrapper around the standard :mod:`logging` utilities.
+
+    The handler ensures that logging is configured exactly once and optionally
+    stores messages in a dedicated log file.  It exposes convenience methods
+    for logging messages and exceptions while keeping the public API minimal.
+    """
+
+    def __init__(self, log_file: Optional[str] = "memory/LOGS/app.log") -> None:
+        """Initialise the handler and attach a file logger if requested."""
+
         logger = configure_logging()
         if log_file:
             file_handler = logging.FileHandler(log_file)
@@ -23,12 +37,27 @@ class ErrorHandler:
             )
             logger.addHandler(file_handler)
 
-    def log_error(self, error_message):
+    def log_error(self, error_message: str) -> None:
+        """Log ``error_message`` at ``ERROR`` level."""
+
         logging.error(error_message)
 
-    def log_info(self, info_message):
+    def log_info(self, info_message: str) -> None:
+        """Log ``info_message`` at ``INFO`` level."""
+
         logging.info(info_message)
 
-    def handle_exception(self, exception):
-        self.log_error(f"Exception occurred: {exception}")
-        # Additional error handling logic
+    def handle_exception(self, exception: Exception, *, raise_error: bool = False) -> None:
+        """Log ``exception`` with traceback and optionally re-raise it.
+
+        Parameters
+        ----------
+        exception:
+            The exception instance to handle.
+        raise_error:
+            When ``True`` the exception is re-raised after being logged.
+        """
+
+        logging.exception("Exception occurred: %s", exception)
+        if raise_error:
+            raise exception

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,32 @@
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "huey" / "memory" / "PY"
+spec = importlib.util.spec_from_file_location(
+    "monkey_head.error_handler",
+    PACKAGE_ROOT / "error_handler.py",
+    submodule_search_locations=[str(PACKAGE_ROOT)],
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules.setdefault("monkey_head", types.ModuleType("monkey_head"))
+sys.modules["monkey_head.error_handler"] = module
+spec.loader.exec_module(module)  # type: ignore[union-attr]
+ErrorHandler = module.ErrorHandler
+
+
+def test_handle_exception_logs_and_reraises(tmp_path, caplog):
+    log_path = tmp_path / "app.log"
+    handler = ErrorHandler(log_file=str(log_path))
+
+    with caplog.at_level(logging.ERROR):
+        handler.handle_exception(ValueError("boom"))
+    assert "Exception occurred: boom" in caplog.text
+    assert log_path.exists()
+
+    with pytest.raises(ValueError):
+        handler.handle_exception(ValueError("again"), raise_error=True)


### PR DESCRIPTION
## Summary
- implement a fully-fledged error handling helper with optional re-raise
- add tests covering logging and exception re-raising

## Testing
- `python -m compileall -q huey/memory/PY`
- `pytest` *(fails: 41 errors)*
- `pytest tests/test_error_handler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895cb5ee9d8832bad5cecb7b47cbff2