### PR TITLE
feat: add multi-stage HueyOS images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,48 @@ jobs:
         with:
           name: coverage-${{ matrix.python-version }}
           path: coverage.xml
+
+  publish-images:
+    needs: tests
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: dev
+            tag: dev
+          - target: hostos
+            tag: hostos
+          - target: subos
+            tag: subos
+          - target: nanoos
+            tag: nanoos
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push ${{ matrix.tag }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/hueyos:${{ matrix.tag }}
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
+          build-args: |
+            PYTHON_VERSION=3.13.5
+            DEBIAN_VERSION=trixie

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,18 +42,93 @@ RUN python3 -m venv "${VIRTUAL_ENV}" && "${VIRTUAL_ENV}/bin/pip" install --no-ca
 
 WORKDIR /workspace
 
-# Optional requirements without failing when file absent
-RUN --mount=type=bind,source=.,target=/src     --mount=type=cache,target=/root/.cache/pip,id=pip-cache,sharing=locked     bash -lc 'if [ -f /src/requirements.txt ]; then pip install -r /src/requirements.txt; fi'
-
 USER ${APP_USER}
 EXPOSE 1995
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=5   CMD python -c "import sys; sys.exit(0)"
 
-LABEL org.opencontainers.image.title="Monkey Head Project Dev Image"       org.opencontainers.image.description="Debian ${DEBIAN_VERSION} + CPython ${PYTHON_VERSION} dev toolbox (non-root, venv, tini)"       org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.title="HueyOS Base Image"       org.opencontainers.image.description="Debian ${DEBIAN_VERSION} + CPython ${PYTHON_VERSION} runtime base (non-root, venv, tini)"       org.opencontainers.image.licenses="MIT"
 
 ENTRYPOINT ["/usr/bin/tini","--"]
 CMD ["sleep","infinity"]
 
-# Compose target
+# -------- Stage: source snapshot --------
+FROM runtime AS hueyos-source
+USER root
+ARG APP_USER=app
+ARG APP_UID=1000
+ARG APP_GID=1000
+WORKDIR /workspace
+COPY --chown=${APP_UID}:${APP_GID} . /workspace
+
+# -------- Stage: HueyOS dev toolbox --------
 FROM runtime AS dev
+USER root
+ARG APP_USER=app
+ARG APP_UID=1000
+ARG APP_GID=1000
+ARG HUEY_EXTRAS="dev,ml,data,cloud"
+ENV HUEY_EXTRAS=${HUEY_EXTRAS}
+WORKDIR /workspace
+COPY --from=hueyos-source --chown=${APP_UID}:${APP_GID} /workspace /workspace
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-dev,sharing=locked     bash -lc 'set -eux; if [ -n "${HUEY_EXTRAS}" ]; then pip install --no-cache-dir --no-build-isolation ".[${HUEY_EXTRAS}]"; else pip install --no-cache-dir --no-build-isolation .; fi'
+LABEL org.opencontainers.image.title="HueyOS Dev"
+USER ${APP_USER}
+VOLUME ["/workspace/config","/workspace/memory"]
+EXPOSE 1995
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["uvicorn","huey.api:app","--host","0.0.0.0","--port","1995"]
+
+# -------- Stage: HueyOS HostOS runtime --------
+FROM runtime AS hostos
+USER root
+ARG APP_USER=app
+ARG APP_UID=1000
+ARG APP_GID=1000
+ARG HUEY_EXTRAS="ml,data,cloud"
+ENV HUEY_EXTRAS=${HUEY_EXTRAS}
+WORKDIR /workspace
+COPY --from=hueyos-source --chown=${APP_UID}:${APP_GID} /workspace /workspace
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-hostos,sharing=locked     bash -lc 'set -eux; if [ -n "${HUEY_EXTRAS}" ]; then pip install --no-cache-dir --no-build-isolation ".[${HUEY_EXTRAS}]"; else pip install --no-cache-dir --no-build-isolation .; fi'
+LABEL org.opencontainers.image.title="HueyOS HostOS"
+USER ${APP_USER}
+VOLUME ["/workspace/config","/workspace/memory"]
+EXPOSE 1995
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["uvicorn","huey.api:app","--host","0.0.0.0","--port","1995"]
+
+# -------- Stage: HueyOS SubOS runtime --------
+FROM runtime AS subos
+USER root
+ARG APP_USER=app
+ARG APP_UID=1000
+ARG APP_GID=1000
+ARG HUEY_EXTRAS="ml,data"
+ENV HUEY_EXTRAS=${HUEY_EXTRAS}
+WORKDIR /workspace
+COPY --from=hueyos-source --chown=${APP_UID}:${APP_GID} /workspace /workspace
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-subos,sharing=locked     bash -lc 'set -eux; if [ -n "${HUEY_EXTRAS}" ]; then pip install --no-cache-dir --no-build-isolation ".[${HUEY_EXTRAS}]"; else pip install --no-cache-dir --no-build-isolation .; fi'
+LABEL org.opencontainers.image.title="HueyOS SubOS"
+USER ${APP_USER}
+VOLUME ["/workspace/config","/workspace/memory"]
+EXPOSE 1995
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["uvicorn","huey.api:app","--host","0.0.0.0","--port","1995"]
+
+# -------- Stage: HueyOS NanoOS runtime --------
+FROM runtime AS nanoos
+USER root
+ARG APP_USER=app
+ARG APP_UID=1000
+ARG APP_GID=1000
+ARG HUEY_EXTRAS=""
+ENV HUEY_EXTRAS=${HUEY_EXTRAS}
+WORKDIR /workspace
+COPY --from=hueyos-source --chown=${APP_UID}:${APP_GID} /workspace /workspace
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-nanoos,sharing=locked     bash -lc 'set -eux; if [ -n "${HUEY_EXTRAS}" ]; then pip install --no-cache-dir --no-build-isolation ".[${HUEY_EXTRAS}]"; else pip install --no-cache-dir --no-build-isolation .; fi'
+LABEL org.opencontainers.image.title="HueyOS NanoOS"
+USER ${APP_USER}
+VOLUME ["/workspace/config","/workspace/memory"]
+EXPOSE 1995
+ENTRYPOINT ["/usr/bin/tini","--"]
+CMD ["uvicorn","huey.api:app","--host","0.0.0.0","--port","1995"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,8 @@ services:
     working_dir: /workspace
     env_file: [.env]
     environment:
-      VIRTUAL_ENV: /workspace/venv
-      PATH: "/workspace/venv/bin:$$PATH"
+      VIRTUAL_ENV: /opt/venv
+      PATH: "/opt/venv/bin:$$PATH"
       APP_ENV: ${APP_ENV:-production}
       TZ: ${TZ:-Etc/UTC}
     volumes:

--- a/docker/[1] HostOS/HostOS.yaml
+++ b/docker/[1] HostOS/HostOS.yaml
@@ -7,13 +7,39 @@ metadata:
 
 ---
 apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hostos-config
+  namespace: hostos
+  labels: { app: hostos }
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hostos-memory
+  namespace: hostos
+  labels: { app: hostos }
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: hostos-config
   namespace: hostos
 data:
   HOSTOS_GREETING: "Welcome to Huey HostOS"
-  HOSTOS_PATH: "/home/hostos/HostOS"
+  HOSTOS_PATH: "/workspace"
 
 ---
 apiVersion: apps/v1
@@ -33,35 +59,38 @@ spec:
     spec:
       containers:
         - name: hostos
-          # Replace this with your built image, e.g. ghcr.io/dylanlrpollock/hostos:latest
-          image: hostos:local
+          image: ghcr.io/dylanlrpollock/hueyos:hostos
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
                 name: hostos-config
-          command: ["/bin/sh","-lc"]
-          args: ["sleep infinity"]
           ports:
-            - containerPort: 5901
-              name: vnc
+            - containerPort: 1995
+              name: http1995
           volumeMounts:
-            - name: workspace
-              mountPath: /home/hostos/HostOS
+            - name: config
+              mountPath: /workspace/config
+            - name: memory
+              mountPath: /workspace/memory
       volumes:
-        - name: workspace
-          emptyDir: {}
+        - name: config
+          persistentVolumeClaim:
+            claimName: hostos-config
+        - name: memory
+          persistentVolumeClaim:
+            claimName: hostos-memory
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: hostos-vnc
+  name: hostos-api
   namespace: hostos
 spec:
   selector:
     app: hostos-toolbox
   ports:
-    - name: vnc
-      port: 5901
-      targetPort: 5901
+    - name: http1995
+      port: 1995
+      targetPort: 1995
   type: ClusterIP

--- a/docker/[2] SubOS/SubOS.yaml
+++ b/docker/[2] SubOS/SubOS.yaml
@@ -5,6 +5,32 @@ metadata:
   name: subos
 
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: subos-config
+  namespace: subos
+  labels: { app: subos }
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 512Mi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: subos-memory
+  namespace: subos
+  labels: { app: subos }
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 2Gi
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,16 +48,23 @@ spec:
     spec:
       containers:
         - name: subos
-          image: subos:local
+          image: ghcr.io/dylanlrpollock/hueyos:subos
           imagePullPolicy: IfNotPresent
-          command: ["/bin/sh","-lc"]
-          args: ["sleep infinity"]
+          ports:
+            - containerPort: 1995
+              name: http1995
           volumeMounts:
-            - name: workspace
-              mountPath: /home/subos/SubOS
+            - name: config
+              mountPath: /workspace/config
+            - name: memory
+              mountPath: /workspace/memory
       volumes:
-        - name: workspace
-          emptyDir: {}
+        - name: config
+          persistentVolumeClaim:
+            claimName: subos-config
+        - name: memory
+          persistentVolumeClaim:
+            claimName: subos-memory
 
 ---
 apiVersion: v1
@@ -43,6 +76,7 @@ spec:
   selector:
     app: subos
   ports:
-    - port: 8080
-      targetPort: 8080
+    - name: http1995
+      port: 1995
+      targetPort: 1995
   type: ClusterIP

--- a/docker/[3] NanoOS/NanoOS.yaml
+++ b/docker/[3] NanoOS/NanoOS.yaml
@@ -5,6 +5,32 @@ metadata:
   name: nanoos
 
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nanoos-config
+  namespace: nanoos
+  labels: { app: nanoos }
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 256Mi
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nanoos-memory
+  namespace: nanoos
+  labels: { app: nanoos }
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,16 +48,23 @@ spec:
     spec:
       containers:
         - name: nanoos
-          image: nanoos:local
+          image: ghcr.io/dylanlrpollock/hueyos:nanoos
           imagePullPolicy: IfNotPresent
-          command: ["/bin/sh","-lc"]
-          args: ["sleep infinity"]
+          ports:
+            - containerPort: 1995
+              name: http1995
           volumeMounts:
-            - name: workspace
-              mountPath: /home/nanoos/NanoOS
+            - name: config
+              mountPath: /workspace/config
+            - name: memory
+              mountPath: /workspace/memory
       volumes:
-        - name: workspace
-          emptyDir: {}
+        - name: config
+          persistentVolumeClaim:
+            claimName: nanoos-config
+        - name: memory
+          persistentVolumeClaim:
+            claimName: nanoos-memory
 
 ---
 apiVersion: v1
@@ -43,6 +76,7 @@ spec:
   selector:
     app: nanoos
   ports:
-    - port: 8081
-      targetPort: 8081
+    - name: http1995
+      port: 1995
+      targetPort: 1995
   type: ClusterIP

--- a/huey/memory/YAML/config.yaml
+++ b/huey/memory/YAML/config.yaml
@@ -11,8 +11,8 @@ database:
 
 system:
   os: 'debian-trixie'
-  python_version: '3.12'
-  virtual_env: '/workspace/venv'
+  python_version: '3.13.5'
+  virtual_env: '/opt/venv'
   dependencies:
     - pygpt-MHP
     - docker

--- a/huey/memory/YML/docker-compose.yml
+++ b/huey/memory/YML/docker-compose.yml
@@ -40,8 +40,8 @@ services:
     working_dir: /workspace
     env_file: [.env]
     environment:
-      VIRTUAL_ENV: /workspace/venv
-      PATH: "/workspace/venv/bin:$$PATH"
+      VIRTUAL_ENV: /opt/venv
+      PATH: "/opt/venv/bin:$$PATH"
       APP_ENV: ${APP_ENV:-production}
       TZ: ${TZ:-Etc/UTC}
     volumes:

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -24,6 +24,30 @@ data:
   # echo -n dummy | base64 -> ZHVtbXk=
   APP_SECRET: ZHVtbXk=
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: monkey-head-config
+  namespace: monkey-head
+  labels: { app: monkey-head }
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: monkey-head-memory
+  namespace: monkey-head
+  labels: { app: monkey-head }
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,17 +64,12 @@ spec:
     spec:
       containers:
         - name: monkey-head
-          image: monkey-head-project:latest         # build: docker build -t monkey-head-project:latest .
-          imagePullPolicy: IfNotPresent             # Docker Desktop shares engine images with k8s
+          image: ghcr.io/dylanlrpollock/hueyos:hostos
+          imagePullPolicy: IfNotPresent
           workingDir: /workspace
           envFrom:
             - configMapRef: { name: monkey-head-config }
             - secretRef:    { name: monkey-head-secrets }
-          env:
-            - name: VIRTUAL_ENV
-              value: /workspace/venv
-            - name: PATH
-              value: /workspace/venv/bin:$(PATH)
           ports:
             - containerPort: 1995
               name: http1995
@@ -74,19 +93,17 @@ spec:
             readOnlyRootFilesystem: false
             capabilities: { drop: ["ALL"] }
           volumeMounts:
-            - name: l-drive
-              mountPath: /L
-            - name: workspace
-              mountPath: /workspace
+            - name: config
+              mountPath: /workspace/config
+            - name: memory
+              mountPath: /workspace/memory
       volumes:
-        # Bind Windows L:\ into the pod (Docker Desktop only)
-        - name: l-drive
-          hostPath:
-            path: /run/desktop/mnt/host/l
-            type: Directory
-        # Local emptyDir for workspace
-        - name: workspace
-          emptyDir: {}
+        - name: config
+          persistentVolumeClaim:
+            claimName: monkey-head-config
+        - name: memory
+          persistentVolumeClaim:
+            claimName: monkey-head-memory
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
- refactor the Dockerfile into reusable dev, hostos, subos, and nanoos targets that install only the required extras and run uvicorn
- align compose examples and configuration defaults with the container virtualenv and expose persistent config/memory volumes across manifests
- extend CI to build and publish the HueyOS images to GHCR for each target

## Testing
- pytest -q *(fails: missing optional test dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fac8e474832bafd808adf26be11f