### PR TITLE
Enhance virtualization checks and document orchestrator deployment

### DIFF
--- a/docker/[2] SubOS/SubOS.yaml
+++ b/docker/[2] SubOS/SubOS.yaml
@@ -1,4 +1,5 @@
 # SubOS Kubernetes manifest
+# Apply with: kubectl apply -f SubOS.yaml
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/docker/[3] NanoOS/NanoOS.yaml
+++ b/docker/[3] NanoOS/NanoOS.yaml
@@ -1,4 +1,5 @@
 # NanoOS Kubernetes manifest (Deployment pattern)
+# Apply with: kubectl apply -f NanoOS.yaml
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/docker/orchestrator_utils.py
+++ b/docker/orchestrator_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
+import platform
 import shutil
 import subprocess
 from pathlib import Path
@@ -197,10 +198,37 @@ def _detect_cpu_flags() -> set[str]:
     return {flag.lower() for flag in flags}
 
 
+def _probe_virtualization_environment(logger: logging.Logger) -> str | None:
+    """Return the detected virtualization environment, if any."""
+
+    if shutil.which("systemd-detect-virt") is None:
+        logger.debug("systemd-detect-virt not available on this host.")
+        return None
+
+    proc = run(["systemd-detect-virt"], logger, check=False)
+    if proc.returncode == 0:
+        output = (proc.stdout or proc.stderr or "").strip()
+        return output or "unknown"
+    if proc.returncode == 1:
+        return "bare-metal"
+
+    logger.debug(
+        "systemd-detect-virt returned %s (stdout=%r, stderr=%r)",
+        proc.returncode,
+        getattr(proc, "stdout", ""),
+        getattr(proc, "stderr", ""),
+    )
+    return None
+
+
 def check_virtualization(logger: logging.Logger) -> None:
     """Verify that hardware virtualization is available for KVM/QEMU."""
 
     logger.info("Checking virtualization support…")
+    virt_env = _probe_virtualization_environment(logger)
+    if virt_env:
+        logger.info("Detected virtualization environment: %s", virt_env)
+
     flags = _detect_cpu_flags()
     kvm_path = Path("/dev/kvm")
     kvm_ok = kvm_path.exists()
@@ -209,14 +237,22 @@ def check_virtualization(logger: logging.Logger) -> None:
     logger.debug("/dev/kvm present: %s", kvm_ok)
 
     if {"vmx", "svm"} & flags and kvm_ok:
-        logger.info("Hardware virtualization available (flags: %s).", ", ".join(sorted({"vmx", "svm"} & flags)))
+        logger.info(
+            "Hardware virtualization available (flags: %s).",
+            ", ".join(sorted({"vmx", "svm"} & flags)),
+        )
         return
 
+    platform_hint = platform.system()
     guidance = (
         "Hardware virtualization was not detected. Ensure that VT-x/AMD-V is enabled in BIOS/UEFI. "
         "If you are running inside a macOS hypervisor or unsupported cloud VM, enable nested virtualization or "
         "consider using a QEMU/KVM capable host."
     )
+    if platform_hint.lower() == "darwin":
+        guidance += " macOS hosts require a hypervisor that exposes /dev/kvm (for example via UTM or QEMU)."
+    elif virt_env and virt_env != "bare-metal":
+        guidance += f" Detected virtualization layer: {virt_env}. Ensure it supports nested virtualization."
 
     missing_bits: list[str] = []
     if not ({"vmx", "svm"} & flags):

--- a/docs/orchestrator-deployment.md
+++ b/docs/orchestrator-deployment.md
@@ -12,7 +12,7 @@ python3 docker/[2]\ SubOS/SubOS.py --workspace "$HOME/SubOS" --service-port 8080
 python3 docker/[3]\ NanoOS/NanoOS.py --workspace "$HOME/NanoOS" --service-port 8081 all
 ```
 
-Use `--skip-os-check` or provide `--allow-os <name>` if you need to override distribution detection (for example on derivative Debian releases). The `setup` sub-command performs package installation, virtualization/firewall checks, and workspace creation without applying manifests.
+Use `--skip-os-check` or provide `--allow-os <name>` if you need to override distribution detection (for example on derivative Debian releases). The `setup` sub-command performs package installation, virtualization/firewall checks, and workspace creation without applying manifests. When running HostOS on nested hypervisors or macOS, ensure that `/dev/kvm` is available; otherwise the virtualization check will provide remediation guidance (e.g., enabling VT-x/AMD-V or using a KVM-capable host).
 
 ## Applying Kubernetes manifests
 

--- a/tests/test_hostos_module.py
+++ b/tests/test_hostos_module.py
@@ -30,7 +30,7 @@ def test_enable_services():
 def test_check_virtualization():
     with patch("orchestrator_utils._detect_cpu_flags", return_value={"vmx", "svm"}), patch(
         "orchestrator_utils.Path.exists", return_value=True
-    ):
+    ), patch("orchestrator_utils._probe_virtualization_environment", return_value="bare-metal"):
         check_virtualization()
 
 


### PR DESCRIPTION
## Summary
- extend the shared virtualization check to probe the host environment via `systemd-detect-virt` and surface platform-specific guidance
- mention the virtualization prerequisites in the orchestrator deployment guide and add inline manifest comments for applying the resources
- adjust the HostOS unit test to accommodate the new virtualization probe helper

## Testing
- pytest tests/test_hostos_module.py

------
https://chatgpt.com/codex/tasks/task_e_68e48c136e50832bb24a8e1f81af3e7e