### PR TITLE
Implement bicameral presidential agents with honeycomb memory

### DIFF
--- a/monkey_head/__init__.py
+++ b/monkey_head/__init__.py
@@ -2,19 +2,41 @@
 
 from __future__ import annotations
 
+import logging
 from importlib import import_module
 from typing import Any
 
-from . import core  # noqa: F401
-from . import function_registry, pdf_utils, system_checks, utils  # noqa: F401
+_LOGGER = logging.getLogger(__name__)
+
+
+def _optional_import(module_name: str) -> Any | None:
+    """Import ``module_name`` capturing errors from optional dependencies."""
+
+    try:
+        return import_module(f"monkey_head.{module_name}")
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency path
+        _LOGGER.debug("Optional module %s not available: %s", module_name, exc)
+        return None
+
+
+agents = _optional_import("agents")
+core = _optional_import("core")
+function_registry = import_module("monkey_head.function_registry")
+pdf_utils = import_module("monkey_head.pdf_utils")
+system_checks = import_module("monkey_head.system_checks")
+utils = import_module("monkey_head.utils")
 
 __all__ = [
-    "core",
     "function_registry",
     "pdf_utils",
     "system_checks",
     "utils",
 ]
+
+if agents is not None:
+    __all__.append("agents")
+if core is not None:
+    __all__.append("core")
 
 _LEGACY_PREFIX = "huey.memory.PY"
 

--- a/monkey_head/agents/__init__.py
+++ b/monkey_head/agents/__init__.py
@@ -1,0 +1,21 @@
+"""Agent implementations used by HueyOS."""
+
+from .presidential import (
+    ActionProposal,
+    AgentDecision,
+    ConsensusDecision,
+    LLMProvider,
+    PresidentialCouncil,
+    SparkAgent,
+    ZapAgent,
+)
+
+__all__ = [
+    "ActionProposal",
+    "AgentDecision",
+    "ConsensusDecision",
+    "LLMProvider",
+    "PresidentialCouncil",
+    "SparkAgent",
+    "ZapAgent",
+]

--- a/monkey_head/agents/llm.py
+++ b/monkey_head/agents/llm.py
@@ -1,0 +1,209 @@
+"""Abstractions for interacting with LLM providers via the pygpt-MHP stack."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+
+class LLMProvider(str, Enum):
+    """Supported language model providers."""
+
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    OLLAMA = "ollama"
+
+
+class LLMAdapter:
+    """Provider agnostic wrapper around chat completion style APIs."""
+
+    def __init__(
+        self,
+        provider: LLMProvider | str,
+        *,
+        model: str,
+        settings: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.provider = LLMProvider(provider)
+        self.model = model
+        self.settings = settings or {}
+        self.metadata = self._load_metadata()
+        self._client: Any | None = None
+        self._pygpt_agent: Any | None = None
+        self._register_with_pygpt()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def generate(
+        self,
+        prompt: str,
+        *,
+        messages: Optional[Sequence[Dict[str, str]]] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Generate a response using the configured provider.
+
+        When the actual provider SDK is unavailable a deterministic fallback
+        response is returned to keep the system operational during tests or on
+        air-gapped deployments.
+        """
+
+        message_history = list(messages) if messages else [
+            {"role": "user", "content": prompt}
+        ]
+        try:
+            client = self._ensure_client()
+        except RuntimeError as exc:  # pragma: no cover - exercised when deps missing
+            return self._fallback_response(prompt, message_history, error=exc)
+
+        if self.provider is LLMProvider.OPENAI:
+            return self._call_openai(client, message_history, kwargs)
+        if self.provider is LLMProvider.ANTHROPIC:
+            return self._call_anthropic(client, message_history, kwargs)
+        if self.provider is LLMProvider.OLLAMA:
+            return self._call_ollama(client, message_history, kwargs)
+        raise ValueError(f"Unsupported provider: {self.provider.value}")
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+    def _load_metadata(self) -> Dict[str, Any]:
+        """Load preset metadata from the pygpt configuration tree."""
+
+        preset_name = f"agent_{self.provider.value}.json"
+        preset_path = (
+            Path(__file__).resolve().parents[2]
+            / "pygpt"
+            / "data"
+            / "config"
+            / "presets"
+            / preset_name
+        )
+        if preset_path.exists():
+            try:
+                return json.loads(preset_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                return {}
+        return {}
+
+    def _register_with_pygpt(self) -> None:
+        """Instantiate a pygpt agent wrapper for integration metadata."""
+
+        try:
+            if self.provider is LLMProvider.OPENAI:
+                from pygpt.provider.agents.openai import OpenAIAgent as ProviderAgent
+            elif self.provider is LLMProvider.ANTHROPIC:
+                from pygpt.provider.agents.react import ReactAgent as ProviderAgent
+            else:
+                from pygpt.provider.agents.planner import PlannerAgent as ProviderAgent
+        except Exception:  # pragma: no cover - optional dependency path
+            self._pygpt_agent = None
+            return
+
+        try:
+            self._pygpt_agent = ProviderAgent()
+        except Exception:  # pragma: no cover - defensive
+            self._pygpt_agent = None
+
+    def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        try:
+            if self.provider is LLMProvider.OPENAI:
+                from openai import OpenAI
+
+                api_key = self.settings.get("api_key")
+                self._client = OpenAI(api_key=api_key) if api_key else OpenAI()
+            elif self.provider is LLMProvider.ANTHROPIC:
+                from anthropic import Anthropic
+
+                api_key = self.settings.get("api_key")
+                self._client = Anthropic(api_key=api_key) if api_key else Anthropic()
+            else:  # Ollama
+                import ollama
+
+                self._client = ollama
+        except ImportError as exc:
+            raise RuntimeError(
+                f"The {self.provider.value} client library is not installed"
+            ) from exc
+        return self._client
+
+    def _call_openai(
+        self,
+        client: Any,
+        messages: Sequence[Dict[str, str]],
+        kwargs: Dict[str, Any],
+    ) -> str:
+        try:
+            response = client.chat.completions.create(
+                model=self.model,
+                messages=list(messages),
+                **kwargs,
+            )
+            return response.choices[0].message["content"]
+        except Exception as exc:  # pragma: no cover - depends on external API
+            return self._fallback_response("", messages, error=exc)
+
+    def _call_anthropic(
+        self,
+        client: Any,
+        messages: Sequence[Dict[str, str]],
+        kwargs: Dict[str, Any],
+    ) -> str:
+        try:
+            response = client.messages.create(
+                model=self.model,
+                messages=list(messages),
+                **kwargs,
+            )
+            # anthropic SDK returns list of content blocks
+            if getattr(response, "content", None):
+                block = response.content[0]
+                return getattr(block, "text", str(block))
+            return str(response)
+        except Exception as exc:  # pragma: no cover - depends on external API
+            return self._fallback_response("", messages, error=exc)
+
+    def _call_ollama(
+        self,
+        client: Any,
+        messages: Sequence[Dict[str, str]],
+        kwargs: Dict[str, Any],
+    ) -> str:
+        try:
+            result = client.chat(
+                model=self.model,
+                messages=list(messages),
+                **kwargs,
+            )
+            if isinstance(result, dict) and "message" in result:
+                return result["message"].get("content", "")
+            return str(result)
+        except Exception as exc:  # pragma: no cover - depends on external API
+            return self._fallback_response("", messages, error=exc)
+
+    def _fallback_response(
+        self,
+        prompt: str,
+        messages: Sequence[Dict[str, str]],
+        *,
+        error: Optional[Exception] = None,
+    ) -> str:
+        """Return a deterministic offline response."""
+
+        last_message = messages[-1]["content"] if messages else prompt
+        summary = last_message[:160].strip().replace("\n", " ")
+        provider = self.provider.value
+        if error:
+            return (
+                f"[{provider} offline] Unable to reach provider because {error}. "
+                f"Summary of request: {summary}"
+            )
+        return f"[{provider} offline] Summary of request: {summary}"
+
+
+__all__ = ["LLMAdapter", "LLMProvider"]

--- a/monkey_head/agents/memory.py
+++ b/monkey_head/agents/memory.py
@@ -1,0 +1,92 @@
+"""Utilities for persisting agent state within the honeycomb memory."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from monkey_head.honeycomb_storage import HoneycombRecord, HoneycombStorage
+
+
+@dataclass(frozen=True)
+class MemoryEntry:
+    """A single memory entry persisted for an agent."""
+
+    key: str
+    topic: str
+    payload: Dict[str, Any]
+    created_at: float
+    updated_at: float
+
+
+class AgentMemory:
+    """High level helper around :class:`HoneycombStorage` for agents."""
+
+    def __init__(self, storage: HoneycombStorage, agent_id: str) -> None:
+        self._storage = storage
+        self._agent_id = agent_id
+
+    # ------------------------------------------------------------------
+    # General purpose memory helpers
+    # ------------------------------------------------------------------
+    def remember(self, topic: str, payload: Dict[str, Any]) -> MemoryEntry:
+        """Persist ``payload`` associated with ``topic``."""
+
+        key = f"agent/{self._agent_id}/{topic}/{uuid.uuid4().hex}"
+        record = self._storage.store(key, payload)
+        return MemoryEntry(
+            key=record.key,
+            topic=topic,
+            payload=payload,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+        )
+
+    def recall(self, topic: str, *, limit: Optional[int] = None) -> List[MemoryEntry]:
+        """Return recent entries for ``topic`` ordered from newest to oldest."""
+
+        prefix = f"agent/{self._agent_id}/{topic}/"
+        records = self._storage.query(prefix, limit=limit)
+        entries: List[MemoryEntry] = []
+        for record in records:
+            entries.append(
+                MemoryEntry(
+                    key=record.key,
+                    topic=topic,
+                    payload=record.data,
+                    created_at=record.created_at,
+                    updated_at=record.updated_at,
+                )
+            )
+        return entries
+
+    def log_conversation(
+        self,
+        conversation_id: str,
+        *,
+        role: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> HoneycombRecord:
+        """Record a conversational turn for transparency."""
+
+        metadata = metadata.copy() if metadata else {}
+        metadata.setdefault("agent_id", self._agent_id)
+        return self._storage.append_conversation(
+            conversation_id,
+            role=role,
+            content=content,
+            metadata=metadata,
+        )
+
+    # ------------------------------------------------------------------
+    # Convenience helpers
+    # ------------------------------------------------------------------
+    def last_decisions(self, limit: int = 5) -> List[MemoryEntry]:
+        """Shortcut for retrieving the most recent decision payloads."""
+
+        return self.recall("decision", limit=limit)
+
+
+__all__ = ["AgentMemory", "MemoryEntry"]

--- a/monkey_head/agents/presidential.py
+++ b/monkey_head/agents/presidential.py
@@ -1,0 +1,495 @@
+"""Bicameral presidential agent structure for HueyOS."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from monkey_head.honeycomb_storage import HoneycombStorage
+from .llm import LLMAdapter, LLMProvider
+from .memory import AgentMemory, MemoryEntry
+
+LOGGER = logging.getLogger(__name__)
+
+_TEMPLATE_CACHE: Dict[str, Any] | None = None
+_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "huey"
+    / "memory"
+    / "JSON"
+    / "agent_openai.json"
+)
+
+
+@dataclass(frozen=True)
+class AgentMetadata:
+    """Metadata describing an agent, derived from the OpenAI template."""
+
+    uuid: str
+    name: str
+    capabilities: List[str]
+    provider: LLMProvider
+    model: str
+    filename: str
+
+    @property
+    def agent_id(self) -> str:
+        return self.name.lower().replace(" ", "-")
+
+    @classmethod
+    def from_template(
+        cls,
+        *,
+        name: str,
+        provider: LLMProvider,
+        model: str,
+        capabilities: Iterable[str],
+        filename: str,
+    ) -> "AgentMetadata":
+        template = _load_template()
+        base_uuid = uuid.UUID(template.get("uuid", uuid.uuid4().hex))
+        derived_uuid = uuid.uuid5(base_uuid, name)
+        return cls(
+            uuid=str(derived_uuid),
+            name=name,
+            capabilities=list(capabilities),
+            provider=provider,
+            model=model,
+            filename=filename,
+        )
+
+
+@dataclass(frozen=True)
+class ActionProposal:
+    """A proposed action that requires executive approval."""
+
+    action_id: str
+    description: str
+    context: Optional[str] = None
+    tags: Sequence[str] = field(default_factory=tuple)
+    requested_by: str = "system"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_prompt(self) -> str:
+        """Render the proposal as a prompt for LLM analysis."""
+
+        prompt = {
+            "action_id": self.action_id,
+            "description": self.description,
+            "context": self.context,
+            "tags": list(self.tags),
+            "requested_by": self.requested_by,
+            "metadata": self.metadata,
+        }
+        return json.dumps(prompt, indent=2)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "action_id": self.action_id,
+            "description": self.description,
+            "context": self.context,
+            "tags": list(self.tags),
+            "requested_by": self.requested_by,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass(frozen=True)
+class AgentDecision:
+    """Decision rendered by an agent."""
+
+    agent: str
+    approved: bool
+    confidence: float
+    rationale: str
+    timestamp: float
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ConsensusDecision:
+    """Outcome of the presidential council."""
+
+    proposal: ActionProposal
+    approved: bool
+    rationale: str
+    votes: Dict[str, AgentDecision]
+    fallback_reason: Optional[str]
+    human_override: Optional[bool]
+    timestamp: float
+
+
+class PresidentialAgent:
+    """Base class shared by Spark and Zap."""
+
+    def __init__(
+        self,
+        metadata: AgentMetadata,
+        *,
+        memory: AgentMemory,
+        llm: LLMAdapter,
+        threshold: float,
+    ) -> None:
+        self.metadata = metadata
+        self.memory = memory
+        self.llm = llm
+        self.threshold = threshold
+        self.logger = logging.getLogger(f"{__name__}.{self.metadata.agent_id}")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def deliberate(self, proposal: ActionProposal) -> AgentDecision:
+        """Evaluate ``proposal`` returning a structured decision."""
+
+        history = self.memory.last_decisions(limit=3)
+        base_score = self._score_proposal(proposal, history)
+        base_score = min(max(base_score, 0.0), 1.0)
+        llm_feedback = self._solicit_llm_feedback(proposal, base_score, history)
+        adjusted_score = self._combine_scores(base_score, llm_feedback)
+        approved = adjusted_score >= self.threshold
+        rationale = self._compose_rationale(
+            proposal,
+            base_score=base_score,
+            adjusted_score=adjusted_score,
+            approved=approved,
+            llm_feedback=llm_feedback,
+        )
+        timestamp = proposal.metadata.get("timestamp") or time.time()
+        decision = AgentDecision(
+            agent=self.metadata.name,
+            approved=approved,
+            confidence=adjusted_score,
+            rationale=rationale,
+            timestamp=timestamp,
+            metadata={
+                "base_score": base_score,
+                "threshold": self.threshold,
+                "llm_feedback": llm_feedback,
+            },
+        )
+        self._persist_decision(proposal, decision)
+        return decision
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _score_proposal(
+        self, proposal: ActionProposal, history: Sequence[MemoryEntry]
+    ) -> float:
+        """Return a heuristic score between 0 and 1 for ``proposal``."""
+
+        score = 0.5
+        tags = {tag.lower() for tag in proposal.tags}
+        if "emergency" in tags:
+            score += 0.1
+        if "maintenance" in tags:
+            score += 0.05
+        risk = float(proposal.metadata.get("risk", 0.3))
+        score -= risk * 0.2
+        if history:
+            score += 0.02 * len(history)
+        return score
+
+    def _solicit_llm_feedback(
+        self,
+        proposal: ActionProposal,
+        base_score: float,
+        history: Sequence[MemoryEntry],
+    ) -> Optional[str]:
+        """Ask the configured LLM for a short opinion on the proposal."""
+
+        try:
+            prompt = (
+                "You are {name}, reviewing an action for HueyOS. Current score: {score:.2f}. "
+                "Recent decisions: {history}. Proposal JSON: {payload}."
+            ).format(
+                name=self.metadata.name,
+                score=base_score,
+                history=[entry.payload.get("decision") for entry in history],
+                payload=proposal.to_prompt(),
+            )
+            response = self.llm.generate(prompt)
+            return response
+        except Exception as exc:  # pragma: no cover - defensive
+            self.logger.warning("LLM feedback failed: %s", exc)
+            return None
+
+    def _combine_scores(self, base_score: float, llm_feedback: Optional[str]) -> float:
+        score = base_score
+        if llm_feedback:
+            text = llm_feedback.lower()
+            modifier = 0.0
+            if any(token in text for token in ("approve", "proceed", "green")):
+                modifier += 0.15
+            if any(token in text for token in ("reject", "halt", "stop")):
+                modifier -= 0.2
+            if "risk" in text:
+                modifier -= 0.1
+            score = min(max((base_score + (base_score + modifier)) / 2, 0.0), 1.0)
+        return score
+
+    def _compose_rationale(
+        self,
+        proposal: ActionProposal,
+        *,
+        base_score: float,
+        adjusted_score: float,
+        approved: bool,
+        llm_feedback: Optional[str],
+    ) -> str:
+        fragments = [
+            f"Base score {base_score:.2f} with threshold {self.threshold:.2f}.",
+            f"Adjusted score {adjusted_score:.2f} -> {'approve' if approved else 'reject'}.",
+        ]
+        if llm_feedback:
+            fragments.append(f"LLM insight: {llm_feedback}")
+        if proposal.metadata:
+            fragments.append(f"Metadata considered: {json.dumps(proposal.metadata)}")
+        return " ".join(fragments)
+
+    def _persist_decision(
+        self, proposal: ActionProposal, decision: AgentDecision
+    ) -> None:
+        payload = {
+            "proposal": proposal.to_dict(),
+            "decision": {
+                "approved": decision.approved,
+                "confidence": decision.confidence,
+                "rationale": decision.rationale,
+            },
+            "meta": decision.metadata,
+        }
+        self.memory.remember("decision", payload)
+        self.memory.log_conversation(
+            proposal.action_id,
+            role=self.metadata.name,
+            content=decision.rationale,
+            metadata={
+                "approved": decision.approved,
+                "confidence": decision.confidence,
+                "base_score": decision.metadata.get("base_score"),
+            },
+        )
+        self.logger.info(
+            "%s decided %s on %s (confidence %.2f)",
+            self.metadata.name,
+            "approve" if decision.approved else "reject",
+            proposal.action_id,
+            decision.confidence,
+        )
+
+
+class SparkAgent(PresidentialAgent):
+    """Creative oriented co-president."""
+
+    def __init__(
+        self,
+        storage: Optional[HoneycombStorage] = None,
+        *,
+        llm_settings: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        storage = storage or HoneycombStorage()
+        llm_settings = llm_settings or {}
+        provider_value = llm_settings.get("provider", LLMProvider.OPENAI)
+        provider = (
+            provider_value
+            if isinstance(provider_value, LLMProvider)
+            else LLMProvider(provider_value)
+        )
+        model = llm_settings.get("model", "gpt-4o")
+        metadata = AgentMetadata.from_template(
+            name="Spark-4",
+            provider=provider,
+            model=model,
+            capabilities=[
+                "creative ideation",
+                "constitutional interpretation",
+                "strategic synthesis",
+            ],
+            filename="agent_spark",
+        )
+        memory = AgentMemory(storage, metadata.uuid)
+        llm_adapter = LLMAdapter(provider, model=model, settings=llm_settings)
+        super().__init__(metadata, memory=memory, llm=llm_adapter, threshold=0.55)
+
+    def _score_proposal(
+        self, proposal: ActionProposal, history: Sequence[MemoryEntry]
+    ) -> float:
+        score = super()._score_proposal(proposal, history)
+        tags = {tag.lower() for tag in proposal.tags}
+        if "innovation" in tags or "creative" in tags:
+            score += 0.2
+        if "exploratory" in tags:
+            score += 0.1
+        risk = float(proposal.metadata.get("risk", 0.3))
+        score -= risk * 0.1
+        return min(max(score, 0.0), 1.0)
+
+
+class ZapAgent(PresidentialAgent):
+    """Operational and safety focused co-president."""
+
+    def __init__(
+        self,
+        storage: Optional[HoneycombStorage] = None,
+        *,
+        llm_settings: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        storage = storage or HoneycombStorage()
+        llm_settings = llm_settings or {}
+        provider_value = llm_settings.get("provider", LLMProvider.OLLAMA)
+        provider = (
+            provider_value
+            if isinstance(provider_value, LLMProvider)
+            else LLMProvider(provider_value)
+        )
+        model = llm_settings.get("model", "mistral")
+        metadata = AgentMetadata.from_template(
+            name="Zap-4",
+            provider=provider,
+            model=model,
+            capabilities=[
+                "operational oversight",
+                "risk mitigation",
+                "sensor fusion",
+            ],
+            filename="agent_zap",
+        )
+        memory = AgentMemory(storage, metadata.uuid)
+        llm_adapter = LLMAdapter(provider, model=model, settings=llm_settings)
+        super().__init__(metadata, memory=memory, llm=llm_adapter, threshold=0.65)
+
+    def _score_proposal(
+        self, proposal: ActionProposal, history: Sequence[MemoryEntry]
+    ) -> float:
+        score = super()._score_proposal(proposal, history)
+        risk = float(proposal.metadata.get("risk", 0.3))
+        score -= risk * 0.3
+        if proposal.metadata.get("requires_manual_override"):
+            score -= 0.2
+        tags = {tag.lower() for tag in proposal.tags}
+        if "safety" in tags:
+            score += 0.1
+        return min(max(score, 0.0), 1.0)
+
+
+class PresidentialCouncil:
+    """Coordinates the bicameral presidential structure."""
+
+    def __init__(
+        self,
+        *,
+        storage: Optional[HoneycombStorage] = None,
+        spark: Optional[SparkAgent] = None,
+        zap: Optional[ZapAgent] = None,
+    ) -> None:
+        self.storage = storage or HoneycombStorage()
+        self.spark = spark or SparkAgent(storage=self.storage)
+        self.zap = zap or ZapAgent(storage=self.storage)
+
+    def decide(
+        self,
+        proposal: ActionProposal,
+        *,
+        human_override: Optional[bool] = None,
+    ) -> ConsensusDecision:
+        """Run the consensus workflow for ``proposal``."""
+
+        spark_decision = self.spark.deliberate(proposal)
+        zap_decision = self.zap.deliberate(proposal)
+        votes = {
+            self.spark.metadata.name: spark_decision,
+            self.zap.metadata.name: zap_decision,
+        }
+        approved = spark_decision.approved and zap_decision.approved
+        fallback_reason: Optional[str] = None
+
+        if spark_decision.approved != zap_decision.approved:
+            if human_override is not None:
+                approved = human_override
+                fallback_reason = "Human override applied"
+            else:
+                approved = False
+                fallback_reason = (
+                    "Agents disagreed; defaulting to fail-safe rejection pending human review."
+                )
+
+        rationale = self._compose_council_rationale(votes, fallback_reason)
+        timestamp = max(spark_decision.timestamp, zap_decision.timestamp)
+        consensus = ConsensusDecision(
+            proposal=proposal,
+            approved=approved,
+            rationale=rationale,
+            votes=votes,
+            fallback_reason=fallback_reason,
+            human_override=human_override,
+            timestamp=timestamp,
+        )
+        self._log_consensus(consensus)
+        return consensus
+
+    def _compose_council_rationale(
+        self, votes: Dict[str, AgentDecision], fallback: Optional[str]
+    ) -> str:
+        fragments = []
+        for agent, decision in votes.items():
+            fragments.append(
+                f"{agent} -> {'approve' if decision.approved else 'reject'} (confidence {decision.confidence:.2f})"
+            )
+        if fallback:
+            fragments.append(f"Fallback: {fallback}")
+        return " | ".join(fragments)
+
+    def _log_consensus(self, decision: ConsensusDecision) -> None:
+        payload = {
+            "proposal": decision.proposal.to_dict(),
+            "approved": decision.approved,
+            "rationale": decision.rationale,
+            "votes": {
+                agent: {
+                    "approved": vote.approved,
+                    "confidence": vote.confidence,
+                    "rationale": vote.rationale,
+                }
+                for agent, vote in decision.votes.items()
+            },
+            "fallback_reason": decision.fallback_reason,
+            "human_override": decision.human_override,
+            "timestamp": decision.timestamp,
+        }
+        key = f"consensus/{decision.proposal.action_id}/{uuid.uuid4().hex}"
+        self.storage.store(key, payload)
+        LOGGER.info(
+            "Consensus on %s -> %s", decision.proposal.action_id, decision.approved
+        )
+
+
+def _load_template() -> Dict[str, Any]:
+    global _TEMPLATE_CACHE
+    if _TEMPLATE_CACHE is not None:
+        return _TEMPLATE_CACHE
+    if not _TEMPLATE_PATH.exists():
+        raise FileNotFoundError(
+            f"Expected template at {_TEMPLATE_PATH} to derive agent metadata"
+        )
+    _TEMPLATE_CACHE = json.loads(_TEMPLATE_PATH.read_text(encoding="utf-8"))
+    return _TEMPLATE_CACHE
+
+
+__all__ = [
+    "ActionProposal",
+    "AgentDecision",
+    "AgentMetadata",
+    "ConsensusDecision",
+    "LLMAdapter",
+    "LLMProvider",
+    "PresidentialCouncil",
+    "SparkAgent",
+    "ZapAgent",
+]

--- a/monkey_head/honeycomb_storage.py
+++ b/monkey_head/honeycomb_storage.py
@@ -1,0 +1,297 @@
+"""Honeycomb inspired structured storage for HueyOS agents."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator, List, Optional
+
+from monkey_head.utils.paths import ensure_subdirectory
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class HoneycombRecord:
+    """Represents a single stored payload inside the honeycomb."""
+
+    key: str
+    data: Any
+    created_at: float
+    updated_at: float
+
+
+class HoneycombStorage:
+    """SQLite backed key-value store arranged using a honeycomb metaphor.
+
+    Parameters
+    ----------
+    base_dir:
+        Optional directory where the SQLite database should be created. When
+        ``None`` the directory ``memory/LOGS/honeycomb`` inside the project is
+        used. The directory is always created if it does not exist.
+    db_filename:
+        Name of the SQLite database file to create within ``base_dir``.
+    """
+
+    def __init__(
+        self,
+        base_dir: Optional[Path | str] = None,
+        *,
+        db_filename: str = "honeycomb.db",
+    ) -> None:
+        if base_dir is None:
+            base_dir = ensure_subdirectory("LOGS", "honeycomb")
+        else:
+            base_dir = Path(base_dir)
+            base_dir.mkdir(parents=True, exist_ok=True)
+        self._db_path = Path(base_dir) / db_filename
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._migrate()
+
+    # ------------------------------------------------------------------
+    # Schema management
+    # ------------------------------------------------------------------
+    def _migrate(self) -> None:
+        """Run schema migrations ensuring backward compatibility."""
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute("PRAGMA user_version")
+            (current_version,) = cursor.fetchone()
+            if current_version == 0:
+                cursor.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS honeycomb_cells (
+                        full_key   TEXT PRIMARY KEY,
+                        comb       TEXT NOT NULL,
+                        cell       TEXT NOT NULL,
+                        payload    TEXT NOT NULL,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL
+                    )
+                    """
+                )
+                cursor.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_honeycomb_comb ON honeycomb_cells(comb)"
+                )
+                cursor.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_honeycomb_updated ON honeycomb_cells(updated_at)"
+                )
+                cursor.execute("PRAGMA user_version = 1")
+                self._conn.commit()
+            elif current_version > SCHEMA_VERSION:
+                raise RuntimeError(
+                    "Honeycomb storage schema is newer than this runtime supports"
+                )
+
+    # ------------------------------------------------------------------
+    # Key helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _split_key(key: str) -> tuple[str, str]:
+        """Split a key into ``comb`` and ``cell`` components."""
+
+        if "/" in key:
+            comb, cell = key.split("/", 1)
+        else:
+            comb, cell = "default", key
+        return comb, cell
+
+    # ------------------------------------------------------------------
+    # Core storage API
+    # ------------------------------------------------------------------
+    def store(self, key: str, data: Any) -> HoneycombRecord:
+        """Store ``data`` under ``key`` returning the resulting record."""
+
+        payload = json.dumps(data, ensure_ascii=False)
+        comb, cell = self._split_key(key)
+        now = time.time()
+        with self._lock:
+            existing = self._fetch_record_metadata(key)
+            created_at = existing.created_at if existing else now
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO honeycomb_cells (full_key, comb, cell, payload, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(full_key) DO UPDATE SET
+                    comb=excluded.comb,
+                    cell=excluded.cell,
+                    payload=excluded.payload,
+                    updated_at=excluded.updated_at
+                """,
+                (key, comb, cell, payload, created_at, now),
+            )
+            self._conn.commit()
+        return HoneycombRecord(key=key, data=data, created_at=created_at, updated_at=now)
+
+    def load(self, key: str) -> Optional[Any]:
+        """Return the stored payload for ``key`` or ``None`` when missing."""
+
+        record = self.get_record(key)
+        return record.data if record else None
+
+    def get_record(self, key: str) -> Optional[HoneycombRecord]:
+        """Return the full record for ``key`` including timestamps."""
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                "SELECT full_key, payload, created_at, updated_at FROM honeycomb_cells WHERE full_key = ?",
+                (key,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        return HoneycombRecord(
+            key=row["full_key"],
+            data=json.loads(row["payload"]),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def list_keys(self, prefix: Optional[str] = None) -> List[str]:
+        """Return all keys or those beginning with ``prefix`` sorted lexicographically."""
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            if prefix is None:
+                cursor.execute("SELECT full_key FROM honeycomb_cells ORDER BY full_key ASC")
+            else:
+                cursor.execute(
+                    "SELECT full_key FROM honeycomb_cells WHERE full_key LIKE ? ORDER BY full_key ASC",
+                    (f"{prefix}%",),
+                )
+            rows = cursor.fetchall()
+        return [row["full_key"] for row in rows]
+
+    def remove(self, key: str) -> None:
+        """Remove ``key`` if it exists."""
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute("DELETE FROM honeycomb_cells WHERE full_key = ?", (key,))
+            self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Honeycomb helpers
+    # ------------------------------------------------------------------
+    def append_conversation(
+        self,
+        conversation_id: str,
+        *,
+        role: str,
+        content: str,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> HoneycombRecord:
+        """Append a conversation entry stored under a deterministic honeycomb path."""
+
+        metadata = metadata.copy() if metadata else {}
+        metadata.setdefault("role", role)
+        cell_id = metadata.get("cell_id") or uuid.uuid4().hex
+        metadata["cell_id"] = cell_id
+        payload = {
+            "conversation_id": conversation_id,
+            "role": role,
+            "content": content,
+            "metadata": metadata,
+            "timestamp": time.time(),
+        }
+        key = f"conversation/{conversation_id}/{cell_id}"
+        return self.store(key, payload)
+
+    def iter_conversation(self, conversation_id: str) -> Iterator[HoneycombRecord]:
+        """Yield conversation records for ``conversation_id`` ordered by time."""
+
+        prefix = f"conversation/{conversation_id}/"
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """
+                SELECT full_key, payload, created_at, updated_at
+                FROM honeycomb_cells
+                WHERE full_key LIKE ?
+                ORDER BY created_at ASC
+                """,
+                (f"{prefix}%",),
+            )
+            rows = cursor.fetchall()
+        for row in rows:
+            yield HoneycombRecord(
+                key=row["full_key"],
+                data=json.loads(row["payload"]),
+                created_at=row["created_at"],
+                updated_at=row["updated_at"],
+            )
+
+    def query(self, prefix: str, *, limit: Optional[int] = None) -> List[HoneycombRecord]:
+        """Return records whose key begins with ``prefix`` sorted by recency."""
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            sql = (
+                "SELECT full_key, payload, created_at, updated_at "
+                "FROM honeycomb_cells WHERE full_key LIKE ? ORDER BY updated_at DESC"
+            )
+            params: list[Any] = [f"{prefix}%"]
+            if limit is not None:
+                sql += " LIMIT ?"
+                params.append(limit)
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+        return [
+            HoneycombRecord(
+                key=row["full_key"],
+                data=json.loads(row["payload"]),
+                created_at=row["created_at"],
+                updated_at=row["updated_at"],
+            )
+            for row in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+
+        with self._lock:
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _fetch_record_metadata(self, key: str) -> Optional[HoneycombRecord]:
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                "SELECT full_key, created_at, updated_at FROM honeycomb_cells WHERE full_key = ?",
+                (key,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        return HoneycombRecord(
+            key=row["full_key"],
+            data=None,
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    # Allow use as a context manager -----------------------------------
+    def __enter__(self) -> "HoneycombStorage":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - passthrough
+        self.close()
+
+
+__all__ = ["HoneycombStorage", "HoneycombRecord", "SCHEMA_VERSION"]


### PR DESCRIPTION
## Summary
- add a SQLite-backed honeycomb storage engine with conversation logging utilities
- implement Spark and Zap presidential agents with consensus workflow, agent memory, and provider-agnostic LLM adapter
- expose the agents package while keeping optional imports lazy for environments without heavy dependencies

## Testing
- pytest tests/test_honeycomb_storage.py

------
https://chatgpt.com/codex/tasks/task_e_68e495378710832b87bd8295a03382ef