### PR TITLE
Add system checks and registry modules to monkey_head package

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -1,0 +1,43 @@
+"""Monkey Head compatibility package."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+from . import core  # noqa: F401
+from . import function_registry, pdf_utils, system_checks  # noqa: F401
+
+__all__ = [
+    "core",
+    "function_registry",
+    "pdf_utils",
+    "system_checks",
+]
+
+_LEGACY_PREFIX = "huey.memory.PY"
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically load legacy modules shipped with the project."""
+
+    try:
+        module = import_module(f"{_LEGACY_PREFIX}.{name}")
+    except ModuleNotFoundError as exc:  # pragma: no cover - error path
+        raise AttributeError(f"module 'monkey_head' has no attribute {name!r}") from exc
+    globals()[name] = module
+    return module
+
+
+def __dir__() -> list[str]:  # pragma: no cover - convenience helper
+    return sorted(set(__all__) | set(globals()) | _legacy_exports())
+
+
+def _legacy_exports() -> set[str]:
+    """Return a set of legacy module names for interactive discovery."""
+
+    try:
+        legacy_pkg = import_module(_LEGACY_PREFIX)
+    except ModuleNotFoundError:  # pragma: no cover - legacy path missing
+        return set()
+    return set(getattr(legacy_pkg, "__all__", ()))

--- a/monkey_head/core/__init__.py
+++ b/monkey_head/core/__init__.py
@@ -1,0 +1,7 @@
+"""Core utilities for the Monkey Head compatibility layer."""
+
+from __future__ import annotations
+
+from . import system_checks
+
+__all__ = ["system_checks"]

--- a/monkey_head/function_registry.py
+++ b/monkey_head/function_registry.py
@@ -1,0 +1,28 @@
+"""Simple function registry used by high level utilities."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List
+
+_FUNCTIONS: Dict[str, Callable] = {}
+
+__all__ = ["register_function", "list_functions", "get_functions"]
+
+
+def register_function(func: Callable) -> Callable:
+    """Register ``func`` in the global registry."""
+
+    _FUNCTIONS[func.__name__] = func
+    return func
+
+
+def list_functions() -> List[str]:
+    """Return a sorted list of registered function names."""
+
+    return sorted(_FUNCTIONS)
+
+
+def get_functions() -> Dict[str, Callable]:
+    """Return a copy of the registered functions."""
+
+    return dict(_FUNCTIONS)

--- a/monkey_head/logging_setup.py
+++ b/monkey_head/logging_setup.py
@@ -1,0 +1,113 @@
+"""Logging helpers for the Monkey Head compatibility layer."""
+
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import os
+from configparser import ConfigParser
+from pathlib import Path
+from typing import Optional
+
+try:  # pragma: no cover - optional GUI dependency
+    import tkinter as tk
+    from tkinter import messagebox
+except Exception:  # pragma: no cover - can't import GUI libs
+    tk = None  # type: ignore[assignment]
+    messagebox = None  # type: ignore[assignment]
+
+__all__ = ["CriticalErrorHandler", "configure_logging"]
+
+
+class CriticalErrorHandler(logging.Handler):
+    """Display a GUI dialog for critical log records."""
+
+    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - GUI
+        if messagebox is None or tk is None:
+            return
+        if record.levelno >= logging.CRITICAL:
+            try:
+                root = tk.Tk()
+                root.withdraw()
+                messagebox.showerror("Critical Error", self.format(record))
+            except Exception:
+                pass
+            finally:
+                try:
+                    root.destroy()
+                except Exception:
+                    pass
+
+
+def _resolve_config_path(config_path: Optional[str]) -> Path:
+    if config_path is not None:
+        return Path(config_path)
+
+    env_path = os.environ.get("MONKEY_HEAD_CONFIG")
+    if env_path:
+        return Path(env_path)
+
+    base_dir = Path(__file__).resolve().parents[1]
+    return base_dir / "config" / "CONFIG.txt"
+
+
+def configure_logging(config_path: Optional[str] = None) -> logging.Logger:
+    """Configure the root logger using settings from the configuration file."""
+
+    cfg_path = _resolve_config_path(config_path)
+    parser = ConfigParser()
+    if cfg_path.exists():
+        parser.read(cfg_path)
+        log_level = parser.get("logging", "log_level", fallback="INFO").upper()
+        log_file = parser.get(
+            "logging",
+            "log_file",
+            fallback="memory/LOGS/monkey_head.log",
+        )
+        max_bytes_raw = parser.get("logging", "log_max_bytes", fallback="10485760")
+        backup_count_raw = parser.get("logging", "log_backup_count", fallback="5")
+        try:
+            max_bytes = int(str(max_bytes_raw).split("#")[0].strip())
+        except (TypeError, ValueError):
+            max_bytes = 10_485_760
+        try:
+            backup_count = int(str(backup_count_raw).split("#")[0].strip())
+        except (TypeError, ValueError):
+            backup_count = 5
+    else:
+        log_level = "INFO"
+        log_file = "memory/LOGS/monkey_head.log"
+        max_bytes = 10_485_760
+        backup_count = 5
+
+    logger = logging.getLogger()
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(getattr(logging, log_level, logging.INFO))
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+    log_path = Path(log_file)
+    log_dir = log_path.parent
+    if log_dir and not log_dir.exists():  # pragma: no cover - fs access
+        try:
+            log_dir.mkdir(parents=True, exist_ok=True)
+        except Exception:
+            log_path = Path(log_path.name)
+
+    file_handler = logging.handlers.RotatingFileHandler(
+        log_path, maxBytes=max_bytes, backupCount=backup_count
+    )
+    file_handler.setFormatter(formatter)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+
+    gui_handler = CriticalErrorHandler()
+    gui_handler.setLevel(logging.CRITICAL)
+    gui_handler.setFormatter(formatter)
+
+    logger.addHandler(file_handler)
+    logger.addHandler(stream_handler)
+    logger.addHandler(gui_handler)
+    return logger

--- a/monkey_head/system_checks.py
+++ b/monkey_head/system_checks.py
@@ -1,0 +1,166 @@
+"""System environment checks for the Monkey Head compatibility layer."""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import shutil
+import sys
+from typing import Dict
+
+try:  # pragma: no cover - optional dependency
+    import distro  # type: ignore
+except Exception:  # pragma: no cover - handled gracefully in tests
+    distro = None  # type: ignore[assignment]
+
+from .logging_setup import configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "logger",
+    "ensure_admin",
+    "check_os_support",
+    "check_python_version",
+    "system_check",
+]
+
+_SUPPORTED_LINUX_CODENAMES = {"trixie", "testing"}
+
+
+def ensure_admin() -> None:
+    """Ensure the current process has administrative privileges."""
+
+    if hasattr(os, "geteuid"):
+        if os.geteuid() != 0:
+            message = "Please run this script as root or with sudo."
+            logger.error(message)
+            raise PermissionError(message)
+        return
+
+    if os.name == "nt":  # pragma: no cover - Windows specific
+        try:
+            import ctypes
+
+            if not ctypes.windll.shell32.IsUserAnAdmin():  # type: ignore[attr-defined]
+                message = "Administrator privileges are required to continue."
+                logger.error(message)
+                raise PermissionError(message)
+        except Exception:  # pragma: no cover - safety net
+            logger.debug(
+                "Unable to determine administrator privileges on Windows.",
+                exc_info=True,
+            )
+        return
+
+    logger.debug("Skipping administrator privilege check on platform %s", os.name)
+
+
+def check_os_support() -> None:
+    """Warn when the operating system is outside the supported matrix."""
+
+    system = platform.system()
+    if system == "Windows":
+        release = platform.release()
+        try:
+            major = int(str(release).split(".")[0])
+        except ValueError:
+            major = 0
+        if major < 10:
+            logger.warning(
+                "Unsupported Windows version detected (%s). Windows 10 or newer is required.",
+                release,
+            )
+    elif system == "Darwin":
+        version, _, _ = platform.mac_ver()
+        try:
+            major = int(str(version).split(".")[0])
+        except ValueError:
+            major = 0
+        if major < 13:
+            logger.warning(
+                "Unsupported macOS version detected (%s). macOS Ventura or newer is required.",
+                version,
+            )
+    elif system == "Linux":
+        dist_id = ""
+        codename = ""
+        if distro is not None:
+            try:
+                dist_id = str(distro.id() or "").lower()
+                codename = str(distro.codename() or "").lower()
+            except Exception:  # pragma: no cover - distro implementation detail
+                dist_id = ""
+                codename = ""
+        if not dist_id:
+            release_info: Dict[str, str] = {}
+            if hasattr(platform, "freedesktop_os_release"):
+                try:
+                    release_info = platform.freedesktop_os_release()  # type: ignore[assignment]
+                except Exception:  # pragma: no cover - platform API not available
+                    release_info = {}
+            dist_id = str(release_info.get("ID", "")).lower()
+            codename = str(release_info.get("VERSION_CODENAME", "")).lower()
+        if dist_id != "debian" or codename not in _SUPPORTED_LINUX_CODENAMES:
+            logger.warning(
+                "Unsupported Linux distribution detected (%s %s). Debian Trixie/testing is required.",
+                dist_id,
+                codename,
+            )
+    else:
+        logger.warning("Unsupported operating system detected: %s", system)
+
+
+def check_python_version() -> None:
+    """Warn when running on experimental Python versions."""
+
+    info = sys.version_info
+    if isinstance(info, tuple):  # pragma: no cover - compatibility
+        major, minor = info[0], info[1]
+    else:
+        major = getattr(info, "major", 0)
+        minor = getattr(info, "minor", 0)
+    if major == 3 and minor == 13:
+        logger.warning(
+            "Python 3.13 detected. This version is experimental and not fully supported.",
+        )
+
+
+def system_check() -> Dict[str, bool]:
+    """Run a suite of lightweight system checks and return their status."""
+
+    logger.info("Performing system checks...")
+    results: Dict[str, bool] = {}
+
+    try:
+        check_os_support()
+        results["os_supported"] = True
+    except Exception:  # pragma: no cover - defensive guard
+        logger.exception("Operating system check failed")
+        results["os_supported"] = False
+
+    check_python_version()
+    results["python_supported"] = True
+
+    try:
+        usage = shutil.disk_usage("/")
+    except Exception:  # pragma: no cover - non-POSIX platforms
+        logger.debug("Unable to determine disk usage for root filesystem.", exc_info=True)
+    else:
+        free_gb = usage.free / (1024 ** 3)
+        if free_gb < 1:
+            logger.warning("Low disk space detected on root filesystem: %.2f GiB free", free_gb)
+            results["disk_space_ok"] = False
+        else:
+            logger.info("Available disk space on root filesystem: %.2f GiB", free_gb)
+            results["disk_space_ok"] = True
+
+    for tool in ("git", "python3"):
+        available = shutil.which(tool) is not None
+        if not available:
+            logger.warning("Required executable '%s' not found on PATH", tool)
+        results[f"{tool}_available"] = available
+
+    return results


### PR DESCRIPTION
## Summary
- add an explicit monkey_head package initializer with legacy fallbacks
- implement local logging setup, system checks, and function registry modules
- expose the new utilities via monkey_head.core and update package exports

## Testing
- pytest tests/test_os_check.py tests/test_os_check_fallback.py tests/test_python_version.py tests/test_function_registry.py tests/test_logging_setup.py

------
https://chatgpt.com/codex/tasks/task_e_68e324179bdc832b911d427c2e183baf