### PR TITLE
Add presidential co-presidents with SQLite-backed honeycomb memory

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -2,25 +2,45 @@
 
 from __future__ import annotations
 
+import logging
 from importlib import import_module
 from typing import Any
 
-from . import core  # noqa: F401
-from . import function_registry, pdf_utils, system_checks, utils  # noqa: F401
+LOGGER = logging.getLogger(__name__)
 
-__all__ = [
+_OPTIONAL_MODULES = (
+    "agents",
     "core",
     "function_registry",
+    "honeycomb_storage",
+    "llm",
     "pdf_utils",
     "system_checks",
     "utils",
-]
+)
+
+_LOADED_MODULES: dict[str, Any] = {}
+_MISSING_OPTIONALS: set[str] = set()
+
+for _module in _OPTIONAL_MODULES:
+    try:
+        _LOADED_MODULES[_module] = import_module(f"{__name__}.{_module}")
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on extras
+        LOGGER.debug("Optional Monkey Head module %s unavailable: %s", _module, exc)
+        _MISSING_OPTIONALS.add(_module)
+    else:
+        globals()[_module] = _LOADED_MODULES[_module]
+
+__all__ = [name for name in _OPTIONAL_MODULES if name not in _MISSING_OPTIONALS]
 
 _LEGACY_PREFIX = "huey.memory.PY"
 
 
 def __getattr__(name: str) -> Any:
-    """Dynamically load legacy modules shipped with the project."""
+    """Dynamically load legacy or lazily imported modules."""
+
+    if name in _LOADED_MODULES:
+        return _LOADED_MODULES[name]
 
     try:
         module = import_module(f"{_LEGACY_PREFIX}.{name}")
@@ -42,3 +62,4 @@ def _legacy_exports() -> set[str]:
     except ModuleNotFoundError:  # pragma: no cover - legacy path missing
         return set()
     return set(getattr(legacy_pkg, "__all__", ()))
+

--- a/monkey_head/agents/__init__.py
+++ b/monkey_head/agents/__init__.py
@@ -1,0 +1,18 @@
+"""High-level agent orchestration utilities."""
+
+from .presidential import (
+    ActionProposal,
+    AgentDecision,
+    PresidentialCouncil,
+    SparkAgent,
+    ZapAgent,
+)
+
+__all__ = [
+    "ActionProposal",
+    "AgentDecision",
+    "PresidentialCouncil",
+    "SparkAgent",
+    "ZapAgent",
+]
+

--- a/monkey_head/agents/presidential.py
+++ b/monkey_head/agents/presidential.py
@@ -1,0 +1,328 @@
+"""Bicameral presidential agent architecture (Spark and Zap)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from uuid import uuid5, NAMESPACE_URL
+
+from monkey_head.honeycomb_storage import HoneycombStorage, ConversationEntry
+from monkey_head.llm import PyGPTLLMClient, StructuredDecision
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AgentMetadata:
+    uuid: str
+    name: str
+    capabilities: List[str]
+    model: str
+    agent_provider: str
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ActionProposal:
+    action_id: str
+    summary: str
+    details: str
+    risk_level: str = "medium"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class AgentDecision:
+    action_id: str
+    agent_name: str
+    approved: bool
+    rationale: str
+    confidence: float
+    structured: StructuredDecision
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ConsensusResult:
+    action_id: str
+    outcome: str
+    decisions: List[AgentDecision]
+    rationale: str
+    human_override: Optional[bool] = None
+
+
+def _load_agent_template() -> Dict[str, Any]:
+    template_path = (
+        Path(__file__).resolve().parents[2]
+        / "huey"
+        / "memory"
+        / "JSON"
+        / "agent_openai.json"
+    )
+    with template_path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+AGENT_TEMPLATE = _load_agent_template()
+
+
+def _metadata_from_template(name: str, capabilities: Iterable[str]) -> AgentMetadata:
+    template = dict(AGENT_TEMPLATE)
+    uuid = str(uuid5(NAMESPACE_URL, f"monkey-head::{name.lower()}"))
+    model = template.get("model", "gpt-4o")
+    provider = template.get("agent_provider", "openai")
+    extra = {
+        "temperature": template.get("temperature", 1.0),
+        "tools": template.get("tools", {}),
+        "template_version": template.get("__meta__", {}).get("version"),
+    }
+    return AgentMetadata(
+        uuid=uuid,
+        name=name,
+        capabilities=list(capabilities),
+        model=model,
+        agent_provider=provider,
+        extra=extra,
+    )
+
+
+class PresidentialAgent:
+    """Base class encapsulating decision, memory, and communication logic."""
+
+    def __init__(
+        self,
+        metadata: AgentMetadata,
+        memory: HoneycombStorage,
+        llm_client: PyGPTLLMClient,
+        persona: str,
+    ) -> None:
+        self.metadata = metadata
+        self.memory = memory
+        self.llm_client = llm_client
+        self.persona = persona
+
+    # ------------------------------------------------------------------
+    def _format_history(self, entries: List[ConversationEntry]) -> List[Dict[str, Any]]:
+        history_payload: List[Dict[str, Any]] = []
+        for entry in entries:
+            history_payload.append(
+                {
+                    "agent": entry.agent,
+                    "role": entry.role,
+                    "content": entry.content,
+                    "timestamp": entry.created_at.isoformat(),
+                    "metadata": entry.metadata,
+                }
+            )
+        return history_payload
+
+    # ------------------------------------------------------------------
+    def _compose_persona(self, action: ActionProposal) -> str:
+        capability_summary = ", ".join(self.metadata.capabilities)
+        return (
+            f"{self.metadata.name} persona: {self.persona}. "
+            f"Capabilities: {capability_summary}. "
+            f"Action summary: {action.summary}. Risk: {action.risk_level}."
+        )
+
+    # ------------------------------------------------------------------
+    def evaluate(self, action: ActionProposal) -> AgentDecision:
+        LOGGER.info(
+            "Agent %s evaluating action %s",
+            self.metadata.name,
+            action.action_id,
+        )
+        history_entries = self.memory.get_conversation(action.action_id)
+        formatted_history = self._format_history(history_entries)
+        persona_prompt = self._compose_persona(action)
+        action_payload = {
+            "action_id": action.action_id,
+            "summary": action.summary,
+            "details": action.details,
+            "risk_level": action.risk_level,
+            "metadata": action.metadata,
+        }
+
+        prompt_metadata = {
+            "persona": persona_prompt,
+            "capabilities": self.metadata.capabilities,
+        }
+        self.memory.append_conversation(
+            action.action_id,
+            self.metadata.name,
+            "prompt",
+            persona_prompt,
+            metadata=prompt_metadata,
+        )
+
+        structured = self.llm_client.generate_decision(
+            persona=persona_prompt,
+            action=action_payload,
+            history=formatted_history,
+        )
+
+        approved = structured.decision in {"approve", "approved", "yes"}
+        rationale = structured.rationale
+        metadata = {
+            "confidence": structured.confidence,
+            "analysis": structured.analysis,
+            "provider": self.metadata.agent_provider,
+        }
+
+        self.memory.append_conversation(
+            action.action_id,
+            self.metadata.name,
+            "analysis",
+            structured.analysis,
+            metadata=metadata,
+        )
+
+        LOGGER.info(
+            "Agent %s decision on %s: %s (confidence %.2f)",
+            self.metadata.name,
+            action.action_id,
+            "approve" if approved else "reject",
+            structured.confidence,
+        )
+
+        return AgentDecision(
+            action_id=action.action_id,
+            agent_name=self.metadata.name,
+            approved=approved,
+            rationale=rationale,
+            confidence=structured.confidence,
+            structured=structured,
+            metadata=metadata,
+        )
+
+    # ------------------------------------------------------------------
+    def communicate(
+        self,
+        action_id: str,
+        recipient: "PresidentialAgent",
+        message: str,
+    ) -> None:
+        self.memory.append_conversation(
+            action_id,
+            self.metadata.name,
+            "communication",
+            message,
+            metadata={"recipient": recipient.metadata.name},
+        )
+        LOGGER.debug(
+            "Agent %s sent message to %s for action %s",
+            self.metadata.name,
+            recipient.metadata.name,
+            action_id,
+        )
+
+
+class SparkAgent(PresidentialAgent):
+    def __init__(self, memory: HoneycombStorage, llm_client: PyGPTLLMClient) -> None:
+        metadata = _metadata_from_template(
+            "Spark",
+            [
+                "Strategic foresight",
+                "Policy alignment",
+                "Long-term risk mitigation",
+            ],
+        )
+        persona = (
+            "Visionary strategist focused on systems thinking, policy cohesion, "
+            "and ethical governance across long horizons"
+        )
+        super().__init__(metadata, memory, llm_client, persona)
+
+
+class ZapAgent(PresidentialAgent):
+    def __init__(self, memory: HoneycombStorage, llm_client: PyGPTLLMClient) -> None:
+        metadata = _metadata_from_template(
+            "Zap",
+            [
+                "Operational execution",
+                "Resource optimisation",
+                "Rapid contingency response",
+            ],
+        )
+        persona = (
+            "Pragmatic tactician specialising in execution detail, resource "
+            "balancing, and adaptive field operations"
+        )
+        super().__init__(metadata, memory, llm_client, persona)
+
+
+class PresidentialCouncil:
+    """Consensus mechanism requiring Spark and Zap alignment."""
+
+    def __init__(self, spark: SparkAgent, zap: ZapAgent, memory: HoneycombStorage) -> None:
+        self.spark = spark
+        self.zap = zap
+        self.memory = memory
+
+    # ------------------------------------------------------------------
+    def deliberate(
+        self,
+        action: ActionProposal,
+        *,
+        human_override: Optional[bool] = None,
+    ) -> ConsensusResult:
+        decisions = [self.spark.evaluate(action), self.zap.evaluate(action)]
+        approvals = {decision.approved for decision in decisions}
+
+        if len(approvals) == 1:
+            approved = approvals.pop()
+            outcome = "approved" if approved else "rejected"
+            rationale = "Spark and Zap reached unanimous consensus."
+            override = None
+        else:
+            if human_override is None:
+                outcome = "requires_human_override"
+                rationale = (
+                    "Spark and Zap are split. Decision escalated for human override "
+                    "per bicameral fail-safe."
+                )
+                override = None
+            else:
+                outcome = "approved" if human_override else "rejected"
+                rationale = (
+                    "Human override applied to resolve Spark/Zap disagreement."
+                )
+                override = human_override
+
+        LOGGER.info(
+            "Presidential council outcome for %s: %s",
+            action.action_id,
+            outcome,
+        )
+
+        self.memory.append_conversation(
+            action.action_id,
+            "PresidentialCouncil",
+            "consensus",
+            rationale,
+            metadata={
+                "outcome": outcome,
+                "decisions": [
+                    {
+                        "agent": decision.agent_name,
+                        "approved": decision.approved,
+                        "confidence": decision.confidence,
+                    }
+                    for decision in decisions
+                ],
+                "human_override": override,
+            },
+        )
+
+        return ConsensusResult(
+            action_id=action.action_id,
+            outcome=outcome,
+            decisions=decisions,
+            rationale=rationale,
+            human_override=override,
+        )
+

--- a/monkey_head/honeycomb_storage.py
+++ b/monkey_head/honeycomb_storage.py
@@ -1,0 +1,300 @@
+"""Honeycomb-inspired persistent storage with SQLite backing.
+
+This module replaces the earlier JSON-based Honeycomb storage with a
+structured SQLite implementation. Data is sharded into logical
+"honeycomb" clusters derived from hashed keys and supports replicated
+metadata alongside rich conversation history suitable for agent memory.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ConversationEntry:
+    """A single conversation message stored within a honeycomb cell."""
+
+    cell_key: str
+    agent: str
+    role: str
+    content: str
+    created_at: datetime
+    metadata: Dict[str, Any]
+
+
+class HoneycombStorage:
+    """Fault-tolerant honeycomb storage backed by SQLite."""
+
+    DEFAULT_DB_FILENAME = "honeycomb.sqlite3"
+
+    def __init__(
+        self,
+        base_dir: str | Path = "memory/HONEYCOMB",
+        replicas: int = 2,
+        db_filename: str = DEFAULT_DB_FILENAME,
+    ) -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.db_path = self.base_dir / db_filename
+        self.replicas = max(1, replicas)
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(
+            self.db_path,
+            check_same_thread=False,
+            detect_types=sqlite3.PARSE_DECLTYPES,
+        )
+        self._conn.row_factory = sqlite3.Row
+        self._apply_migrations()
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        """Close the SQLite connection."""
+
+        with self._lock:
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    def _apply_migrations(self) -> None:
+        """Apply schema migrations ensuring backwards compatibility."""
+
+        with self._lock:
+            cursor = self._conn.execute("PRAGMA user_version")
+            (version,) = cursor.fetchone()
+
+            if version < 1:
+                self._conn.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS honeycomb_cells (
+                        cell_key TEXT PRIMARY KEY,
+                        cluster TEXT NOT NULL,
+                        data TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
+                    );
+
+                    CREATE TABLE IF NOT EXISTS honeycomb_replicas (
+                        cell_key TEXT NOT NULL,
+                        replica_index INTEGER NOT NULL,
+                        cluster TEXT NOT NULL,
+                        PRIMARY KEY (cell_key, replica_index)
+                    );
+
+                    CREATE TABLE IF NOT EXISTS conversation_entries (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        cell_key TEXT NOT NULL,
+                        agent TEXT NOT NULL,
+                        role TEXT NOT NULL,
+                        content TEXT NOT NULL,
+                        created_at TEXT NOT NULL,
+                        metadata TEXT
+                    );
+                    """
+                )
+                self._conn.execute("PRAGMA user_version = 1")
+
+            if version < 2:
+                # Reserved for future migrations to avoid recreating structures.
+                self._conn.execute("PRAGMA user_version = 2")
+
+            self._conn.commit()
+
+    # ------------------------------------------------------------------
+    def _cluster_ids(self, key: str) -> List[str]:
+        digest = hashlib.sha256(key.encode("utf-8")).hexdigest()
+        clusters: List[str] = []
+        for index in range(self.replicas):
+            start = index * 2
+            end = start + 2
+            clusters.append(digest[start:end])
+        return clusters or [digest[:2]]
+
+    # ------------------------------------------------------------------
+    def _write_cell(self, key: str, cluster: str, payload: str, updated_at: str) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO honeycomb_cells (cell_key, cluster, data, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(cell_key) DO UPDATE SET
+                cluster=excluded.cluster,
+                data=excluded.data,
+                updated_at=excluded.updated_at
+            """,
+            (key, cluster, payload, updated_at),
+        )
+
+    # ------------------------------------------------------------------
+    def _write_replicas(self, key: str, clusters: Iterable[str]) -> None:
+        self._conn.execute(
+            "DELETE FROM honeycomb_replicas WHERE cell_key = ?",
+            (key,),
+        )
+        self._conn.executemany(
+            """
+            INSERT INTO honeycomb_replicas (cell_key, replica_index, cluster)
+            VALUES (?, ?, ?)
+            """,
+            ((key, index, cluster) for index, cluster in enumerate(clusters)),
+        )
+
+    # ------------------------------------------------------------------
+    def store(self, key: str, data: Dict[str, Any]) -> None:
+        """Persist JSON-serialisable data for a honeycomb key."""
+
+        payload = json.dumps(data, sort_keys=True)
+        updated_at = datetime.utcnow().isoformat()
+        clusters = self._cluster_ids(key)
+
+        with self._lock, self._conn:
+            self._write_cell(key, clusters[0], payload, updated_at)
+            self._write_replicas(key, clusters)
+
+    # ------------------------------------------------------------------
+    def load(self, key: str) -> Optional[Dict[str, Any]]:
+        """Retrieve JSON data for the given key, if present."""
+
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT data FROM honeycomb_cells WHERE cell_key = ?",
+                (key,),
+            ).fetchone()
+        if not row:
+            return None
+        return json.loads(row["data"])
+
+    # ------------------------------------------------------------------
+    def remove(self, key: str) -> None:
+        """Remove the honeycomb cell and associated replicas and history."""
+
+        with self._lock, self._conn:
+            self._conn.execute(
+                "DELETE FROM conversation_entries WHERE cell_key = ?",
+                (key,),
+            )
+            self._conn.execute(
+                "DELETE FROM honeycomb_replicas WHERE cell_key = ?",
+                (key,),
+            )
+            self._conn.execute(
+                "DELETE FROM honeycomb_cells WHERE cell_key = ?",
+                (key,),
+            )
+
+    # ------------------------------------------------------------------
+    def list_keys(self) -> List[str]:
+        """Return all known honeycomb keys sorted alphabetically."""
+
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT cell_key FROM honeycomb_cells ORDER BY cell_key ASC"
+            ).fetchall()
+        return [row["cell_key"] for row in rows]
+
+    # ------------------------------------------------------------------
+    def append_conversation(
+        self,
+        key: str,
+        agent: str,
+        role: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Persist a conversation entry linked to the honeycomb key."""
+
+        metadata_json = json.dumps(metadata or {}, sort_keys=True)
+        created_at = datetime.utcnow().isoformat()
+
+        with self._lock, self._conn:
+            clusters = self._cluster_ids(key)
+            if self.load(key) is None:
+                self._write_cell(
+                    key,
+                    clusters[0],
+                    json.dumps({}, sort_keys=True),
+                    created_at,
+                )
+                self._write_replicas(key, clusters)
+
+            self._conn.execute(
+                """
+                INSERT INTO conversation_entries
+                    (cell_key, agent, role, content, created_at, metadata)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (key, agent, role, content, created_at, metadata_json),
+            )
+
+            base_payload = self.load(key) or {}
+            stats = {
+                "conversation_count": self._conversation_count_locked(key),
+                "last_speaker": agent,
+                "last_role": role,
+                "last_updated": created_at,
+            }
+            base_payload.update(stats)
+            self._write_cell(
+                key,
+                clusters[0],
+                json.dumps(base_payload, sort_keys=True),
+                created_at,
+            )
+
+    # ------------------------------------------------------------------
+    def _conversation_count_locked(self, key: str) -> int:
+        row = self._conn.execute(
+            "SELECT COUNT(*) as total FROM conversation_entries WHERE cell_key = ?",
+            (key,),
+        ).fetchone()
+        if row is None:
+            return 0
+        if "total" in row.keys():
+            return int(row["total"])
+        return int(row[0])
+
+    # ------------------------------------------------------------------
+    def get_conversation(self, key: str, limit: Optional[int] = None) -> List[ConversationEntry]:
+        """Return ordered conversation history for a given honeycomb key."""
+
+        query = (
+            "SELECT cell_key, agent, role, content, created_at, metadata "
+            "FROM conversation_entries WHERE cell_key = ? "
+            "ORDER BY id ASC"
+        )
+        if limit is not None:
+            query += " LIMIT ?"
+            params: Iterable[Any] = (key, limit)
+        else:
+            params = (key,)
+
+        with self._lock:
+            rows = self._conn.execute(query, params).fetchall()
+
+        entries: List[ConversationEntry] = []
+        for row in rows:
+            metadata_raw = row["metadata"]
+            metadata = json.loads(metadata_raw) if metadata_raw else {}
+            entries.append(
+                ConversationEntry(
+                    cell_key=row["cell_key"],
+                    agent=row["agent"],
+                    role=row["role"],
+                    content=row["content"],
+                    created_at=datetime.fromisoformat(row["created_at"]),
+                    metadata=metadata,
+                )
+            )
+        return entries
+
+
+__all__ = ["HoneycombStorage", "ConversationEntry"]
+

--- a/monkey_head/llm/__init__.py
+++ b/monkey_head/llm/__init__.py
@@ -1,0 +1,10 @@
+"""LLM provider abstractions for Monkey Head agents."""
+
+from .providers import (
+    LLMProviderRegistry,
+    PyGPTLLMClient,
+    StructuredDecision,
+)
+
+__all__ = ["LLMProviderRegistry", "PyGPTLLMClient", "StructuredDecision"]
+

--- a/monkey_head/llm/providers.py
+++ b/monkey_head/llm/providers.py
@@ -1,0 +1,152 @@
+"""Abstractions for routing LLM calls through the pygpt-MHP stack."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Protocol
+
+try:  # pragma: no cover - optional dependency tree
+    from pygpt.provider.agents.openai import OpenAIAgent
+except ModuleNotFoundError:  # pragma: no cover - llama_index missing
+    OpenAIAgent = None  # type: ignore[assignment]
+
+
+class ProviderExecutor(Protocol):
+    """Protocol describing callables that execute provider-specific requests."""
+
+    def __call__(
+        self,
+        *,
+        provider: str,
+        model: Dict[str, Any],
+        persona: str,
+        action: Dict[str, Any],
+        history: List[Dict[str, Any]],
+        provider_metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        ...
+
+
+@dataclass
+class StructuredDecision:
+    """Structured response from an LLM provider."""
+
+    decision: str
+    rationale: str
+    confidence: float
+    analysis: str
+    metadata: Dict[str, Any]
+
+
+class LLMProviderRegistry:
+    """Registry that reads pygpt-MHP model configuration."""
+
+    def __init__(self, models_config_path: Optional[Path] = None) -> None:
+        root = Path(__file__).resolve().parents[2]
+        default_path = root / "pygpt" / "data" / "config" / "models.json"
+        self.models_config_path = models_config_path or default_path
+        with self.models_config_path.open("r", encoding="utf-8") as handle:
+            loaded: Dict[str, Any] = json.load(handle)
+        self._models = loaded.get("items", loaded)
+
+    # ------------------------------------------------------------------
+    def get_model(self, model_id: str) -> Dict[str, Any]:
+        if model_id not in self._models:
+            raise KeyError(f"Model '{model_id}' is not available in pygpt configuration")
+        return self._models[model_id]
+
+    # ------------------------------------------------------------------
+    def resolve_provider(self, model_id: str) -> str:
+        model = self.get_model(model_id)
+        provider = model.get("provider") or model.get("langchain", {}).get("provider")
+        if not provider:
+            raise KeyError(f"Model '{model_id}' does not declare a provider")
+        return provider
+
+    # ------------------------------------------------------------------
+    def available_providers(self) -> List[str]:
+        providers = {model.get("provider") for model in self._models.values() if model.get("provider")}
+        return sorted(p for p in providers if p)
+
+
+PROVIDER_CLASS_MAP: Dict[str, Callable[[], Any]] = {
+    "openai": (lambda: OpenAIAgent()) if OpenAIAgent is not None else (lambda: None),
+    # Anthropic and Ollama providers are surfaced for completeness even if
+    # specialised provider wrappers are supplied at runtime.
+    "anthropic": lambda: None,
+    "ollama": lambda: None,
+}
+
+
+class PyGPTLLMClient:
+    """Adapter that uses pygpt configuration to route LLM decisions."""
+
+    def __init__(
+        self,
+        model: str,
+        *,
+        registry: Optional[LLMProviderRegistry] = None,
+        executor: Optional[ProviderExecutor] = None,
+    ) -> None:
+        self.registry = registry or LLMProviderRegistry()
+        self.model_id = model
+        self.model_config = self.registry.get_model(model)
+        self.provider_name = self.registry.resolve_provider(model)
+        self.provider_metadata = self._build_provider_metadata(self.provider_name)
+        self.executor = executor
+
+    # ------------------------------------------------------------------
+    def _build_provider_metadata(self, provider_name: str) -> Dict[str, Any]:
+        factory = PROVIDER_CLASS_MAP.get(provider_name)
+        metadata: Dict[str, Any] = {"provider": provider_name}
+        if factory is None:
+            return metadata
+
+        instance = factory()
+        if instance is None:
+            return metadata
+
+        metadata.update({
+            "agent_id": getattr(instance, "id", provider_name),
+            "mode": getattr(instance, "mode", "step"),
+        })
+        return metadata
+
+    # ------------------------------------------------------------------
+    def generate_decision(
+        self,
+        *,
+        persona: str,
+        action: Dict[str, Any],
+        history: List[Dict[str, Any]],
+    ) -> StructuredDecision:
+        if self.executor is None:
+            raise RuntimeError(
+                "PyGPTLLMClient requires an executor callable to dispatch provider requests"
+            )
+
+        raw = self.executor(
+            provider=self.provider_name,
+            model=self.model_config,
+            persona=persona,
+            action=action,
+            history=history,
+            provider_metadata=self.provider_metadata,
+        )
+
+        decision = raw.get("decision", "undetermined").lower()
+        rationale = raw.get("rationale", "")
+        confidence = float(raw.get("confidence", 0.5))
+        analysis = raw.get("analysis", rationale)
+        metadata = raw.get("metadata", {})
+
+        return StructuredDecision(
+            decision=decision,
+            rationale=rationale,
+            confidence=confidence,
+            analysis=analysis,
+            metadata=metadata,
+        )
+

--- a/tests/test_honeycomb_storage.py
+++ b/tests/test_honeycomb_storage.py
@@ -1,11 +1,32 @@
 from monkey_head.honeycomb_storage import HoneycombStorage
 
 
-def test_store_and_load(tmp_path):
+def test_store_load_and_conversation(tmp_path):
     storage = HoneycombStorage(base_dir=tmp_path)
     storage.store("alpha", {"a": 1})
-    assert storage.load("alpha") == {"a": 1}
+    stored = storage.load("alpha")
+    assert stored == {"a": 1}
+
+    storage.append_conversation(
+        "alpha",
+        "Spark",
+        "analysis",
+        "Review complete",
+        metadata={"decision": "approve"},
+    )
+
+    history = storage.get_conversation("alpha")
+    assert len(history) == 1
+    assert history[0].agent == "Spark"
+    assert history[0].metadata["decision"] == "approve"
+
+    updated_payload = storage.load("alpha")
+    assert updated_payload["conversation_count"] == 1
+    assert updated_payload["last_speaker"] == "Spark"
+
     keys = storage.list_keys()
     assert "alpha" in keys
+
     storage.remove("alpha")
     assert storage.load("alpha") is None
+    assert storage.get_conversation("alpha") == []

--- a/tests/test_presidential_council.py
+++ b/tests/test_presidential_council.py
@@ -1,0 +1,93 @@
+from monkey_head.agents import (
+    ActionProposal,
+    PresidentialCouncil,
+    SparkAgent,
+    ZapAgent,
+)
+from monkey_head.honeycomb_storage import HoneycombStorage
+from monkey_head.llm import PyGPTLLMClient
+
+
+def _make_executor(spark_response, zap_response):
+    def executor(*, provider, model, persona, action, history, provider_metadata):
+        if persona.startswith("Spark persona"):
+            return spark_response
+        if persona.startswith("Zap persona"):
+            return zap_response
+        raise RuntimeError("Unknown persona request")
+
+    return executor
+
+
+def _build_agents(tmp_path, executor):
+    storage = HoneycombStorage(base_dir=tmp_path)
+    spark_client = PyGPTLLMClient(model="gpt-4o", executor=executor)
+    zap_client = PyGPTLLMClient(model="gpt-4o", executor=executor)
+    spark = SparkAgent(storage, spark_client)
+    zap = ZapAgent(storage, zap_client)
+    council = PresidentialCouncil(spark, zap, storage)
+    return storage, council
+
+
+def test_consensus_approval(tmp_path):
+    executor = _make_executor(
+        {
+            "decision": "approve",
+            "rationale": "Strategic objectives satisfied",
+            "confidence": 0.85,
+            "analysis": "Spark approves",
+        },
+        {
+            "decision": "approve",
+            "rationale": "Operational checks complete",
+            "confidence": 0.8,
+            "analysis": "Zap approves",
+        },
+    )
+    storage, council = _build_agents(tmp_path, executor)
+    action = ActionProposal(
+        action_id="deploy-1",
+        summary="Deploy update",
+        details="Roll out patch",
+        risk_level="low",
+    )
+    result = council.deliberate(action)
+
+    assert result.outcome == "approved"
+    assert all(decision.approved for decision in result.decisions)
+
+    history = storage.get_conversation("deploy-1")
+    assert any(entry.role == "consensus" for entry in history)
+
+
+def test_split_requires_human_override(tmp_path):
+    executor = _make_executor(
+        {
+            "decision": "approve",
+            "rationale": "Long-term alignment",
+            "confidence": 0.7,
+            "analysis": "Spark approve",
+        },
+        {
+            "decision": "reject",
+            "rationale": "Operational risk",
+            "confidence": 0.6,
+            "analysis": "Zap reject",
+        },
+    )
+    storage, council = _build_agents(tmp_path, executor)
+    action = ActionProposal(
+        action_id="deploy-2",
+        summary="Deploy risky change",
+        details="High risk patch",
+        risk_level="high",
+    )
+
+    result = council.deliberate(action)
+
+    assert result.outcome == "requires_human_override"
+    assert result.human_override is None
+
+    override_result = council.deliberate(action, human_override=False)
+    assert override_result.outcome == "rejected"
+    assert override_result.human_override is False


### PR DESCRIPTION
## Summary
- introduce a SQLite-backed honeycomb storage layer with conversation logging and migrations
- add Spark and Zap presidential agents with a consensus council and LLM abstraction built on pygpt metadata
- cover the new behaviour with unit tests for the honeycomb storage and the presidential council

## Testing
- pytest tests/test_honeycomb_storage.py tests/test_presidential_council.py


------
https://chatgpt.com/codex/tasks/task_e_68e48fa23a34832bac0bdd3336a77a89