### PR TITLE
Add messaging protocol and resource-aware task scheduler

### DIFF
--- a/monkey_head/core/__init__.py
+++ b/monkey_head/core/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from . import system_checks
+from . import messaging, system_checks, task_scheduler
 
-__all__ = ["system_checks"]
+__all__ = ["messaging", "system_checks", "task_scheduler"]

--- a/monkey_head/core/messaging.py
+++ b/monkey_head/core/messaging.py
@@ -1,0 +1,208 @@
+"""Messaging protocol primitives for inter-component communication.
+
+This module defines the internal envelope structure used by HueyOS
+subsystems (HostOS, SubOS, NanoOS, and external modules). The protocol is
+designed around ZeroMQ message frames but the JSON encoding is transport
+agnostic and may also be carried over MQTT topics.
+
+Each message is composed of a :class:`MessageEnvelope` with a structured
+header containing routing metadata, priority details, and health hints. The
+payload remains an arbitrary JSON object to keep the protocol flexible while
+still allowing schema validation via :class:`pydantic.BaseModel`.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class Component(str, Enum):
+    """Enumerates all known logical communication endpoints."""
+
+    HOST_OS = "host_os"
+    SUB_OS = "sub_os"
+    NANO_OS = "nano_os"
+    SPARK = "spark"
+    ZAP = "zap"
+    EXTERNAL_MODULE = "external_module"
+
+
+class Transport(str, Enum):
+    """Supported transport layers for the messaging protocol."""
+
+    ZEROMQ = "zeromq"
+    MQTT = "mqtt"
+
+
+class MessagePriority(int, Enum):
+    """Priority levels compatible with ZeroMQ and MQTT QoS semantics."""
+
+    LOW = 1
+    NORMAL = 5
+    HIGH = 8
+    CRITICAL = 10
+
+
+class MessageHeader(BaseModel):
+    """Structured metadata that precedes all message payloads."""
+
+    schema_version: str = Field(
+        "1.0",
+        description="Semantic version of the envelope schema for compatibility.",
+    )
+    message_id: str = Field(
+        default_factory=lambda: uuid.uuid4().hex,
+        description="Unique identifier for this message instance.",
+    )
+    correlation_id: Optional[str] = Field(
+        None,
+        description="Identifier linking request / response message flows.",
+    )
+    reply_to: Optional[str] = Field(
+        None,
+        description="Logical component or topic for directed replies.",
+    )
+    sender: Component = Field(..., description="Originating component identifier.")
+    recipient: Component = Field(
+        ..., description="Intended recipient component or broadcast scope."
+    )
+    topic: str = Field(
+        ..., description="Topic or channel name within the transport fabric."
+    )
+    priority: MessagePriority = Field(
+        MessagePriority.NORMAL,
+        description="Priority weighting used for queue ordering and QoS.",
+    )
+    transport: Transport = Field(
+        Transport.ZEROMQ,
+        description="Transport mechanism expected to deliver the message.",
+    )
+    timestamp: float = Field(
+        default_factory=lambda: time.time(),
+        description="Unix epoch timestamp at message creation.",
+    )
+    expiry: Optional[float] = Field(
+        None,
+        description=(
+            "Optional unix epoch after which the recipient should discard the "
+            "message if not yet processed."
+        ),
+    )
+    requires_ack: bool = Field(
+        False,
+        description="True when the sender expects an acknowledgement message.",
+    )
+
+    @field_validator("topic")
+    @classmethod
+    def _validate_topic(cls, value: str) -> str:
+        if not value:
+            raise ValueError("message topic must be a non-empty string")
+        return value
+
+
+class MessageEnvelope(BaseModel):
+    """Full message wrapper used across transports."""
+
+    header: MessageHeader
+    payload: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arbitrary JSON compatible payload to deliver to recipient.",
+    )
+    signature: Optional[str] = Field(
+        None,
+        description="Optional detached signature for tamper detection.",
+    )
+
+    def to_json(self) -> str:
+        """Serialise the envelope to a canonical JSON string."""
+
+        return self.json(sort_keys=True)
+
+    def to_bytes(self) -> bytes:
+        """Serialise the envelope to UTF-8 encoded bytes."""
+
+        return self.to_json().encode("utf-8")
+
+    @classmethod
+    def from_json(cls, data: str) -> "MessageEnvelope":
+        """Deserialize a :class:`MessageEnvelope` from JSON text."""
+
+        return cls.parse_raw(data)
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "MessageEnvelope":
+        """Deserialize a :class:`MessageEnvelope` from bytes."""
+
+        return cls.from_json(data.decode("utf-8"))
+
+    def build_ack(self, status: str, payload: Optional[Dict[str, Any]] = None) -> "MessageEnvelope":
+        """Create a reply envelope acknowledging the current message."""
+
+        if not self.header.reply_to:
+            raise ValueError("cannot build acknowledgement without reply_to")
+        reply_header = MessageHeader(
+            sender=self.header.recipient,
+            recipient=self.header.sender,
+            topic=self.header.reply_to,
+            correlation_id=self.header.message_id,
+            priority=self.header.priority,
+            transport=self.header.transport,
+        )
+        ack_payload = {"status": status}
+        if payload:
+            ack_payload.update(payload)
+        return MessageEnvelope(header=reply_header, payload=ack_payload)
+
+
+def encode_envelope(envelope: MessageEnvelope) -> bytes:
+    """Helper for use with ZeroMQ multipart frames."""
+
+    return envelope.to_bytes()
+
+
+def decode_envelope(raw: bytes) -> MessageEnvelope:
+    """Decode bytes received from a transport back into an envelope."""
+
+    return MessageEnvelope.from_bytes(raw)
+
+
+def envelope_from_components(
+    *,
+    sender: Component,
+    recipient: Component,
+    topic: str,
+    payload: Optional[Dict[str, Any]] = None,
+    priority: MessagePriority = MessagePriority.NORMAL,
+    correlation_id: Optional[str] = None,
+    reply_to: Optional[str] = None,
+    transport: Transport = Transport.ZEROMQ,
+    expiry: Optional[float] = None,
+    requires_ack: bool = False,
+) -> MessageEnvelope:
+    """Create a :class:`MessageEnvelope` from primitive components."""
+
+    header = MessageHeader(
+        sender=sender,
+        recipient=recipient,
+        topic=topic,
+        priority=priority,
+        correlation_id=correlation_id,
+        reply_to=reply_to,
+        transport=transport,
+        expiry=expiry,
+        requires_ack=requires_ack,
+    )
+    return MessageEnvelope(header=header, payload=payload or {})
+
+
+def pretty_print_envelope(envelope: MessageEnvelope) -> str:
+    """Return a human readable version of the envelope for logging."""
+
+    return json.dumps(json.loads(envelope.to_json()), indent=2, sort_keys=True)

--- a/monkey_head/core/task_scheduler.py
+++ b/monkey_head/core/task_scheduler.py
@@ -1,0 +1,436 @@
+"""Task scheduling and resource aware assignment for HueyOS agents."""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from threading import RLock
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+try:  # pragma: no cover - psutil optional at runtime
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - provide stub behaviour
+    psutil = None  # type: ignore[assignment]
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Agent(str, Enum):
+    """Enumeration of the primary AI agents managed by the scheduler."""
+
+    SPARK = "spark"
+    ZAP = "zap"
+
+
+class TaskStatus(str, Enum):
+    """Lifecycle states for submitted tasks."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class TaskPriority(int, Enum):
+    """Integer priority levels compatible with queue comparisons."""
+
+    LOW = 1
+    NORMAL = 5
+    HIGH = 8
+    CRITICAL = 10
+
+
+@dataclass
+class ResourceProfile:
+    """Relative resource expectations for a task.
+
+    Values represent a fraction between 0.0 and 1.0 describing the expected
+    utilisation of the referenced resource. They are heuristics rather than
+    guarantees but enable the scheduler to decline heavy work when the system is
+    already constrained.
+    """
+
+    cpu: float = 0.3
+    memory: float = 0.2
+    battery: float = 0.1
+    gpu: float = 0.0
+
+    def clamp(self) -> "ResourceProfile":
+        """Return a new profile with values constrained to the 0..1 range."""
+
+        return ResourceProfile(
+            cpu=min(max(self.cpu, 0.0), 1.0),
+            memory=min(max(self.memory, 0.0), 1.0),
+            battery=min(max(self.battery, 0.0), 1.0),
+            gpu=min(max(self.gpu, 0.0), 1.0),
+        )
+
+
+@dataclass
+class ResourceSnapshot:
+    """Point-in-time observation of host resource utilisation."""
+
+    timestamp: float = field(default_factory=lambda: time.time())
+    cpu_percent: Optional[float] = None
+    memory_available: Optional[float] = None
+    memory_total: Optional[float] = None
+    battery_percent: Optional[float] = None
+    notes: Optional[str] = None
+
+
+@dataclass
+class TaskLogEntry:
+    """Historical status update for a task."""
+
+    timestamp: float
+    status: TaskStatus
+    message: str
+
+
+@dataclass
+class TaskRecord:
+    """Internal representation of a tracked task."""
+
+    task_id: str
+    command: str
+    priority: TaskPriority
+    requested_agent: Optional[Agent]
+    assigned_agent: Optional[Agent]
+    status: TaskStatus
+    created_at: float
+    updated_at: float
+    attempts: int = 0
+    result: Optional[Any] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    resource_profile: ResourceProfile = field(default_factory=ResourceProfile)
+    snapshot: Optional[ResourceSnapshot] = None
+    history: List[TaskLogEntry] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the record to a JSON compatible mapping."""
+
+        return {
+            "task_id": self.task_id,
+            "command": self.command,
+            "priority": int(self.priority),
+            "requested_agent": self.requested_agent.value if self.requested_agent else None,
+            "assigned_agent": self.assigned_agent.value if self.assigned_agent else None,
+            "status": self.status.value,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "attempts": self.attempts,
+            "result": self.result,
+            "error": self.error,
+            "metadata": self.metadata,
+            "resource_profile": {
+                "cpu": self.resource_profile.cpu,
+                "memory": self.resource_profile.memory,
+                "battery": self.resource_profile.battery,
+                "gpu": self.resource_profile.gpu,
+            },
+            "snapshot": {
+                "timestamp": self.snapshot.timestamp if self.snapshot else None,
+                "cpu_percent": self.snapshot.cpu_percent if self.snapshot else None,
+                "memory_available": self.snapshot.memory_available if self.snapshot else None,
+                "memory_total": self.snapshot.memory_total if self.snapshot else None,
+                "battery_percent": self.snapshot.battery_percent if self.snapshot else None,
+                "notes": self.snapshot.notes if self.snapshot else None,
+            },
+            "history": [
+                {
+                    "timestamp": entry.timestamp,
+                    "status": entry.status.value,
+                    "message": entry.message,
+                }
+                for entry in self.history
+            ],
+        }
+
+
+HealthProvider = Callable[[], ResourceSnapshot]
+
+
+class TaskScheduler:
+    """Priority aware scheduler with host resource monitoring."""
+
+    def __init__(
+        self,
+        *,
+        cpu_threshold: float = 85.0,
+        battery_threshold: float = 20.0,
+        min_free_memory: float = 0.15,
+        health_provider: Optional[HealthProvider] = None,
+        max_retries: int = 1,
+    ) -> None:
+        self.cpu_threshold = cpu_threshold
+        self.battery_threshold = battery_threshold
+        self.min_free_memory = min_free_memory
+        self.health_provider = health_provider or self._default_health_provider
+        self.max_retries = max_retries
+        self._lock = RLock()
+        self._tasks: Dict[str, TaskRecord] = {}
+        self._agent_load: Dict[Agent, int] = {Agent.SPARK: 0, Agent.ZAP: 0}
+
+    # ------------------------------------------------------------------
+    # Health monitoring
+    # ------------------------------------------------------------------
+    def _default_health_provider(self) -> ResourceSnapshot:  # pragma: no cover -
+        """Collect current resource usage metrics from the operating system."""
+
+        snapshot = ResourceSnapshot()
+        if psutil is None:
+            snapshot.notes = "psutil not available"
+            return snapshot
+
+        try:
+            snapshot.cpu_percent = float(psutil.cpu_percent(interval=0.05))
+        except Exception as exc:  # pragma: no cover - defensive
+            snapshot.notes = f"cpu_percent unavailable: {exc}"
+
+        try:
+            virtual_mem = psutil.virtual_memory()
+            snapshot.memory_available = float(virtual_mem.available)
+            snapshot.memory_total = float(virtual_mem.total)
+        except Exception as exc:  # pragma: no cover - defensive
+            snapshot.notes = (snapshot.notes or "") + f" memory unavailable: {exc}"
+
+        try:
+            if hasattr(psutil, "sensors_battery"):
+                battery = psutil.sensors_battery()
+                if battery:
+                    snapshot.battery_percent = float(battery.percent)
+        except Exception as exc:  # pragma: no cover - defensive
+            snapshot.notes = (snapshot.notes or "") + f" battery unavailable: {exc}"
+
+        return snapshot
+
+    def _system_ready(
+        self, profile: ResourceProfile
+    ) -> Tuple[bool, Optional[str], ResourceSnapshot]:
+        """Determine whether the host can accept additional load."""
+
+        profile = profile.clamp()
+        snapshot = self.health_provider()
+        reason: Optional[str] = None
+
+        cpu_percent = snapshot.cpu_percent
+        if cpu_percent is not None:
+            allowed = max(0.0, self.cpu_threshold - (profile.cpu * 15.0))
+            if cpu_percent > allowed:
+                reason = f"CPU utilisation {cpu_percent:.1f}% exceeds {allowed:.1f}% allowance"
+
+        if reason is None and snapshot.memory_available is not None and snapshot.memory_total:
+            free_ratio = snapshot.memory_available / snapshot.memory_total
+            minimum = max(0.05, self.min_free_memory - (profile.memory * 0.1))
+            if free_ratio < minimum:
+                reason = (
+                    "Insufficient memory headroom "
+                    f"({free_ratio:.2%} available, required >= {minimum:.2%})"
+                )
+
+        battery_percent = snapshot.battery_percent
+        if (
+            reason is None
+            and battery_percent is not None
+            and battery_percent < (self.battery_threshold + profile.battery * 10.0)
+        ):
+            reason = (
+                f"Battery level {battery_percent:.0f}% below threshold "
+                f"{self.battery_threshold:.0f}%"
+            )
+
+        return reason is None, reason, snapshot
+
+    # ------------------------------------------------------------------
+    # Task management helpers
+    # ------------------------------------------------------------------
+    def _select_agent(self, requested: Optional[Agent]) -> Agent:
+        """Choose an agent based on requested preference and load."""
+
+        if requested is not None:
+            return requested
+        # Prefer the agent with fewer running tasks
+        spark_load = self._agent_load[Agent.SPARK]
+        zap_load = self._agent_load[Agent.ZAP]
+        return Agent.SPARK if spark_load <= zap_load else Agent.ZAP
+
+    def _log_transition(self, record: TaskRecord, message: str) -> None:
+        entry = TaskLogEntry(timestamp=time.time(), status=record.status, message=message)
+        record.history.append(entry)
+        LOGGER.debug("Task %s: %s", record.task_id, message)
+
+    def _update_status(self, record: TaskRecord, status: TaskStatus, message: str) -> None:
+        record.status = status
+        record.updated_at = time.time()
+        self._log_transition(record, message)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def submit_task(
+        self,
+        *,
+        command: str,
+        priority: TaskPriority = TaskPriority.NORMAL,
+        requested_agent: Optional[Agent] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        resource_profile: Optional[ResourceProfile] = None,
+    ) -> TaskRecord:
+        """Register a new task and attempt assignment to an agent."""
+
+        resource_profile = (resource_profile or ResourceProfile()).clamp()
+        task_id = uuid.uuid4().hex
+        created = time.time()
+        record = TaskRecord(
+            task_id=task_id,
+            command=command,
+            priority=priority,
+            requested_agent=requested_agent,
+            assigned_agent=None,
+            status=TaskStatus.PENDING,
+            created_at=created,
+            updated_at=created,
+            metadata=metadata or {},
+            resource_profile=resource_profile,
+        )
+
+        with self._lock:
+            can_run, reason, snapshot = self._system_ready(resource_profile)
+            record.snapshot = snapshot
+            if can_run:
+                agent = self._select_agent(requested_agent)
+                record.assigned_agent = agent
+                record.attempts += 1
+                self._agent_load[agent] += 1
+                self._update_status(record, TaskStatus.RUNNING, "Task dispatched to agent")
+            else:
+                self._update_status(
+                    record,
+                    TaskStatus.PENDING,
+                    reason or "System health unknown; task pending",
+                )
+            self._tasks[task_id] = record
+
+        return record
+
+    def reconcile(self) -> List[TaskRecord]:
+        """Re-evaluate pending tasks to see if they can now be dispatched."""
+
+        dispatched: List[TaskRecord] = []
+        with self._lock:
+            for record in sorted(
+                self._tasks.values(),
+                key=lambda r: (int(-r.priority), r.created_at),
+            ):
+                if record.status is not TaskStatus.PENDING:
+                    continue
+                can_run, reason, snapshot = self._system_ready(record.resource_profile)
+                record.snapshot = snapshot
+                if not can_run:
+                    self._log_transition(record, reason or "Still pending due to health")
+                    continue
+                agent = self._select_agent(record.requested_agent)
+                record.assigned_agent = agent
+                record.attempts += 1
+                self._agent_load[agent] += 1
+                self._update_status(record, TaskStatus.RUNNING, "Task dispatched during reconcile")
+                dispatched.append(record)
+        return dispatched
+
+    def complete_task(self, task_id: str, result: Optional[Any] = None) -> TaskRecord:
+        with self._lock:
+            record = self._require_task(task_id)
+            if record.assigned_agent:
+                self._agent_load[record.assigned_agent] = max(
+                    0, self._agent_load[record.assigned_agent] - 1
+                )
+            record.result = result
+            self._update_status(record, TaskStatus.COMPLETED, "Task completed successfully")
+            return record
+
+    def fail_task(self, task_id: str, error: str) -> TaskRecord:
+        with self._lock:
+            record = self._require_task(task_id)
+            record.error = error
+            previous_agent = record.assigned_agent
+            if previous_agent is not None:
+                self._agent_load[previous_agent] = max(
+                    0, self._agent_load[previous_agent] - 1
+                )
+
+            if record.attempts <= self.max_retries:
+                alternate = self._alternate_agent(previous_agent)
+                can_run, reason, snapshot = self._system_ready(record.resource_profile)
+                record.snapshot = snapshot
+                if can_run:
+                    record.assigned_agent = alternate
+                    record.attempts += 1
+                    self._agent_load[alternate] += 1
+                    self._update_status(
+                        record,
+                        TaskStatus.RUNNING,
+                        f"Reassigned to {alternate.value} after failure",
+                    )
+                    return record
+                self._log_transition(record, reason or "Reassignment blocked by health")
+
+            record.assigned_agent = None
+            self._update_status(record, TaskStatus.FAILED, error)
+            return record
+
+    def cancel_task(self, task_id: str, reason: str = "Cancelled by request") -> TaskRecord:
+        with self._lock:
+            record = self._require_task(task_id)
+            if record.status in {TaskStatus.COMPLETED, TaskStatus.CANCELLED}:
+                return record
+            if record.assigned_agent:
+                self._agent_load[record.assigned_agent] = max(
+                    0, self._agent_load[record.assigned_agent] - 1
+                )
+            record.error = reason
+            record.assigned_agent = None
+            self._update_status(record, TaskStatus.CANCELLED, reason)
+            return record
+
+    def get_task(self, task_id: str) -> TaskRecord:
+        with self._lock:
+            return self._require_task(task_id)
+
+    def list_tasks(self, statuses: Optional[Iterable[TaskStatus]] = None) -> List[TaskRecord]:
+        with self._lock:
+            records = list(self._tasks.values())
+        if statuses is None:
+            return records
+        allowed = {status for status in statuses}
+        return [record for record in records if record.status in allowed]
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+    def _require_task(self, task_id: str) -> TaskRecord:
+        try:
+            return self._tasks[task_id]
+        except KeyError as exc:
+            raise KeyError(f"Unknown task_id {task_id}") from exc
+
+    def _alternate_agent(self, current: Optional[Agent]) -> Agent:
+        if current is None:
+            return self._select_agent(None)
+        return Agent.ZAP if current is Agent.SPARK else Agent.SPARK
+
+
+__all__ = [
+    "Agent",
+    "TaskStatus",
+    "TaskPriority",
+    "ResourceProfile",
+    "ResourceSnapshot",
+    "TaskScheduler",
+    "TaskRecord",
+]

--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -6,7 +6,7 @@ import shutil
 import socket
 import time
 from pathlib import Path
-from typing import AsyncGenerator, Dict, List, Optional
+from typing import Any, AsyncGenerator, Dict, List, Optional
 
 try:  # pragma: no cover - psutil is an optional dependency at runtime
     import psutil  # type: ignore
@@ -18,6 +18,14 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from huey.memory.PY.ai_processor import AIProcessor
+from monkey_head.core.task_scheduler import (
+    Agent,
+    ResourceProfile,
+    TaskPriority,
+    TaskRecord,
+    TaskScheduler,
+    TaskStatus,
+)
 from monkey_head.pdf_utils import find_pdf, list_available_pdfs
 from monkey_head.system_checks import system_check
 from monkey_head.utils.auto_sort import auto_sort_memory
@@ -172,7 +180,138 @@ class SystemCheckResponse(BaseModel):
 
 
 AI_PROCESSOR = AIProcessor()
+SCHEDULER = TaskScheduler()
 _SERVICE_STATES: Dict[str, ServiceStatus] = {}
+
+
+class ResourceProfileModel(BaseModel):
+    """API schema exposing the scheduler resource hints."""
+
+    cpu: float = Field(0.3, ge=0.0, le=1.0, description="Expected CPU utilisation bias")
+    memory: float = Field(0.2, ge=0.0, le=1.0, description="Expected memory utilisation bias")
+    battery: float = Field(
+        0.1,
+        ge=0.0,
+        le=1.0,
+        description="Battery drain sensitivity; higher values require higher charge.",
+    )
+    gpu: float = Field(0.0, ge=0.0, le=1.0, description="Relative GPU demand if applicable")
+
+    def to_profile(self) -> ResourceProfile:
+        return ResourceProfile(
+            cpu=self.cpu,
+            memory=self.memory,
+            battery=self.battery,
+            gpu=self.gpu,
+        )
+
+
+class ResourceSnapshotModel(BaseModel):
+    """Current host health metrics observed during scheduling decisions."""
+
+    timestamp: Optional[float] = None
+    cpu_percent: Optional[float] = None
+    memory_available: Optional[float] = None
+    memory_total: Optional[float] = None
+    battery_percent: Optional[float] = None
+    notes: Optional[str] = None
+
+
+class TaskHistoryEntry(BaseModel):
+    """Chronological log entries captured for each task."""
+
+    timestamp: float
+    status: TaskStatus
+    message: str
+
+
+class TaskResponse(BaseModel):
+    """Serialized representation of a scheduled task."""
+
+    task_id: str
+    command: str
+    priority: int
+    requested_agent: Optional[Agent]
+    assigned_agent: Optional[Agent]
+    status: TaskStatus
+    created_at: float
+    updated_at: float
+    attempts: int
+    result: Optional[Any]
+    error: Optional[str]
+    metadata: Dict[str, Any]
+    resource_profile: ResourceProfileModel
+    snapshot: Optional[ResourceSnapshotModel]
+    history: List[TaskHistoryEntry]
+
+    @classmethod
+    def from_record(cls, record: TaskRecord) -> "TaskResponse":
+        snapshot = None
+        if record.snapshot is not None:
+            snapshot = ResourceSnapshotModel(
+                timestamp=record.snapshot.timestamp,
+                cpu_percent=record.snapshot.cpu_percent,
+                memory_available=record.snapshot.memory_available,
+                memory_total=record.snapshot.memory_total,
+                battery_percent=record.snapshot.battery_percent,
+                notes=record.snapshot.notes,
+            )
+        return cls(
+            task_id=record.task_id,
+            command=record.command,
+            priority=int(record.priority),
+            requested_agent=record.requested_agent,
+            assigned_agent=record.assigned_agent,
+            status=record.status,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+            attempts=record.attempts,
+            result=record.result,
+            error=record.error,
+            metadata=record.metadata,
+            resource_profile=ResourceProfileModel(
+                cpu=record.resource_profile.cpu,
+                memory=record.resource_profile.memory,
+                battery=record.resource_profile.battery,
+                gpu=record.resource_profile.gpu,
+            ),
+            snapshot=snapshot,
+            history=[
+                TaskHistoryEntry(
+                    timestamp=entry.timestamp,
+                    status=entry.status,
+                    message=entry.message,
+                )
+                for entry in record.history
+            ],
+        )
+
+
+class TaskSubmissionRequest(BaseModel):
+    """Payload for creating a new task via the scheduler."""
+
+    command: str = Field(..., description="Instruction to execute within the agent context")
+    priority: TaskPriority = Field(
+        TaskPriority.NORMAL,
+        description="Relative priority for queue ordering; higher values run sooner.",
+    )
+    requested_agent: Optional[Agent] = Field(
+        None, description="Preferred agent when coordination requires affinity"
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arbitrary metadata echoed back in task status queries.",
+    )
+    resource_profile: Optional[ResourceProfileModel] = Field(
+        None,
+        description="Expected resource intensity. Defaults are tuned for general work.",
+    )
+
+
+class TaskListResponse(BaseModel):
+    """Container for multiple tasks."""
+
+    tasks: List[TaskResponse]
 
 
 def _build_system_status() -> SystemStatusResponse:
@@ -256,6 +395,75 @@ def healthz() -> Dict[str, str]:
     """Lightweight probe used by orchestrators to ensure the API is responsive."""
 
     return {"status": "ok", "service": "hueyos"}
+
+
+@app.post(
+    "/tasks",
+    response_model=TaskResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    tags=["Task Management"],
+)
+def submit_task(request: TaskSubmissionRequest) -> TaskResponse:
+    """Submit a task for execution by Spark or Zap."""
+
+    profile = (
+        request.resource_profile.to_profile()
+        if request.resource_profile is not None
+        else ResourceProfile()
+    )
+    record = SCHEDULER.submit_task(
+        command=request.command,
+        priority=request.priority,
+        requested_agent=request.requested_agent,
+        metadata=dict(request.metadata),
+        resource_profile=profile,
+    )
+    return TaskResponse.from_record(record)
+
+
+@app.get("/tasks", response_model=TaskListResponse, tags=["Task Management"])
+def list_tasks_endpoint(
+    status_filter: Optional[List[TaskStatus]] = Query(
+        None,
+        alias="status",
+        description="Filter results to tasks with the specified status",
+    )
+) -> TaskListResponse:
+    """List known tasks with optional status filters."""
+
+    records = SCHEDULER.list_tasks(status_filter)
+    return TaskListResponse(tasks=[TaskResponse.from_record(record) for record in records])
+
+
+@app.get(
+    "/tasks/{task_id}",
+    response_model=TaskResponse,
+    tags=["Task Management"],
+)
+def get_task(task_id: str) -> TaskResponse:
+    """Return the scheduler record for a specific task."""
+
+    try:
+        record = SCHEDULER.get_task(task_id)
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return TaskResponse.from_record(record)
+
+
+@app.post(
+    "/tasks/{task_id}/cancel",
+    response_model=TaskResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    tags=["Task Management"],
+)
+def cancel_task(task_id: str) -> TaskResponse:
+    """Cancel a pending or running task."""
+
+    try:
+        record = SCHEDULER.cancel_task(task_id)
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return TaskResponse.from_record(record)
 
 
 @app.get("/system/status", response_model=SystemStatusResponse, tags=["System"])

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -4,12 +4,33 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+import types
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(REPO_ROOT))
+sys.path.append(str(REPO_ROOT / "src"))
+
+if "huey" not in sys.modules:
+    huey_pkg = types.ModuleType("huey")
+    huey_pkg.__path__ = [
+        str(REPO_ROOT / "src" / "huey"),
+        str(REPO_ROOT / "huey"),
+    ]
+    sys.modules["huey"] = huey_pkg
+else:
+    pkg = sys.modules["huey"]
+    current_path = list(getattr(pkg, "__path__", []))
+    for candidate in (REPO_ROOT / "src" / "huey", REPO_ROOT / "huey"):
+        candidate_str = str(candidate)
+        if candidate_str not in current_path:
+            current_path.append(candidate_str)
+    pkg.__path__ = current_path
+import huey.api as api_module
 from huey.api import app
+from monkey_head.core.task_scheduler import ResourceSnapshot, TaskScheduler, TaskStatus
 
 
 @pytest.mark.asyncio
@@ -20,3 +41,61 @@ async def test_healthz_endpoint_returns_service_status():
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok", "service": "hueyos"}
+
+
+def _healthy_snapshot() -> ResourceSnapshot:
+    return ResourceSnapshot(
+        cpu_percent=10.0,
+        memory_available=8 * 1024**3,
+        memory_total=16 * 1024**3,
+        battery_percent=80.0,
+    )
+
+
+def _degraded_snapshot() -> ResourceSnapshot:
+    return ResourceSnapshot(
+        cpu_percent=98.0,
+        memory_available=512 * 1024**2,
+        memory_total=16 * 1024**3,
+        battery_percent=10.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_management_endpoints_support_submission_and_cancellation(monkeypatch):
+    scheduler = TaskScheduler(health_provider=_healthy_snapshot)
+    monkeypatch.setattr(api_module, "SCHEDULER", scheduler, raising=False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        submit = await client.post("/tasks", json={"command": "calibrate sensors"})
+        assert submit.status_code == 202
+        payload = submit.json()
+        task_id = payload["task_id"]
+        assert payload["status"] == TaskStatus.RUNNING.value
+
+        listing = await client.get("/tasks")
+        assert listing.status_code == 200
+        list_payload = listing.json()
+        assert list_payload["tasks"]
+
+        detail = await client.get(f"/tasks/{task_id}")
+        assert detail.status_code == 200
+        assert detail.json()["task_id"] == task_id
+
+        cancel = await client.post(f"/tasks/{task_id}/cancel")
+        assert cancel.status_code == 202
+        assert cancel.json()["status"] == TaskStatus.CANCELLED.value
+
+
+@pytest.mark.asyncio
+async def test_task_submission_respects_resource_constraints(monkeypatch):
+    scheduler = TaskScheduler(health_provider=_degraded_snapshot)
+    monkeypatch.setattr(api_module, "SCHEDULER", scheduler, raising=False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        submit = await client.post("/tasks", json={"command": "train heavy model"})
+
+    assert submit.status_code == 202
+    assert submit.json()["status"] == TaskStatus.PENDING.value

--- a/tests/test_task_scheduler.py
+++ b/tests/test_task_scheduler.py
@@ -1,0 +1,92 @@
+"""Tests for the :mod:`monkey_head.core.task_scheduler` module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(REPO_ROOT))
+sys.path.append(str(REPO_ROOT / "src"))
+
+if "huey" not in sys.modules:
+    huey_pkg = types.ModuleType("huey")
+    huey_pkg.__path__ = [
+        str(REPO_ROOT / "src" / "huey"),
+        str(REPO_ROOT / "huey"),
+    ]
+    sys.modules["huey"] = huey_pkg
+else:
+    pkg = sys.modules["huey"]
+    current_path = list(getattr(pkg, "__path__", []))
+    for candidate in (REPO_ROOT / "src" / "huey", REPO_ROOT / "huey"):
+        candidate_str = str(candidate)
+        if candidate_str not in current_path:
+            current_path.append(candidate_str)
+    pkg.__path__ = current_path
+
+from monkey_head.core.task_scheduler import (  # noqa: E402  pylint: disable=wrong-import-position
+    Agent,
+    ResourceProfile,
+    ResourceSnapshot,
+    TaskPriority,
+    TaskScheduler,
+    TaskStatus,
+)
+
+
+def _healthy_snapshot() -> ResourceSnapshot:
+    return ResourceSnapshot(
+        cpu_percent=12.0,
+        memory_available=8 * 1024**3,
+        memory_total=16 * 1024**3,
+        battery_percent=80.0,
+    )
+
+
+def _overloaded_snapshot() -> ResourceSnapshot:
+    return ResourceSnapshot(
+        cpu_percent=97.0,
+        memory_available=1 * 1024**3,
+        memory_total=16 * 1024**3,
+        battery_percent=15.0,
+    )
+
+
+def test_submit_task_dispatches_when_resources_are_healthy():
+    scheduler = TaskScheduler(health_provider=_healthy_snapshot)
+
+    record = scheduler.submit_task(command="run diagnostics")
+
+    assert record.status is TaskStatus.RUNNING
+    assert record.assigned_agent in {Agent.SPARK, Agent.ZAP}
+    assert record.attempts == 1
+
+
+def test_submit_task_is_pending_when_resources_are_constrained():
+    scheduler = TaskScheduler(health_provider=_overloaded_snapshot)
+
+    record = scheduler.submit_task(command="train model", priority=TaskPriority.CRITICAL)
+
+    assert record.status is TaskStatus.PENDING
+    assert record.assigned_agent is None
+    assert record.attempts == 0
+
+
+def test_fail_task_reassigns_to_alternate_agent():
+    scheduler = TaskScheduler(health_provider=_healthy_snapshot)
+
+    record = scheduler.submit_task(
+        command="analyze telemetry",
+        requested_agent=Agent.SPARK,
+        resource_profile=ResourceProfile(cpu=0.2, memory=0.1, battery=0.1),
+    )
+
+    assert record.assigned_agent is Agent.SPARK
+
+    failed = scheduler.fail_task(record.task_id, "transient GPU fault")
+
+    assert failed.status is TaskStatus.RUNNING
+    assert failed.assigned_agent is Agent.ZAP
+    assert failed.attempts == 2


### PR DESCRIPTION
## Summary
- add a reusable messaging protocol module with explicit envelopes for ZeroMQ/MQTT traffic
- implement a resource-aware task scheduler for Spark/Zap assignments and expose it through new FastAPI task endpoints
- cover the scheduler and API task flows with focused tests, including path setup for the Huey namespace

## Testing
- pytest tests/test_task_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68e48d6813b4832bb17a694adf8bc251