### PR TITLE
Improve PDF discovery and wrapper synchronization

### DIFF
--- a/monkey_head/core/system_checks.py
+++ b/monkey_head/core/system_checks.py
@@ -1,0 +1,49 @@
+"""Compatibility layer for :mod:`monkey_head.system_checks`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_module = import_module("monkey_head.system_checks")
+
+__all__ = getattr(_module, "__all__", [name for name in dir(_module) if not name.startswith("_")])
+if "check_python_version" not in __all__:
+    __all__.append("check_python_version")
+
+for _name in __all__:
+    if _name != "check_python_version":
+        globals()[_name] = getattr(_module, _name)
+
+logger = getattr(_module, "logger")
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - proxy
+    return getattr(_module, name)
+
+
+def __setattr__(name: str, value: Any) -> None:  # pragma: no cover - proxy
+    setattr(_module, name, value)
+    globals()[name] = value
+
+
+def check_python_version() -> None:
+    """Warn when running on experimental Python versions.
+
+    This wrapper mirrors :func:`monkey_head.system_checks.check_python_version`
+    but uses the ``logger`` attribute from this proxy module. Tests that patch
+    ``monkey_head.core.system_checks.logger`` therefore observe the expected
+    behaviour without needing to modify the legacy implementation directly.
+    """
+
+    info = getattr(_module, "sys").version_info
+    if isinstance(info, tuple):
+        major, minor = info[0], info[1]
+    else:
+        major = getattr(info, "major", 0)
+        minor = getattr(info, "minor", 0)
+
+    if major == 3 and minor == 13:
+        logger.warning(
+            "Python 3.13 detected. This version is experimental and not fully supported."
+        )

--- a/monkey_head/pdf_utils.py
+++ b/monkey_head/pdf_utils.py
@@ -1,0 +1,80 @@
+"""Utilities for handling project PDF documents."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, Optional
+
+from .function_registry import register_function
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+
+def _iter_pdf_dir_candidates(pdf_dir: str | Path) -> List[Path]:
+    """Return candidate directories for ``pdf_dir`` in order of preference."""
+
+    path = Path(pdf_dir)
+    candidates: List[Path] = [path]
+    if not path.is_absolute():
+        candidates.append(BASE_DIR / path)
+        if path.parts and path.parts[0] != "huey":
+            candidates.append(BASE_DIR / "huey" / path)
+    return candidates
+
+
+def _resolve_pdf_dir(pdf_dir: str | Path) -> Optional[Path]:
+    """Return the first existing directory among the candidate paths."""
+
+    for candidate in _iter_pdf_dir_candidates(pdf_dir):
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+@register_function
+def list_available_pdfs(pdf_dir: Optional[str | Path] = None) -> List[str]:
+    """Return a sorted list of PDF filenames in ``pdf_dir``."""
+
+    if pdf_dir is None:
+        env = os.environ.get("PDF_DIR")
+        if env:
+            pdf_dir = Path(env)
+        else:
+            for candidate in (
+                BASE_DIR / "memory" / "PDF",
+                BASE_DIR / "huey" / "memory" / "PDF",
+            ):
+                if candidate.is_dir():
+                    pdf_dir = candidate
+                    break
+            else:
+                pdf_dir = BASE_DIR / "memory" / "PDF"
+
+    resolved = _resolve_pdf_dir(pdf_dir)
+    if resolved is None:
+        return []
+    return sorted(p.name for p in resolved.glob("*.pdf"))
+
+
+@register_function
+def find_pdf(filename: str, pdf_dir: Optional[str | Path] = None) -> Optional[Path]:
+    """Return the path to ``filename`` within ``pdf_dir`` if it exists."""
+
+    if pdf_dir is None:
+        env = os.environ.get("PDF_DIR")
+        if env:
+            pdf_dir = Path(env)
+        else:
+            candidates = [BASE_DIR / "memory" / "PDF", BASE_DIR / "huey" / "memory" / "PDF"]
+            for candidate in candidates:
+                if candidate.is_dir():
+                    pdf_dir = candidate
+                    break
+            else:
+                pdf_dir = candidates[0]
+    for directory in _iter_pdf_dir_candidates(pdf_dir):
+        candidate = directory / filename
+        if candidate.is_file():
+            return candidate
+    return None

--- a/run.py
+++ b/run.py
@@ -1,0 +1,48 @@
+"""Entry point wrapper for the legacy :mod:`monkey_head.run` module."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any, Callable
+
+_module = import_module("monkey_head.run")
+
+__all__ = getattr(_module, "__all__", [name for name in dir(_module) if not name.startswith("_")])
+for _name in ("main", "launch_gui", "launch_manager_ui", "_load_cli"):
+    if _name not in __all__:
+        __all__.append(_name)
+
+_launch_manager_ui_impl: Callable[..., Any] = getattr(_module, "launch_manager_ui")
+_launch_gui_impl: Callable[..., Any] = getattr(_module, "launch_gui")
+_load_cli_impl: Callable[..., Any] = getattr(_module, "_load_cli")
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - proxy
+    return getattr(_module, name)
+
+
+def launch_manager_ui(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to the real ``launch_manager_ui`` implementation."""
+
+    return _launch_manager_ui_impl(*args, **kwargs)
+
+
+def launch_gui(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to the real ``launch_gui`` implementation."""
+
+    return _launch_gui_impl(*args, **kwargs)
+
+
+def _load_cli(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to the real ``_load_cli`` implementation."""
+
+    return _load_cli_impl(*args, **kwargs)
+
+
+def main(*args: Any, **kwargs: Any) -> Any:
+    """Invoke :func:`monkey_head.run.main` with patched hooks."""
+
+    setattr(_module, "launch_manager_ui", globals()["launch_manager_ui"])
+    setattr(_module, "launch_gui", globals()["launch_gui"])
+    setattr(_module, "_load_cli", globals()["_load_cli"])
+    return _module.main(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add a PDF utility module that searches legacy memory locations when listing and resolving files
- wrap `monkey_head.system_checks` so patched loggers are honoured when warning about Python 3.13
- update the top-level `run` wrapper to pass through patched hooks for the manager UI and CLI helpers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e209434f10832b8a05ec9d495313ce