### PR TITLE
Implement resilience and emergency governance tooling

### DIFF
--- a/monkey_head/core/resilience.py
+++ b/monkey_head/core/resilience.py
@@ -1,0 +1,393 @@
+"""Resilience and emergency management utilities for HueyOS.
+
+This module centralises the logic required to monitor long running
+processes, automatically recover from crashes, interface with watchdog
+facilities provided by systemd/Kubernetes and coordinate emergency
+powers that require quorum style approval.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+HealthCheck = Callable[[], bool]
+RestartCallback = Callable[[], None]
+
+
+@dataclass
+class CrashEvent:
+    """Represents a crash or health failure detected for a monitored process."""
+
+    process: str
+    timestamp: float
+    restarted: bool
+    message: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MonitoredProcess:
+    """A process tracked by :class:`CrashRecoveryManager`."""
+
+    name: str
+    health_check: HealthCheck
+    restart_callback: RestartCallback
+    auto_restart_enabled: bool = True
+    last_heartbeat: float = field(default_factory=lambda: time.time())
+    last_restart: Optional[float] = None
+    restart_attempts: int = 0
+    healthy: bool = True
+    manual_override_reason: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def check_health(self) -> bool:
+        """Execute the configured health check and update cached state."""
+
+        try:
+            healthy = bool(self.health_check())
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            healthy = False
+            self.metadata["health_error"] = str(exc)
+            LOGGER.exception("Health check for %%s raised an exception", self.name)
+        self.healthy = healthy
+        self.last_heartbeat = time.time()
+        return healthy
+
+    def restart(self) -> None:
+        """Invoke the restart callback and update counters."""
+
+        self.restart_callback()
+        self.restart_attempts += 1
+        self.last_restart = time.time()
+
+
+class SystemdWatchdogClient:
+    """Best-effort interface to the systemd watchdog notification socket."""
+
+    def __init__(self, notify_socket: Optional[str] = None) -> None:
+        self.notify_socket = notify_socket or os.environ.get("NOTIFY_SOCKET")
+
+    def _send(self, payload: bytes) -> bool:
+        if not self.notify_socket:
+            return False
+        address = self.notify_socket
+        if address.startswith("@"):
+            address = "\0" + address[1:]
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+            sock.connect(address)
+            sock.sendall(payload)
+            return True
+        except OSError as exc:  # pragma: no cover - environment dependent
+            LOGGER.debug("Failed to notify systemd watchdog: %s", exc)
+            return False
+        finally:
+            try:
+                sock.close()
+            except Exception:  # pragma: no cover - defensive cleanup
+                pass
+
+    def ready(self) -> bool:
+        """Signal to systemd that the service initialisation completed."""
+
+        return self._send(b"READY=1")
+
+    def ping(self) -> bool:
+        """Send a watchdog heartbeat. Returns ``True`` when delivered."""
+
+        return self._send(b"WATCHDOG=1")
+
+
+class EmergencyState(str, Enum):
+    """Operational modes for the emergency governance controller."""
+
+    NORMAL = "normal"
+    EMERGENCY = "emergency"
+
+
+@dataclass
+class RegisteredService:
+    """Represents a service managed during emergency transitions."""
+
+    name: str
+    stop: Callable[[], None]
+    start: Optional[Callable[[], None]] = None
+    essential: bool = False
+
+
+class EmergencyGovernanceController:
+    """Coordinate the HueyOS emergency powers workflow."""
+
+    def __init__(self, required_approvals: int = 2) -> None:
+        if required_approvals < 1:
+            raise ValueError("required_approvals must be at least 1")
+        self.required_approvals = required_approvals
+        self.state = EmergencyState.NORMAL
+        self.active_since: Optional[float] = None
+        self.reason: Optional[str] = None
+        self.triggered_by: Optional[str] = None
+        self.approvals: List[str] = []
+        self._services: Dict[str, RegisteredService] = {}
+        self._lock = threading.RLock()
+
+    def register_service(
+        self,
+        name: str,
+        *,
+        stop: Callable[[], None],
+        start: Optional[Callable[[], None]] = None,
+        essential: bool = False,
+    ) -> None:
+        """Track a service that should be managed during emergency transitions."""
+
+        with self._lock:
+            self._services[name] = RegisteredService(
+                name=name, stop=stop, start=start, essential=essential
+            )
+
+    def _validate_approvals(self, approvals: Iterable[str], initiator: str) -> List[str]:
+        unique = {initiator}
+        for approval in approvals:
+            if approval:
+                unique.add(approval)
+        if len(unique) < self.required_approvals:
+            raise PermissionError(
+                "Emergency actions require at least "
+                f"{self.required_approvals} distinct approvals"
+            )
+        return sorted(unique)
+
+    def enter_emergency_mode(
+        self, *, triggered_by: str, reason: str, approvals: Iterable[str] = ()
+    ) -> None:
+        """Activate emergency mode and halt non-essential services."""
+
+        if not reason:
+            raise ValueError("An emergency reason must be provided")
+        with self._lock:
+            if self.state is EmergencyState.EMERGENCY:
+                LOGGER.info("Emergency mode already active; ignoring duplicate request")
+                return
+            self.approvals = self._validate_approvals(approvals, triggered_by)
+            self.state = EmergencyState.EMERGENCY
+            self.active_since = time.time()
+            self.reason = reason
+            self.triggered_by = triggered_by
+            LOGGER.warning(
+                "Emergency mode activated by %s with reason: %s", triggered_by, reason
+            )
+            for service in self._services.values():
+                if service.essential:
+                    continue
+                try:
+                    service.stop()
+                    LOGGER.info("Stopped non-essential service: %s", service.name)
+                except Exception:  # pragma: no cover - defensive logging
+                    LOGGER.exception(
+                        "Failed to stop non-essential service %s", service.name
+                    )
+
+    def exit_emergency_mode(
+        self, *, requested_by: str, approvals: Iterable[str] = ()
+    ) -> None:
+        """Return HueyOS to normal operations."""
+
+        with self._lock:
+            if self.state is EmergencyState.NORMAL:
+                LOGGER.info("Exit request ignored because system is not in emergency mode")
+                return
+            approval_identities = self._validate_approvals(approvals, requested_by)
+            LOGGER.warning(
+                "Emergency mode exit authorised by %s (approvals=%s)",
+                requested_by,
+                approval_identities,
+            )
+            for service in self._services.values():
+                if service.start is None:
+                    continue
+                try:
+                    service.start()
+                    LOGGER.info("Restarted service after emergency: %s", service.name)
+                except Exception:  # pragma: no cover - defensive logging
+                    LOGGER.exception(
+                        "Failed to restart service %s after emergency", service.name
+                    )
+            self.state = EmergencyState.NORMAL
+            self.active_since = None
+            self.reason = None
+            self.triggered_by = None
+            self.approvals = []
+
+    def request_authorised_action(
+        self, *, actor: str, approvals: Iterable[str], action: str
+    ) -> None:
+        """Validate quorum before allowing an emergency-only action."""
+
+        self._validate_approvals(approvals, actor)
+        LOGGER.info(
+            "Action '%s' authorised by %s with approvals %s",
+            action,
+            actor,
+            sorted(set(approvals) | {actor}),
+        )
+
+    def status(self) -> Dict[str, Any]:
+        """Return a serialisable snapshot of the emergency state."""
+
+        with self._lock:
+            return {
+                "state": self.state.value,
+                "active_since": self.active_since,
+                "reason": self.reason,
+                "triggered_by": self.triggered_by,
+                "approvals": list(self.approvals),
+                "services": [
+                    {
+                        "name": service.name,
+                        "essential": service.essential,
+                        "managed": True,
+                    }
+                    for service in self._services.values()
+                ],
+            }
+
+
+class CrashRecoveryManager:
+    """Monitor a set of processes and restart them when crashes occur."""
+
+    def __init__(self, watchdog: Optional[SystemdWatchdogClient] = None) -> None:
+        self._watchdog = watchdog or SystemdWatchdogClient()
+        self._processes: Dict[str, MonitoredProcess] = {}
+        self._lock = threading.RLock()
+
+    def register_process(
+        self,
+        name: str,
+        *,
+        health_check: HealthCheck,
+        restart: RestartCallback,
+        auto_restart: bool = True,
+    ) -> None:
+        """Register a process for monitoring and automatic recovery."""
+
+        with self._lock:
+            self._processes[name] = MonitoredProcess(
+                name=name,
+                health_check=health_check,
+                restart_callback=restart,
+                auto_restart_enabled=auto_restart,
+            )
+            LOGGER.debug("Registered monitored process: %s", name)
+
+    def unregister_process(self, name: str) -> None:
+        """Stop monitoring a previously registered process."""
+
+        with self._lock:
+            self._processes.pop(name, None)
+            LOGGER.debug("Unregistered monitored process: %s", name)
+
+    def poll(self) -> List[CrashEvent]:
+        """Check the health of all processes and restart crashed ones."""
+
+        events: List[CrashEvent] = []
+        with self._lock:
+            for process in self._processes.values():
+                healthy = process.check_health()
+                if healthy:
+                    continue
+                metadata: Dict[str, Any] = {}
+                restarted = False
+                message = "Process reported unhealthy state"
+                if process.auto_restart_enabled:
+                    try:
+                        process.restart()
+                        restarted = True
+                        message = "Process restarted after crash"
+                    except Exception as exc:  # pragma: no cover - defensive logging
+                        metadata["restart_error"] = str(exc)
+                        message = f"Automatic restart failed: {exc}"
+                        LOGGER.exception(
+                            "Automatic restart failed for process %s", process.name
+                        )
+                else:
+                    metadata["manual_override"] = process.manual_override_reason or True
+                    message = "Automatic restart bypassed due to manual override"
+                event = CrashEvent(
+                    process=process.name,
+                    timestamp=time.time(),
+                    restarted=restarted,
+                    message=message,
+                    metadata=metadata,
+                )
+                events.append(event)
+                LOGGER.warning(
+                    "Crash detected for process %s (auto_restart=%s, restarted=%s)",
+                    process.name,
+                    process.auto_restart_enabled,
+                    restarted,
+                )
+        self.ping_watchdog()
+        return events
+
+    def ping_watchdog(self) -> bool:
+        """Notify systemd that the watchdog is still alive."""
+
+        return self._watchdog.ping()
+
+    def set_auto_restart(self, name: str, enabled: bool, *, reason: Optional[str] = None) -> None:
+        """Enable or disable automatic restarts for a monitored process."""
+
+        with self._lock:
+            process = self._processes.get(name)
+            if process is None:
+                raise KeyError(f"Unknown monitored process: {name}")
+            process.auto_restart_enabled = enabled
+            process.manual_override_reason = reason if not enabled else None
+            LOGGER.info(
+                "Manual override for %s set to %s (reason=%s)",
+                name,
+                enabled,
+                reason,
+            )
+
+    def manual_restart(self, name: str) -> None:
+        """Force restart a process even when auto-restart is disabled."""
+
+        with self._lock:
+            process = self._processes.get(name)
+            if process is None:
+                raise KeyError(f"Unknown monitored process: {name}")
+            process.restart()
+            LOGGER.info("Manual restart executed for process %s", name)
+
+    def statuses(self) -> List[Dict[str, Any]]:
+        """Return serialisable status information for each process."""
+
+        with self._lock:
+            return [
+                {
+                    "name": process.name,
+                    "healthy": process.healthy,
+                    "auto_restart": process.auto_restart_enabled,
+                    "last_heartbeat": process.last_heartbeat,
+                    "last_restart": process.last_restart,
+                    "restart_attempts": process.restart_attempts,
+                    "manual_override_reason": process.manual_override_reason,
+                }
+                for process in self._processes.values()
+            ]
+
+    def has_process(self, name: str) -> bool:
+        """Return ``True`` when a process is registered."""
+
+        with self._lock:
+            return name in self._processes

--- a/monkey_head/legacy/__init__.py
+++ b/monkey_head/legacy/__init__.py
@@ -1,0 +1,15 @@
+"""Legacy hardware integration helpers for HueyOS."""
+
+from .connectors import (
+    EmulatedLegacyConnector,
+    LegacyConnector,
+    LegacyConnectorFactory,
+    SerialLegacyConnector,
+)
+
+__all__ = [
+    "EmulatedLegacyConnector",
+    "LegacyConnector",
+    "LegacyConnectorFactory",
+    "SerialLegacyConnector",
+]

--- a/monkey_head/legacy/connectors.py
+++ b/monkey_head/legacy/connectors.py
@@ -1,0 +1,133 @@
+"""Legacy system connector abstractions.
+
+The HueyOS codex references Commodore and other retro systems that need to
+interface with modern infrastructure. This module provides a thin layer
+that can transparently operate in one of two modes:
+
+* **Serial bridging** using USB/RS-232 interfaces for real hardware.
+* **Emulation bridge** leveraging software emulators such as VICE.
+
+The goal is to hide connection and transport details from higher level
+callers while keeping the implementation fully testable in isolation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, Protocol
+
+LOGGER = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    import serial  # type: ignore
+except Exception:  # pragma: no cover - fallback when pyserial missing
+    serial = None  # type: ignore[assignment]
+
+
+class LegacyConnector(Protocol):
+    """Abstract interface implemented by all legacy connectors."""
+
+    async def connect(self) -> None:
+        """Establish the connection to the legacy system."""
+
+    async def send(self, payload: bytes) -> None:
+        """Send raw bytes to the legacy system."""
+
+    async def receive(self, size: int = 1024) -> bytes:
+        """Receive bytes from the legacy system."""
+
+    async def close(self) -> None:
+        """Tear down the connection."""
+
+
+@dataclass
+class SerialLegacyConnector:
+    """USB/serial bridge for physical VIC-20/C64/C128 hardware."""
+
+    port: str
+    baudrate: int = 9600
+    timeout: float = 1.0
+    _serial: Any = None
+
+    async def connect(self) -> None:
+        if serial is None:
+            raise RuntimeError(
+                "pyserial is required for SerialLegacyConnector but is not installed"
+            )
+        LOGGER.info("Opening serial connection to legacy system on %s", self.port)
+        self._serial = serial.Serial(self.port, self.baudrate, timeout=self.timeout)
+        await asyncio.sleep(0)
+
+    async def send(self, payload: bytes) -> None:
+        if self._serial is None:
+            raise RuntimeError("Serial connection has not been initialised")
+        LOGGER.debug("Writing %s bytes to legacy serial device", len(payload))
+        self._serial.write(payload)
+        await asyncio.sleep(0)
+
+    async def receive(self, size: int = 1024) -> bytes:
+        if self._serial is None:
+            raise RuntimeError("Serial connection has not been initialised")
+        data = self._serial.read(size)
+        await asyncio.sleep(0)
+        return data
+
+    async def close(self) -> None:
+        if self._serial is not None:
+            LOGGER.info("Closing serial connection to %s", self.port)
+            self._serial.close()
+            self._serial = None
+        await asyncio.sleep(0)
+
+
+@dataclass
+class EmulatedLegacyConnector:
+    """Connector that proxies requests to a software emulator."""
+
+    command_channel: asyncio.Queue[bytes] = field(init=False)
+    response_channel: asyncio.Queue[bytes] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.command_channel = asyncio.Queue()
+        self.response_channel = asyncio.Queue()
+
+    async def connect(self) -> None:
+        LOGGER.info("Initialising emulated legacy connector")
+        await asyncio.sleep(0)
+
+    async def send(self, payload: bytes) -> None:
+        LOGGER.debug("Queueing %s bytes for emulator", len(payload))
+        await self.command_channel.put(payload)
+
+    async def receive(self, size: int = 1024) -> bytes:
+        LOGGER.debug("Awaiting emulator response (max %s bytes)", size)
+        data = await self.response_channel.get()
+        return data[:size]
+
+    async def close(self) -> None:
+        LOGGER.info("Shutting down emulator connector queues")
+        await asyncio.sleep(0)
+
+    async def inject_emulator_response(self, payload: bytes) -> None:
+        """Utility helper used by tests to simulate emulator output."""
+
+        await self.response_channel.put(payload)
+
+
+class LegacyConnectorFactory:
+    """Factory for instantiating connectors based on configuration."""
+
+    @staticmethod
+    def create(config: Dict[str, Any]) -> LegacyConnector:
+        mode = config.get("mode", "emulated").lower()
+        if mode == "serial":
+            return SerialLegacyConnector(
+                port=config["port"],
+                baudrate=int(config.get("baudrate", 9600)),
+                timeout=float(config.get("timeout", 1.0)),
+            )
+        if mode == "emulated":
+            return EmulatedLegacyConnector()
+        raise ValueError(f"Unsupported legacy connector mode: {mode}")

--- a/monkey_head/scripts/failover.py
+++ b/monkey_head/scripts/failover.py
@@ -1,0 +1,103 @@
+"""Dual-motherboard failover orchestration utilities.
+
+The HueyOS hardware topology includes redundant motherboards. This module
+produces repeatable replication plans that can be executed manually or by
+a CI pipeline to mirror the active system onto the standby board.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, List, Sequence
+
+LOGGER = logging.getLogger(__name__)
+
+CommandRunner = Callable[[Sequence[str]], None]
+
+
+@dataclass
+class ReplicationTask:
+    """Represents a single rsync style replication command."""
+
+    source: Path
+    target: Path
+    command: List[str]
+
+
+@dataclass
+class FailoverPlan:
+    """Describes the work required to mirror the primary system."""
+
+    primary_root: Path
+    secondary_root: Path
+    tasks: List[ReplicationTask] = field(default_factory=list)
+    hot_swap_delay: float = 5.0
+    created_at: float = field(default_factory=lambda: time.time())
+
+    def commands(self) -> List[List[str]]:
+        return [task.command for task in self.tasks]
+
+
+def build_failover_plan(
+    primary_root: Path,
+    secondary_root: Path,
+    *,
+    volumes: Iterable[str] | None = None,
+    excludes: Iterable[str] | None = None,
+    dry_run: bool = False,
+) -> FailoverPlan:
+    """Create a failover plan that mirrors key volumes to the standby board."""
+
+    volumes = list(volumes or ("etc", "var", "home", "opt"))
+    excludes = list(excludes or ("/proc", "/sys", "/dev"))
+
+    plan = FailoverPlan(primary_root=primary_root, secondary_root=secondary_root)
+    for volume in volumes:
+        source = primary_root / volume
+        target = secondary_root / volume
+        command = [
+            "rsync",
+            "-aH",
+            "--delete",
+            "--numeric-ids",
+            str(source) + "/",
+            str(target),
+        ]
+        for pattern in excludes:
+            command.insert(3, f"--exclude={pattern}")
+        if dry_run:
+            command.insert(1, "--dry-run")
+        plan.tasks.append(ReplicationTask(source=source, target=target, command=command))
+        LOGGER.debug("Planned replication of %s -> %s", source, target)
+    return plan
+
+
+def execute_plan(plan: FailoverPlan, runner: CommandRunner | None = None) -> None:
+    """Execute the replication commands for the supplied plan."""
+
+    runner = runner or (lambda cmd: subprocess.run(cmd, check=True))
+    for task in plan.tasks:
+        LOGGER.info("Replicating %s -> %s", task.source, task.target)
+        runner(task.command)
+
+
+def simulate_hot_swap(plan: FailoverPlan, runner: CommandRunner | None = None) -> None:
+    """Simulate a hot swap by running a basic verification command set."""
+
+    runner = runner or (lambda cmd: subprocess.run(cmd, check=True))
+    verification_commands = [
+        ["test", "-d", str(plan.secondary_root / "etc")],
+        ["test", "-d", str(plan.secondary_root / "var")],
+    ]
+    for command in verification_commands:
+        LOGGER.debug("Verifying failover target: %s", " ".join(command))
+        runner(command)
+    LOGGER.info(
+        "Hot swap simulation waiting %.1f seconds before declaring success",
+        plan.hot_swap_delay,
+    )
+    time.sleep(plan.hot_swap_delay)

--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -18,6 +18,10 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from huey.memory.PY.ai_processor import AIProcessor
+from monkey_head.core.resilience import (
+    CrashRecoveryManager,
+    EmergencyGovernanceController,
+)
 from monkey_head.core.task_scheduler import (
     Agent,
     ResourceProfile,
@@ -227,8 +231,101 @@ class SystemCheckResponse(BaseModel):
     passed: bool = Field(..., description="True when every reported check passed")
 
 
+class CrashEventModel(BaseModel):
+    """Serialized representation of :class:`CrashEvent`."""
+
+    process: str
+    timestamp: float
+    restarted: bool
+    message: str
+    metadata: Dict[str, Any]
+
+
+class MonitoredProcessStatusModel(BaseModel):
+    """Status information for a process monitored by the resilience manager."""
+
+    name: str
+    healthy: bool
+    auto_restart: bool
+    last_heartbeat: Optional[float]
+    last_restart: Optional[float]
+    restart_attempts: int
+    manual_override_reason: Optional[str]
+
+
+class CrashPollResponse(BaseModel):
+    """Response emitted after polling the crash recovery manager."""
+
+    events: List[CrashEventModel]
+
+
+class ManualOverrideRequest(BaseModel):
+    """Request payload used to toggle automatic crash recovery."""
+
+    auto_restart: bool = Field(
+        ..., description="Set to False to disable automatic restarts"
+    )
+    reason: Optional[str] = Field(
+        None,
+        description="Operator reason recorded when disabling automatic restarts",
+    )
+
+
+class EmergencyServiceStatus(BaseModel):
+    """Metadata about a service managed during emergency mode."""
+
+    name: str
+    essential: bool
+    managed: bool
+
+
+class EmergencyStatusResponse(BaseModel):
+    """Snapshot of the emergency governance controller state."""
+
+    state: str
+    active_since: Optional[float]
+    reason: Optional[str]
+    triggered_by: Optional[str]
+    approvals: List[str]
+    services: List[EmergencyServiceStatus]
+
+
+class EmergencyModeRequest(BaseModel):
+    """Parameters needed to activate emergency mode."""
+
+    triggered_by: str = Field(..., description="Agent or operator requesting mode")
+    reason: str = Field(..., description="Human readable reason for emergency")
+    approvals: List[str] = Field(
+        default_factory=list,
+        description="List of additional approvers for quorum validation",
+    )
+
+
+class EmergencyExitRequest(BaseModel):
+    """Parameters required to exit emergency mode."""
+
+    requested_by: str = Field(..., description="Operator requesting exit")
+    approvals: List[str] = Field(
+        default_factory=list,
+        description="Approvers confirming exit is safe",
+    )
+
+
+class EmergencyActionRequest(BaseModel):
+    """Request payload for actions that require dual authorisation."""
+
+    actor: str = Field(..., description="Agent initiating the action")
+    approvals: List[str] = Field(
+        default_factory=list,
+        description="Additional approvers satisfying quorum",
+    )
+    action: str = Field(..., description="Description of the requested action")
+
+
 AI_PROCESSOR = AIProcessor()
 SCHEDULER = TaskScheduler()
+CRASH_MANAGER = CrashRecoveryManager()
+EMERGENCY_CONTROLLER = EmergencyGovernanceController()
 _SERVICE_STATES: Dict[str, ServiceStatus] = {}
 
 
@@ -438,6 +535,31 @@ def _update_service_status(name: str, status_value: str) -> ServiceStatus:
     return state
 
 
+def _monitor_status(name: str) -> MonitoredProcessStatusModel:
+    """Return the status object for ``name`` or raise ``KeyError``."""
+
+    for status in CRASH_MANAGER.statuses():
+        if status["name"] == name:
+            return MonitoredProcessStatusModel(**status)
+    raise KeyError(f"Unknown monitored process: {name}")
+
+
+def _register_default_emergency_services() -> None:
+    """Register baseline services that are paused during emergencies."""
+
+    service_names = ("spark-agent", "zap-agent", "ollama")
+    for service_name in service_names:
+        EMERGENCY_CONTROLLER.register_service(
+            service_name,
+            stop=lambda name=service_name: _update_service_status(name, "stopped"),
+            start=lambda name=service_name: _update_service_status(name, "running"),
+            essential=False,
+        )
+
+
+_register_default_emergency_services()
+
+
 @app.get("/healthz", tags=["System"])
 def healthz() -> Dict[str, str]:
     """Lightweight probe used by orchestrators to ensure the API is responsive."""
@@ -519,6 +641,78 @@ def system_status() -> SystemStatusResponse:
     """Return operating system, hardware, and configuration details for HueyOS."""
 
     return _build_system_status()
+
+
+@app.get(
+    "/resilience/monitors",
+    response_model=List[MonitoredProcessStatusModel],
+    tags=["Resilience"],
+)
+def list_monitored_processes() -> List[MonitoredProcessStatusModel]:
+    """Return the set of processes being watched by the crash manager."""
+
+    return [MonitoredProcessStatusModel(**status) for status in CRASH_MANAGER.statuses()]
+
+
+@app.post(
+    "/resilience/monitors/{name}/override",
+    response_model=MonitoredProcessStatusModel,
+    tags=["Resilience"],
+)
+def override_monitored_process(name: str, request: ManualOverrideRequest) -> MonitoredProcessStatusModel:
+    """Enable or disable automatic crash recovery for the given process."""
+
+    try:
+        CRASH_MANAGER.set_auto_restart(name, request.auto_restart, reason=request.reason)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return _monitor_status(name)
+
+
+@app.post(
+    "/resilience/monitors/{name}/restart",
+    response_model=MonitoredProcessStatusModel,
+    tags=["Resilience"],
+)
+def manual_restart_monitored_process(name: str) -> MonitoredProcessStatusModel:
+    """Force a restart for a monitored process regardless of overrides."""
+
+    try:
+        CRASH_MANAGER.manual_restart(name)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return _monitor_status(name)
+
+
+@app.post(
+    "/resilience/poll",
+    response_model=CrashPollResponse,
+    tags=["Resilience"],
+)
+def poll_crash_manager() -> CrashPollResponse:
+    """Poll the crash manager and return any crash events."""
+
+    events = [
+        CrashEventModel(
+            process=event.process,
+            timestamp=event.timestamp,
+            restarted=event.restarted,
+            message=event.message,
+            metadata=event.metadata,
+        )
+        for event in CRASH_MANAGER.poll()
+    ]
+    return CrashPollResponse(events=events)
+
+
+@app.post(
+    "/resilience/watchdog/ping",
+    tags=["Resilience"],
+)
+def watchdog_ping() -> Dict[str, bool]:
+    """Forward a watchdog heartbeat to the host environment."""
+
+    return {"watchdog": CRASH_MANAGER.ping_watchdog()}
 
 
 @app.get("/memory/pdfs", response_model=PDFListResponse, tags=["Memory"])
@@ -637,6 +831,83 @@ def ai_analyze_text(request: AnalyzeTextRequest) -> AnalyzeTextResponse:
 
     metrics = AI_PROCESSOR.analyze_data(request.text)
     return AnalyzeTextResponse(metrics=metrics)
+
+
+@app.get(
+    "/governance/emergency/status",
+    response_model=EmergencyStatusResponse,
+    tags=["Governance"],
+)
+def emergency_status() -> EmergencyStatusResponse:
+    """Return the current emergency governance state."""
+
+    snapshot = EMERGENCY_CONTROLLER.status()
+    services = [EmergencyServiceStatus(**service) for service in snapshot["services"]]
+    return EmergencyStatusResponse(
+        state=snapshot["state"],
+        active_since=snapshot["active_since"],
+        reason=snapshot["reason"],
+        triggered_by=snapshot["triggered_by"],
+        approvals=snapshot["approvals"],
+        services=services,
+    )
+
+
+@app.post(
+    "/governance/emergency/enter",
+    response_model=EmergencyStatusResponse,
+    tags=["Governance"],
+)
+def enter_emergency_mode(request: EmergencyModeRequest) -> EmergencyStatusResponse:
+    """Enter emergency mode after validating approvals."""
+
+    try:
+        EMERGENCY_CONTROLLER.enter_emergency_mode(
+            triggered_by=request.triggered_by,
+            reason=request.reason,
+            approvals=request.approvals,
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return emergency_status()
+
+
+@app.post(
+    "/governance/emergency/exit",
+    response_model=EmergencyStatusResponse,
+    tags=["Governance"],
+)
+def exit_emergency_mode(request: EmergencyExitRequest) -> EmergencyStatusResponse:
+    """Exit emergency mode when sufficient approvals are provided."""
+
+    try:
+        EMERGENCY_CONTROLLER.exit_emergency_mode(
+            requested_by=request.requested_by,
+            approvals=request.approvals,
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return emergency_status()
+
+
+@app.post(
+    "/governance/emergency/action",
+    tags=["Governance"],
+)
+def emergency_authorised_action(request: EmergencyActionRequest) -> Dict[str, str]:
+    """Validate that an emergency action has dual authorisation."""
+
+    try:
+        EMERGENCY_CONTROLLER.request_authorised_action(
+            actor=request.actor,
+            approvals=request.approvals,
+            action=request.action,
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    return {"status": "authorised", "action": request.action}
 
 
 @app.get("/admin/services", response_model=ServicesOverviewResponse, tags=["Administration"])

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -28,6 +28,36 @@ else:
         if candidate_str not in current_path:
             current_path.append(candidate_str)
     pkg.__path__ = current_path
+
+if "huey.memory" not in sys.modules:
+    memory_pkg = types.ModuleType("huey.memory")
+    memory_pkg.__path__ = [str(REPO_ROOT / "huey" / "memory")]
+    sys.modules["huey.memory"] = memory_pkg
+else:
+    memory_pkg = sys.modules["huey.memory"]
+
+py_pkg = types.ModuleType("huey.memory.PY")
+py_pkg.__path__ = [str(REPO_ROOT / "huey" / "memory" / "PY")]
+sys.modules["huey.memory.PY"] = py_pkg
+setattr(memory_pkg, "PY", py_pkg)
+
+ai_module = types.ModuleType("huey.memory.PY.ai_processor")
+
+
+class _DummyAIProcessor:
+    def process_data(self, text: str) -> str:
+        return text
+
+    def compute_mean(self, numbers: list[float]) -> float:
+        return sum(numbers) / len(numbers) if numbers else 0.0
+
+    def analyze_data(self, text: str) -> dict[str, int]:
+        return {"length": len(text)}
+
+ai_module.AIProcessor = _DummyAIProcessor  # type: ignore[attr-defined]
+sys.modules["huey.memory.PY.ai_processor"] = ai_module
+setattr(py_pkg, "ai_processor", ai_module)
+
 import huey.api as api_module
 from huey.api import app
 from monkey_head.core.task_scheduler import ResourceSnapshot, TaskScheduler, TaskStatus
@@ -99,3 +129,89 @@ async def test_task_submission_respects_resource_constraints(monkeypatch):
 
     assert submit.status_code == 202
     assert submit.json()["status"] == TaskStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_resilience_endpoints_support_manual_override(monkeypatch):
+    from monkey_head.core.resilience import CrashRecoveryManager
+
+    manager = CrashRecoveryManager()
+    monkeypatch.setattr(api_module, "CRASH_MANAGER", manager, raising=False)
+
+    state = {"healthy": False, "restarts": 0}
+
+    def health_check() -> bool:
+        return state["healthy"]
+
+    def restart() -> None:
+        state["restarts"] += 1
+        state["healthy"] = True
+
+    manager.register_process("core-loop", health_check=health_check, restart=restart)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        state["healthy"] = False
+        poll = await client.post("/resilience/poll")
+        assert poll.status_code == 200
+        assert poll.json()["events"][0]["restarted"] is True
+
+        override = await client.post(
+            "/resilience/monitors/core-loop/override",
+            json={"auto_restart": False, "reason": "maintenance"},
+        )
+        assert override.status_code == 200
+        payload = override.json()
+        assert payload["auto_restart"] is False
+        assert payload["manual_override_reason"] == "maintenance"
+
+        state["healthy"] = False
+        second_poll = await client.post("/resilience/poll")
+        assert second_poll.status_code == 200
+        assert second_poll.json()["events"][0]["restarted"] is False
+
+        manual = await client.post("/resilience/monitors/core-loop/restart")
+        assert manual.status_code == 200
+        assert manual.json()["restart_attempts"] >= 2
+
+
+@pytest.mark.asyncio
+async def test_emergency_endpoints_require_quorum(monkeypatch):
+    from monkey_head.core.resilience import EmergencyGovernanceController
+
+    controller = EmergencyGovernanceController()
+    controller.register_service("mock", stop=lambda: None, start=lambda: None)
+    monkeypatch.setattr(api_module, "EMERGENCY_CONTROLLER", controller, raising=False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        status_response = await client.get("/governance/emergency/status")
+        assert status_response.status_code == 200
+        assert status_response.json()["state"] == "normal"
+
+        denied = await client.post(
+            "/governance/emergency/enter",
+            json={"triggered_by": "spark", "reason": "test"},
+        )
+        assert denied.status_code == 403
+
+        entered = await client.post(
+            "/governance/emergency/enter",
+            json={"triggered_by": "spark", "reason": "grid", "approvals": ["zap"]},
+        )
+        assert entered.status_code == 200
+        assert entered.json()["state"] == "emergency"
+
+        authorised = await client.post(
+            "/governance/emergency/action",
+            json={"actor": "spark", "approvals": ["zap"], "action": "shed-load"},
+        )
+        assert authorised.status_code == 200
+        assert authorised.json()["status"] == "authorised"
+
+        exited = await client.post(
+            "/governance/emergency/exit",
+            json={"requested_by": "spark", "approvals": ["zap"]},
+        )
+        assert exited.status_code == 200
+        assert exited.json()["state"] == "normal"

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from monkey_head.scripts.failover import (
+    build_failover_plan,
+    execute_plan,
+    simulate_hot_swap,
+)
+
+
+def test_build_failover_plan_constructs_commands():
+    plan = build_failover_plan(
+        Path("/primary"),
+        Path("/secondary"),
+        volumes=["etc"],
+        excludes=["tmp"],
+        dry_run=True,
+    )
+    assert plan.tasks
+    command = plan.tasks[0].command
+    assert command[0] == "rsync"
+    assert "--dry-run" in command
+    assert any(entry.startswith("--exclude=tmp") for entry in command)
+
+
+def test_execute_plan_invokes_runner(monkeypatch):
+    plan = build_failover_plan(Path("/a"), Path("/b"), volumes=["home"], excludes=[])
+    executed = []
+
+    def runner(cmd):
+        executed.append(cmd)
+
+    execute_plan(plan, runner=runner)
+    assert executed == plan.commands()
+
+
+def test_simulate_hot_swap_runs_verification(monkeypatch):
+    plan = build_failover_plan(Path("/a"), Path("/b"), volumes=["etc"], excludes=[])
+    called = []
+
+    def runner(cmd):
+        called.append(cmd)
+
+    monkeypatch.setattr("monkey_head.scripts.failover.time.sleep", lambda _: None)
+    simulate_hot_swap(plan, runner=runner)
+    assert called

--- a/tests/test_legacy_connectors.py
+++ b/tests/test_legacy_connectors.py
@@ -1,0 +1,44 @@
+import asyncio
+
+import pytest
+
+from monkey_head.legacy.connectors import (
+    EmulatedLegacyConnector,
+    LegacyConnectorFactory,
+    SerialLegacyConnector,
+)
+
+
+@pytest.mark.asyncio
+async def test_emulated_connector_buffers_messages():
+    connector = EmulatedLegacyConnector()
+    await connector.connect()
+    await connector.send(b"LOAD\"*\",8,1")
+    queued = await connector.command_channel.get()
+    assert queued.startswith(b"LOAD")
+
+    async def respond():
+        await connector.inject_emulator_response(b"READY")
+
+    asyncio.create_task(respond())
+    payload = await connector.receive()
+    assert payload == b"READY"
+    await connector.close()
+
+
+@pytest.mark.asyncio
+async def test_serial_connector_requires_pyserial(monkeypatch):
+    monkeypatch.setattr("monkey_head.legacy.connectors.serial", None)
+    connector = SerialLegacyConnector(port="/dev/ttyUSB0")
+    with pytest.raises(RuntimeError):
+        await connector.connect()
+
+
+def test_legacy_connector_factory_defaults_to_emulated():
+    connector = LegacyConnectorFactory.create({})
+    assert isinstance(connector, EmulatedLegacyConnector)
+
+    config = {"mode": "serial", "port": "/dev/ttyUSB0"}
+    # When serial support is unavailable the connector still instantiates
+    instance = LegacyConnectorFactory.create(config)
+    assert isinstance(instance, SerialLegacyConnector)

--- a/tests/test_resilience_core.py
+++ b/tests/test_resilience_core.py
@@ -1,0 +1,84 @@
+import pytest
+
+from monkey_head.core.resilience import (
+    CrashRecoveryManager,
+    EmergencyGovernanceController,
+    EmergencyState,
+)
+
+
+class DummyWatchdog:
+    def __init__(self) -> None:
+        self.pings = 0
+
+    def ping(self) -> bool:
+        self.pings += 1
+        return True
+
+
+def test_crash_recovery_manager_restarts_crashed_process():
+    state = {"healthy": False, "restart_calls": 0}
+
+    def health_check() -> bool:
+        return state["healthy"]
+
+    def restart() -> None:
+        state["restart_calls"] += 1
+        state["healthy"] = True
+
+    manager = CrashRecoveryManager(watchdog=DummyWatchdog())
+    manager.register_process("spark-loop", health_check=health_check, restart=restart)
+
+    events = manager.poll()
+    assert events
+    assert events[0].restarted is True
+    assert state["restart_calls"] == 1
+
+    status = manager.statuses()[0]
+    assert status["restart_attempts"] == 1
+    assert status["auto_restart"] is True
+
+
+def test_crash_recovery_manual_override_prevents_restart():
+    state = {"healthy": False}
+
+    def health_check() -> bool:
+        return state["healthy"]
+
+    def restart() -> None:
+        state["healthy"] = True
+
+    manager = CrashRecoveryManager(watchdog=DummyWatchdog())
+    manager.register_process("zap-loop", health_check=health_check, restart=restart)
+    manager.set_auto_restart("zap-loop", False, reason="maintenance window")
+
+    events = manager.poll()
+    assert events[0].restarted is False
+    assert events[0].metadata["manual_override"] == "maintenance window"
+
+
+def test_emergency_governance_controller_requires_quorum():
+    controller = EmergencyGovernanceController(required_approvals=2)
+
+    stop_calls: list[str] = []
+    start_calls: list[str] = []
+
+    controller.register_service(
+        "ollama",
+        stop=lambda: stop_calls.append("stop"),
+        start=lambda: start_calls.append("start"),
+    )
+
+    with pytest.raises(PermissionError):
+        controller.enter_emergency_mode(triggered_by="spark", reason="grid", approvals=[])
+
+    controller.enter_emergency_mode(triggered_by="spark", reason="grid", approvals=["zap"])
+    assert controller.state is EmergencyState.EMERGENCY
+    assert stop_calls == ["stop"]
+
+    controller.exit_emergency_mode(requested_by="spark", approvals=["zap"])
+    assert controller.state is EmergencyState.NORMAL
+    assert start_calls == ["start"]
+
+    controller.enter_emergency_mode(triggered_by="spark", reason="grid", approvals=["zap"])
+    controller.request_authorised_action(actor="spark", approvals=["zap"], action="shed-load")


### PR DESCRIPTION
## Summary
- add a crash recovery manager with systemd watchdog integration and new API endpoints for manual overrides and emergency governance workflows
- introduce dual-motherboard failover replication tooling and new legacy hardware connector abstractions with accompanying unit tests
- extend FastAPI routes and tests to expose resilience status, emergency quorum controls, and manual restart capabilities through the HueyOS API

## Testing
- pytest tests/test_resilience_core.py tests/test_failover.py tests/test_legacy_connectors.py
- pytest tests/test_api_routes.py::test_resilience_endpoints_support_manual_override tests/test_api_routes.py::test_emergency_endpoints_require_quorum


------
https://chatgpt.com/codex/tasks/task_e_68e49f88c450832b87152c041beedf78