### PR TITLE
Add honeycomb storage index, monitoring API, and backup tooling

### DIFF
--- a/docs/honeycomb-storage.md
+++ b/docs/honeycomb-storage.md
@@ -1,0 +1,75 @@
+# Honeycomb Storage Operations
+
+HueyOS stores long lived data inside a resilient honeycomb structure backed by
+SQLite. This document explains how the new memory index, backup procedures,
+monitoring, and retention policies work together to keep the hive healthy.
+
+## Content-aware memory index
+
+The honeycomb index maps high level content types (images, documents, logs,
+telemetry sensor data, etc.) onto deterministic comb and cell prefixes. It uses
+the existing auto-sort extension categories so the same heuristics drive both
+filesystem organisation and database persistence.
+
+| Content type | Honeycomb path prefix      | Auto-sort categories |
+| ------------ | -------------------------- | -------------------- |
+| Images       | `media/images/<cell>`      | JPEG, PNG            |
+| Documents    | `knowledge/documents/<cell>` | PDF, MD, TXT, DOC, PPT, XLS |
+| Logs         | `telemetry/logs/<cell>`    | LOG, JSON            |
+| Sensor data  | `telemetry/sensor/<cell>`  | CSV, JSON            |
+| Archives     | `packages/archives/<cell>` | ZIP, GZ              |
+| Code         | `knowledge/code/<cell>`    | PY, SH               |
+
+Developers interact with the index through
+`monkey_head.honeycomb_index.HoneycombIndex`, which can classify a path and
+store structured metadata alongside content-specific payloads. Custom content
+mappings can be registered when new categories emerge, and all mappings are
+returned via the API for introspection.
+
+## Replication and backups
+
+`monkey_head.honeycomb_backup.perform_rsync_snapshot` creates timestamped
+snapshots of the memory directory using `rsync`. Snapshots may be sent to local
+or remote (e.g. SSH mounted) destinations. Restoring a snapshot uses the same
+utility via `restore_snapshot`.
+
+Typical cron entry using a helper script:
+
+```
+0 * * * * hueyos /opt/hueyos/.venv/bin/python - <<'PY'
+from pathlib import Path
+from monkey_head.honeycomb_backup import perform_rsync_snapshot
+
+perform_rsync_snapshot(destination=Path("/mnt/honeycomb-backups"))
+PY
+```
+
+Restoration procedure:
+
+1. Mount or attach the external media containing snapshots.
+2. Choose the snapshot directory (e.g. `20240101-000000`).
+3. Run `restore_snapshot(<snapshot>, <target>)` to repopulate the memory tree.
+4. Restart services that rely on the honeycomb database.
+
+If `rsync` is unavailable the helper raises a `BackupError`, ensuring operators
+are alerted to missing tooling before an incident occurs.
+
+## Monitoring honeycomb growth
+
+`monkey_head.honeycomb_monitor.HoneycombMonitor` calculates per-comb usage,
+content-type breakdowns, and growth trends (daily buckets). The data is
+returned as JSON and feeds the new `/memory/honeycomb/usage` API endpoint.
+Dashboard integrations can visualise the `summary`, `content_types`, and
+`growth` arrays to highlight hot spots or unusually fast growth.
+
+## Retention and pruning
+
+`monkey_head.honeycomb_retention.RetentionPolicy` deletes stale records while
+respecting critical data. Retention windows can be defined per content type
+(using the index) or directly per comb, with durations specified as symbols
+such as `14d` or `6m`. Applying a policy prunes cells older than the configured
+thresholds and reports how many were removed, allowing automation to log and
+alert on reclaimed capacity.
+
+Combine backups, monitoring, and retention policies to maintain a resilient and
+self-healing storage hive.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,4 +3,5 @@
 - Constitution & Governance
 - Architecture: MacroOS, MicroOS, NanoOS
 - Storage: Bees & Honey
+  - [Honeycomb storage operations](honeycomb-storage.md)
 - Orchestration Node (X9QRI-F+), Nodes (BD795I-SE), Black Box

--- a/monkey_head/honeycomb_backup.py
+++ b/monkey_head/honeycomb_backup.py
@@ -1,0 +1,109 @@
+"""Backup and replication helpers for honeycomb memory."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from monkey_head.utils.paths import get_memory_path
+
+
+class BackupError(RuntimeError):
+    """Raised when the backup tooling is not available or fails."""
+
+
+@dataclass(frozen=True)
+class BackupResult:
+    """Details about a completed backup snapshot."""
+
+    snapshot: Path
+    command: List[str]
+    stdout: str
+    stderr: str
+
+
+def _resolve_source(source: Optional[Path] = None) -> Path:
+    if source is None:
+        return get_memory_path(create=True)
+    return Path(source).resolve()
+
+
+def _ensure_destination(destination: Path) -> Path:
+    destination = Path(destination).expanduser().resolve()
+    destination.mkdir(parents=True, exist_ok=True)
+    return destination
+
+
+def _resolve_rsync() -> str:
+    binary = shutil.which("rsync")
+    if not binary:
+        raise BackupError("rsync is required for honeycomb snapshots but was not found in PATH")
+    return binary
+
+
+def perform_rsync_snapshot(
+    *,
+    destination: Path,
+    source: Optional[Path] = None,
+    extra_args: Optional[Iterable[str]] = None,
+    dry_run: bool = False,
+    timestamp: Optional[str] = None,
+) -> BackupResult:
+    """Create a timestamped rsync snapshot of the honeycomb memory tree."""
+
+    rsync_binary = _resolve_rsync()
+    source_path = _resolve_source(source)
+    destination_root = _ensure_destination(destination)
+    snapshot_id = timestamp or time.strftime("%Y%m%d-%H%M%S")
+    snapshot_path = destination_root / snapshot_id
+    snapshot_path.mkdir(parents=True, exist_ok=True)
+    command: List[str] = [rsync_binary, "-a", "--delete"]
+    if dry_run:
+        command.append("--dry-run")
+    if extra_args:
+        command.extend(list(extra_args))
+    command.extend([f"{source_path}/", str(snapshot_path)])
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return BackupResult(
+        snapshot=snapshot_path,
+        command=command,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def restore_snapshot(snapshot: Path, target: Path, *, extra_args: Optional[Iterable[str]] = None) -> BackupResult:
+    """Restore a snapshot into ``target`` using ``rsync``."""
+
+    rsync_binary = _resolve_rsync()
+    snapshot_path = Path(snapshot).resolve()
+    target_path = Path(target).resolve()
+    target_path.mkdir(parents=True, exist_ok=True)
+    command: List[str] = [rsync_binary, "-a", "--delete"]
+    if extra_args:
+        command.extend(list(extra_args))
+    command.extend([f"{snapshot_path}/", str(target_path)])
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return BackupResult(
+        snapshot=target_path,
+        command=command,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+__all__ = ["BackupError", "BackupResult", "perform_rsync_snapshot", "restore_snapshot"]

--- a/monkey_head/honeycomb_index.py
+++ b/monkey_head/honeycomb_index.py
@@ -1,0 +1,223 @@
+"""Content aware indexing helpers for :class:`HoneycombStorage`."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from monkey_head.honeycomb_storage import HoneycombRecord, HoneycombStorage
+from monkey_head.utils.auto_sort import get_extension_map
+
+
+@dataclass(frozen=True)
+class HoneycombContentMapping:
+    """Describe how a high level content type maps onto the honeycomb."""
+
+    comb: str
+    cell_prefix: str
+    categories: Sequence[str]
+    description: str = ""
+    retention: Optional[str] = None
+
+    def prefixes(self) -> List[str]:
+        """Return full key prefixes managed by this mapping."""
+
+        base = f"{self.comb}/{self.cell_prefix}"
+        return [f"{base}/"]
+
+
+_DEFAULT_MAPPINGS: Dict[str, HoneycombContentMapping] = {
+    "images": HoneycombContentMapping(
+        comb="media",
+        cell_prefix="images",
+        categories=("JPEG", "PNG"),
+        description="Raster and photographic imagery including JPEG and PNG payloads.",
+    ),
+    "documents": HoneycombContentMapping(
+        comb="knowledge",
+        cell_prefix="documents",
+        categories=("PDF", "MD", "TXT", "DOC", "PPT", "XLS"),
+        description="Research notes, PDFs, spreadsheets and other knowledge artefacts.",
+    ),
+    "logs": HoneycombContentMapping(
+        comb="telemetry",
+        cell_prefix="logs",
+        categories=("LOG", "JSON"),
+        description="Structured and unstructured log output captured from systems.",
+    ),
+    "sensor": HoneycombContentMapping(
+        comb="telemetry",
+        cell_prefix="sensor",
+        categories=("CSV", "JSON"),
+        description="Sensor derived timeseries and JSON snapshots from the field.",
+    ),
+    "archives": HoneycombContentMapping(
+        comb="packages",
+        cell_prefix="archives",
+        categories=("ZIP", "GZ"),
+        description="Compressed backups and data bundles stored for posterity.",
+    ),
+    "code": HoneycombContentMapping(
+        comb="knowledge",
+        cell_prefix="code",
+        categories=("PY", "SH"),
+        description="Executable snippets and scripts relevant to Honeycomb operations.",
+    ),
+}
+
+
+class HoneycombIndex:
+    """Resolve content types into deterministic honeycomb storage locations."""
+
+    def __init__(
+        self,
+        storage: HoneycombStorage,
+        *,
+        mappings: Optional[Mapping[str, HoneycombContentMapping]] = None,
+        extension_map: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self._storage = storage
+        self._mappings: Dict[str, HoneycombContentMapping] = dict(
+            mappings or _DEFAULT_MAPPINGS
+        )
+        self._extension_map: Mapping[str, str] = extension_map or get_extension_map()
+        self._category_index: MutableMapping[str, str] = {}
+        self._rebuild_category_index()
+
+    # ------------------------------------------------------------------
+    # Mapping helpers
+    # ------------------------------------------------------------------
+    def _rebuild_category_index(self) -> None:
+        self._category_index.clear()
+        for content_type, mapping in self._mappings.items():
+            for category in mapping.categories:
+                self._category_index.setdefault(category.upper(), content_type)
+
+    def register_content_type(self, name: str, mapping: HoneycombContentMapping) -> None:
+        """Register or replace a mapping for ``name``."""
+
+        self._mappings[name] = mapping
+        self._rebuild_category_index()
+
+    def list_content_types(self) -> List[str]:
+        """Return the known content type identifiers."""
+
+        return sorted(self._mappings.keys())
+
+    def get_mapping(self, content_type: str) -> HoneycombContentMapping:
+        """Return the mapping for ``content_type`` raising ``KeyError`` when unknown."""
+
+        return self._mappings[content_type]
+
+    # ------------------------------------------------------------------
+    # Classification helpers
+    # ------------------------------------------------------------------
+    def infer_category(self, path: Path) -> Optional[str]:
+        """Return the auto-sort category for ``path`` when possible."""
+
+        if path.suffix:
+            extension = path.suffix.lower().lstrip(".")
+        else:
+            extension = ""
+        category = self._extension_map.get(extension)
+        if category:
+            return category.upper()
+        if extension:
+            return extension.upper()
+        return None
+
+    def infer_content_type(self, path: Path) -> Optional[str]:
+        """Return the logical content type for ``path`` if it is known."""
+
+        category = self.infer_category(path)
+        if category is None:
+            return None
+        return self._category_index.get(category)
+
+    # ------------------------------------------------------------------
+    # Storage integration
+    # ------------------------------------------------------------------
+    def _build_key(self, mapping: HoneycombContentMapping, *, cell_id: Optional[str] = None) -> str:
+        cell = cell_id or uuid.uuid4().hex
+        return f"{mapping.comb}/{mapping.cell_prefix}/{cell}"
+
+    def store_payload(
+        self,
+        content_type: str,
+        payload: Dict[str, object],
+        *,
+        metadata: Optional[Dict[str, object]] = None,
+        cell_id: Optional[str] = None,
+    ) -> HoneycombRecord:
+        """Persist ``payload`` under the path defined for ``content_type``."""
+
+        mapping = self.get_mapping(content_type)
+        record_payload = {
+            "content_type": content_type,
+            "payload": payload,
+            "metadata": metadata or {},
+            "indexed_at": time.time(),
+        }
+        key = self._build_key(mapping, cell_id=cell_id)
+        return self._storage.store(key, record_payload)
+
+    def index_file(
+        self,
+        path: Path,
+        *,
+        content_type: Optional[str] = None,
+        metadata: Optional[Dict[str, object]] = None,
+    ) -> HoneycombRecord:
+        """Record metadata about ``path`` into the honeycomb."""
+
+        resolved = Path(path).resolve()
+        inferred = content_type or self.infer_content_type(resolved)
+        mapping_type = inferred or "misc"
+        mapping = self._mappings.get(mapping_type)
+        if mapping is None:
+            mapping = HoneycombContentMapping(
+                comb="misc",
+                cell_prefix="general",
+                categories=(),
+                description="Fallback bucket for unclassified artefacts.",
+            )
+            self._mappings[mapping_type] = mapping
+            self._rebuild_category_index()
+        payload = {
+            "path": str(resolved),
+            "name": resolved.name,
+            "suffix": resolved.suffix,
+            "category": self.infer_category(resolved),
+            "content_type": mapping_type,
+        }
+        payload.update(metadata or {})
+        return self.store_payload(mapping_type, payload)
+
+    def prefixes_for_content_type(self, content_type: str) -> Iterable[str]:
+        """Return storage prefixes used by ``content_type``."""
+
+        mapping = self.get_mapping(content_type)
+        return mapping.prefixes()
+
+    def describe(self) -> Dict[str, Dict[str, object]]:
+        """Return a serialisable description of the registered mappings."""
+
+        description: Dict[str, Dict[str, object]] = {}
+        for name, mapping in self._mappings.items():
+            description[name] = {
+                "comb": mapping.comb,
+                "cell_prefix": mapping.cell_prefix,
+                "categories": list(mapping.categories),
+                "description": mapping.description,
+                "retention": mapping.retention,
+            }
+        return description
+
+
+__all__ = [
+    "HoneycombContentMapping",
+    "HoneycombIndex",
+]

--- a/monkey_head/honeycomb_monitor.py
+++ b/monkey_head/honeycomb_monitor.py
@@ -1,0 +1,109 @@
+"""Monitoring helpers for analysing honeycomb memory utilisation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+from monkey_head.honeycomb_index import HoneycombIndex
+from monkey_head.honeycomb_storage import HoneycombStorage
+
+
+@dataclass(frozen=True)
+class HoneycombUsageTotals:
+    """Aggregate totals derived from the honeycomb usage metrics."""
+
+    cells: int
+    payload_bytes: int
+    combs: int
+    last_update: Optional[float]
+
+
+class HoneycombMonitor:
+    """Compute summary metrics describing how the honeycomb is being used."""
+
+    def __init__(
+        self,
+        storage: HoneycombStorage,
+        *,
+        index: Optional[HoneycombIndex] = None,
+    ) -> None:
+        self._storage = storage
+        self._index = index
+
+    def _content_type_summary(self) -> List[Dict[str, object]]:
+        if self._index is None:
+            return []
+        summary: List[Dict[str, object]] = []
+        for content_type in self._index.list_content_types():
+            aggregates = {
+                "content_type": content_type,
+                "cells": 0,
+                "payload_bytes": 0,
+                "oldest": None,
+                "newest": None,
+            }
+            for prefix in self._index.prefixes_for_content_type(content_type):
+                metrics = self._storage.prefix_metrics(prefix)
+                aggregates["cells"] += metrics["cells"]
+                aggregates["payload_bytes"] += metrics["payload_bytes"]
+                oldest = aggregates["oldest"]
+                newest = aggregates["newest"]
+                metrics_oldest = metrics.get("oldest")
+                metrics_newest = metrics.get("newest")
+                if metrics_oldest is not None and (
+                    oldest is None or metrics_oldest < oldest
+                ):
+                    aggregates["oldest"] = metrics_oldest
+                if metrics_newest is not None and (
+                    newest is None or metrics_newest > newest
+                ):
+                    aggregates["newest"] = metrics_newest
+            summary.append(aggregates)
+        return summary
+
+    def usage_totals(self, comb_usage: Iterable[Dict[str, object]]) -> HoneycombUsageTotals:
+        cells = 0
+        payload_bytes = 0
+        combs = 0
+        last_update: Optional[float] = None
+        for comb in comb_usage:
+            cells += int(comb.get("cells", 0))
+            payload_bytes += int(comb.get("payload_bytes", 0))
+            combs += 1
+            newest = comb.get("newest")
+            if newest is not None and (last_update is None or newest > last_update):
+                last_update = float(newest)
+        return HoneycombUsageTotals(
+            cells=cells,
+            payload_bytes=payload_bytes,
+            combs=combs,
+            last_update=last_update,
+        )
+
+    def build_usage_report(self, *, window_days: int = 30) -> Dict[str, object]:
+        """Return a structured overview of honeycomb usage suitable for dashboards."""
+
+        comb_usage = self._storage.comb_usage()
+        totals = self.usage_totals(comb_usage)
+        content_types = self._content_type_summary()
+        growth = self._storage.growth_samples(window_days)
+        return {
+            "summary": comb_usage,
+            "totals": {
+                "cells": totals.cells,
+                "payload_bytes": totals.payload_bytes,
+                "combs": totals.combs,
+                "last_update": totals.last_update,
+            },
+            "content_types": content_types,
+            "growth": growth,
+        }
+
+    def dashboard_payload(self, *, window_days: int = 30) -> Dict[str, object]:
+        """Alias for :meth:`build_usage_report` for readability."""
+
+        return self.build_usage_report(window_days=window_days)
+
+
+__all__ = ["HoneycombMonitor", "HoneycombUsageTotals"]

--- a/monkey_head/honeycomb_retention.py
+++ b/monkey_head/honeycomb_retention.py
@@ -1,0 +1,93 @@
+"""Retention policy helpers for honeycomb storage."""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Mapping, Optional
+
+from monkey_head.honeycomb_index import HoneycombIndex
+from monkey_head.honeycomb_storage import HoneycombStorage
+
+_DURATION_PATTERN = re.compile(r"^(?P<value>\d+)(?P<unit>[smhdwy])$")
+_UNIT_SECONDS = {
+    "s": 1,
+    "m": 60,
+    "h": 3600,
+    "d": 86400,
+    "w": 604800,
+    "y": 31557600,
+}
+
+
+def parse_duration(value: str) -> float:
+    """Convert a symbolic duration (``30d``) into seconds."""
+
+    match = _DURATION_PATTERN.match(value.strip())
+    if not match:
+        raise ValueError(f"Unsupported retention duration: {value!r}")
+    unit = match.group("unit")
+    seconds = _UNIT_SECONDS[unit]
+    amount = int(match.group("value"))
+    return float(amount * seconds)
+
+
+@dataclass
+class RetentionPolicy:
+    """Retention settings keyed by content type and comb."""
+
+    content_types: Dict[str, float] = field(default_factory=dict)
+    combs: Dict[str, float] = field(default_factory=dict)
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Mapping[str, str]]) -> "RetentionPolicy":
+        content_types: Dict[str, float] = {}
+        combs: Dict[str, float] = {}
+        for name, value in config.get("content_types", {}).items():
+            content_types[name] = parse_duration(value)
+        for name, value in config.get("combs", {}).items():
+            combs[name] = parse_duration(value)
+        return cls(content_types=content_types, combs=combs)
+
+    def to_config(self) -> Dict[str, Dict[str, str]]:
+        def _format(entries: Mapping[str, float]) -> Dict[str, str]:
+            formatted: Dict[str, str] = {}
+            for key, seconds in entries.items():
+                formatted[key] = f"{int(seconds)}s"
+            return formatted
+
+        return {
+            "content_types": _format(self.content_types),
+            "combs": _format(self.combs),
+        }
+
+    def apply(
+        self,
+        storage: HoneycombStorage,
+        *,
+        index: Optional[HoneycombIndex] = None,
+        now: Optional[float] = None,
+    ) -> Dict[str, int]:
+        """Apply the retention rules returning the number of pruned cells per key."""
+
+        now_ts = now if now is not None else time.time()
+        removed: Dict[str, int] = {}
+        if index is not None:
+            for content_type, retention_seconds in self.content_types.items():
+                prefixes = list(index.prefixes_for_content_type(content_type))
+                cutoff = now_ts - retention_seconds
+                for prefix in prefixes:
+                    count = storage.prune(prefix, older_than=cutoff)
+                    if count:
+                        removed[content_type] = removed.get(content_type, 0) + count
+        for comb, retention_seconds in self.combs.items():
+            cutoff = now_ts - retention_seconds
+            prefix = f"{comb}/"
+            count = storage.prune(prefix, older_than=cutoff)
+            if count:
+                removed[comb] = removed.get(comb, 0) + count
+        return removed
+
+
+__all__ = ["RetentionPolicy", "parse_duration"]

--- a/monkey_head/honeycomb_storage.py
+++ b/monkey_head/honeycomb_storage.py
@@ -9,7 +9,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from monkey_head.utils.paths import ensure_subdirectory
 
@@ -180,6 +180,116 @@ class HoneycombStorage:
             cursor = self._conn.cursor()
             cursor.execute("DELETE FROM honeycomb_cells WHERE full_key = ?", (key,))
             self._conn.commit()
+
+    def count(self, prefix: Optional[str] = None) -> int:
+        """Return the number of stored cells optionally scoped by ``prefix``."""
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            if prefix is None:
+                cursor.execute("SELECT COUNT(*) FROM honeycomb_cells")
+            else:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM honeycomb_cells WHERE full_key LIKE ?",
+                    (f"{prefix}%",),
+                )
+            (count,) = cursor.fetchone()
+        return int(count)
+
+    def prune(self, prefix: str, *, older_than: float) -> int:
+        """Remove cells matching ``prefix`` older than ``older_than`` seconds."""
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                "DELETE FROM honeycomb_cells WHERE full_key LIKE ? AND updated_at < ?",
+                (f"{prefix}%", older_than),
+            )
+            deleted = cursor.rowcount or 0
+            self._conn.commit()
+        return int(deleted)
+
+    def comb_usage(self) -> List[Dict[str, Any]]:
+        """Return aggregate metrics for each comb stored in the database."""
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    comb,
+                    COUNT(*) AS cells,
+                    SUM(LENGTH(payload)) AS payload_bytes,
+                    MIN(created_at) AS oldest,
+                    MAX(updated_at) AS newest
+                FROM honeycomb_cells
+                GROUP BY comb
+                ORDER BY comb ASC
+                """
+            )
+            rows = cursor.fetchall()
+        usage: List[Dict[str, Any]] = []
+        for row in rows:
+            usage.append(
+                {
+                    "comb": row["comb"],
+                    "cells": int(row["cells"]),
+                    "payload_bytes": int(row["payload_bytes"] or 0),
+                    "oldest": row["oldest"],
+                    "newest": row["newest"],
+                }
+            )
+        return usage
+
+    def prefix_metrics(self, prefix: str) -> Dict[str, Any]:
+        """Return aggregate metrics scoped to ``prefix``."""
+
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    COUNT(*) AS cells,
+                    SUM(LENGTH(payload)) AS payload_bytes,
+                    MIN(created_at) AS oldest,
+                    MAX(updated_at) AS newest
+                FROM honeycomb_cells
+                WHERE full_key LIKE ?
+                """,
+                (f"{prefix}%",),
+            )
+            row = cursor.fetchone()
+        return {
+            "cells": int(row["cells"] or 0),
+            "payload_bytes": int(row["payload_bytes"] or 0),
+            "oldest": row["oldest"],
+            "newest": row["newest"],
+        }
+
+    def growth_samples(self, window_days: int = 30) -> List[Dict[str, Any]]:
+        """Return per-day growth metrics limited to ``window_days`` worth of data."""
+
+        cutoff = time.time() - (window_days * 86400)
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    strftime('%Y-%m-%d', created_at, 'unixepoch') AS bucket,
+                    COUNT(*) AS cells
+                FROM honeycomb_cells
+                WHERE created_at >= ?
+                GROUP BY bucket
+                ORDER BY bucket ASC
+                """,
+                (cutoff,),
+            )
+            rows = cursor.fetchall()
+        return [
+            {"date": row["bucket"], "cells": int(row["cells"])}
+            for row in rows
+            if row["bucket"] is not None
+        ]
 
     # ------------------------------------------------------------------
     # Honeycomb helpers

--- a/monkey_head/utils/auto_sort.py
+++ b/monkey_head/utils/auto_sort.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Mapping
 
 from ..function_registry import register_function
 from .paths import get_memory_path
@@ -33,6 +33,12 @@ _EXTENSION_MAP: Dict[str, str] = {
     "yml": "YAML",
     "zip": "ZIP",
 }
+
+
+def get_extension_map() -> Mapping[str, str]:
+    """Return a read-only view of the extension to category mapping."""
+
+    return _EXTENSION_MAP.copy()
 
 
 def _normalise_destination_root(destination: str | Path | None) -> Path:

--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -26,6 +26,9 @@ from monkey_head.core.task_scheduler import (
     TaskScheduler,
     TaskStatus,
 )
+from monkey_head.honeycomb_index import HoneycombIndex
+from monkey_head.honeycomb_monitor import HoneycombMonitor
+from monkey_head.honeycomb_storage import HoneycombStorage
 from monkey_head.pdf_utils import find_pdf, list_available_pdfs
 from monkey_head.system_checks import system_check
 from monkey_head.utils.auto_sort import auto_sort_memory
@@ -113,6 +116,51 @@ class AutoSortResponse(BaseModel):
     destination: str
     moved: List[str]
     skipped: List[str]
+
+
+class HoneycombUsageEntry(BaseModel):
+    """Metrics for a single comb inside the honeycomb storage."""
+
+    comb: str
+    cells: int
+    payload_bytes: int
+    oldest: Optional[float]
+    newest: Optional[float]
+
+
+class HoneycombContentUsage(BaseModel):
+    """Aggregated metrics for a logical content type."""
+
+    content_type: str
+    cells: int
+    payload_bytes: int
+    oldest: Optional[float]
+    newest: Optional[float]
+
+
+class HoneycombGrowthSample(BaseModel):
+    """Historical growth sample for the honeycomb."""
+
+    date: str
+    cells: int
+
+
+class HoneycombUsageTotals(BaseModel):
+    """Aggregate totals summarising honeycomb usage."""
+
+    cells: int
+    payload_bytes: int
+    combs: int
+    last_update: Optional[float]
+
+
+class HoneycombUsageResponse(BaseModel):
+    """Response payload describing honeycomb utilisation."""
+
+    summary: List[HoneycombUsageEntry]
+    totals: HoneycombUsageTotals
+    content_types: List[HoneycombContentUsage]
+    growth: List[HoneycombGrowthSample]
 
 
 class ProcessTextRequest(BaseModel):
@@ -520,6 +568,37 @@ def auto_sort(request: AutoSortRequest) -> AutoSortResponse:
     except FileNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     return AutoSortResponse(**summary)
+
+
+@app.get(
+    "/memory/honeycomb/usage",
+    response_model=HoneycombUsageResponse,
+    tags=["Memory"],
+)
+def honeycomb_usage(
+    window_days: int = Query(
+        30,
+        ge=1,
+        le=365,
+        description="Number of days to include when calculating growth statistics.",
+    )
+) -> HoneycombUsageResponse:
+    """Return aggregate metrics describing honeycomb storage utilisation."""
+
+    with HoneycombStorage() as storage:
+        index = HoneycombIndex(storage)
+        monitor = HoneycombMonitor(storage, index=index)
+        report = monitor.build_usage_report(window_days=window_days)
+    summary = [HoneycombUsageEntry(**item) for item in report["summary"]]
+    content_types = [HoneycombContentUsage(**item) for item in report["content_types"]]
+    totals = HoneycombUsageTotals(**report["totals"])
+    growth = [HoneycombGrowthSample(**item) for item in report["growth"]]
+    return HoneycombUsageResponse(
+        summary=summary,
+        totals=totals,
+        content_types=content_types,
+        growth=growth,
+    )
 
 
 @app.post(

--- a/tests/test_honeycomb_management.py
+++ b/tests/test_honeycomb_management.py
@@ -1,0 +1,101 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from monkey_head.honeycomb_backup import perform_rsync_snapshot, restore_snapshot
+from monkey_head.honeycomb_index import HoneycombIndex
+from monkey_head.honeycomb_retention import RetentionPolicy, parse_duration
+from monkey_head.honeycomb_storage import HoneycombStorage
+from monkey_head.honeycomb_monitor import HoneycombMonitor
+
+
+def test_honeycomb_index_maps_extensions(tmp_path):
+    storage = HoneycombStorage(base_dir=tmp_path)
+    index = HoneycombIndex(storage)
+    image_path = tmp_path / "photo.jpeg"
+    image_path.write_bytes(b"data")
+    record = index.index_file(image_path)
+    assert record.key.startswith("media/images/")
+    payload = storage.load(record.key)
+    assert payload["payload"]["content_type"] == "images"
+    assert payload["payload"]["name"] == "photo.jpeg"
+
+
+def test_honeycomb_monitor_reports_usage(tmp_path):
+    storage = HoneycombStorage(base_dir=tmp_path)
+    index = HoneycombIndex(storage)
+    storage.store("media/images/abc", {"payload": {}})
+    storage.store("telemetry/logs/def", {"payload": {}})
+    monitor = HoneycombMonitor(storage, index=index)
+    report = monitor.build_usage_report()
+    assert report["totals"]["cells"] == 2
+    assert len(report["summary"]) >= 2
+    assert any(item["content_type"] == "images" for item in report["content_types"])
+
+
+def test_retention_policy_prunes_old_cells(tmp_path, monkeypatch):
+    import monkey_head.honeycomb_storage as storage_module
+    import monkey_head.honeycomb_retention as retention_module
+
+    storage = HoneycombStorage(base_dir=tmp_path)
+    index = HoneycombIndex(storage)
+
+    monkeypatch.setattr(storage_module.time, "time", lambda: 1000.0)
+    index.store_payload("logs", {"message": "old"}, cell_id="old")
+
+    monkeypatch.setattr(storage_module.time, "time", lambda: 2000.0)
+    index.store_payload("logs", {"message": "new"}, cell_id="new")
+
+    policy = RetentionPolicy(content_types={"logs": 500.0})
+    monkeypatch.setattr(retention_module.time, "time", lambda: 2000.0)
+
+    removed = policy.apply(storage, index=index)
+    assert removed["logs"] == 1
+    assert storage.count("telemetry/logs/") == 1
+
+
+def test_parse_duration_supports_units():
+    assert parse_duration("10s") == 10
+    assert parse_duration("5m") == 300
+    with pytest.raises(ValueError):
+        parse_duration("abc")
+
+
+def test_backup_helpers_build_rsync_commands(tmp_path, monkeypatch):
+    import monkey_head.honeycomb_backup as backup_module
+
+    source = tmp_path / "memory"
+    destination = tmp_path / "snapshots"
+    source.mkdir()
+    (source / "data.txt").write_text("hello")
+
+    monkeypatch.setattr(backup_module, "_resolve_rsync", lambda: "/usr/bin/rsync")
+
+    commands = {}
+
+    def fake_run(cmd, check, capture_output, text):
+        commands["cmd"] = cmd
+
+        class Result:
+            stdout = "ok"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = perform_rsync_snapshot(
+        destination=destination,
+        source=source,
+        timestamp="20240101-000000",
+    )
+
+    assert commands["cmd"][0] == "/usr/bin/rsync"
+    assert commands["cmd"][-2] == f"{source.resolve()}/"
+    assert result.snapshot == destination / "20240101-000000"
+
+    commands.clear()
+    restore_result = restore_snapshot(destination / "20240101-000000", tmp_path / "restore")
+    assert commands["cmd"][0] == "/usr/bin/rsync"
+    assert restore_result.snapshot == (tmp_path / "restore")


### PR DESCRIPTION
## Summary
- add a honeycomb content index together with retention helpers and monitoring utilities
- expose honeycomb usage metrics via the API and document storage/operations guidance
- provide rsync-based backup and restore helpers with accompanying tests

## Testing
- pytest *(fails: environment lacks optional dependencies such as httpx and pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68e49774d604832b8832b7429aa623d5