### PR TITLE
Add modular hardware integration and operations telemetry

### DIFF
--- a/monkey_head/hardware/__init__.py
+++ b/monkey_head/hardware/__init__.py
@@ -1,0 +1,28 @@
+"""Hardware integration layer for HueyOS.
+
+This package provides abstractions around sensors and actuators along with
+managers that coordinate data collection, storage, and runtime telemetry
+streaming.  It is intentionally lightweight so that downstream projects can
+extend the robotics stack without touching core application code.
+"""
+
+from .manager import (
+    ActuatorManager,
+    SensorManager,
+    create_default_actuator_manager,
+    create_default_sensor_manager,
+)
+from .plugins import ActuatorPlugin, ActuatorRegistry, SensorPlugin, SensorReading, SensorRegistry
+
+__all__ = [
+    "ActuatorManager",
+    "ActuatorPlugin",
+    "ActuatorRegistry",
+    "SensorManager",
+    "create_default_actuator_manager",
+    "SensorPlugin",
+    "SensorReading",
+    "SensorRegistry",
+    "create_default_sensor_manager",
+]
+

--- a/monkey_head/hardware/drivers.py
+++ b/monkey_head/hardware/drivers.py
@@ -1,0 +1,178 @@
+"""Built-in sensor and actuator plugins leveraging common robotics libraries."""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any, Dict, Optional
+
+from .plugins import ActuatorPlugin, ActuatorRegistry, SensorPlugin, SensorRegistry
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GPIOZeroDigitalSensor(SensorPlugin):
+    """Digital GPIO sensor using :mod:`gpiozero`."""
+
+    plugin_name = "gpiozero.digital"
+
+    def setup(self) -> None:
+        try:
+            from gpiozero import Device, DigitalInputDevice  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("gpiozero is required for GPIOZeroDigitalSensor") from exc
+        pin = int(self.config.get("pin"))
+        bounce = float(self.config.get("bounce_time", 0)) or None
+        self._device = DigitalInputDevice(pin, bounce_time=bounce)
+        LOGGER.debug("Initialised gpiozero sensor %s on pin %s", self.name, pin)
+
+    def read(self) -> Any:
+        return float(getattr(self, "_device").value)
+
+
+class GPIOZeroDigitalActuator(ActuatorPlugin):
+    """GPIO actuator using :mod:`gpiozero`."""
+
+    plugin_name = "gpiozero.output"
+
+    def setup(self) -> None:
+        try:
+            from gpiozero import Device, DigitalOutputDevice  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("gpiozero is required for GPIOZeroDigitalActuator") from exc
+        pin = int(self.config.get("pin"))
+        self._device = DigitalOutputDevice(pin)
+        LOGGER.debug("Initialised gpiozero actuator %s on pin %s", self.name, pin)
+
+    def perform(self, command: str, payload: Optional[Dict[str, Any]] = None) -> Any:
+        device = getattr(self, "_device")
+        if command == "on":
+            device.on()
+        elif command == "off":
+            device.off()
+        elif command == "toggle":
+            device.toggle()
+        else:
+            raise ValueError(f"Unsupported command {command!r} for gpiozero actuator")
+        return {"state": command}
+
+
+class SerialLineSensor(SensorPlugin):
+    """Serial sensor using :mod:`pyserial` to read newline terminated data."""
+
+    plugin_name = "serial.line"
+
+    def setup(self) -> None:
+        try:
+            import serial  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("pyserial is required for SerialLineSensor") from exc
+        port = self.config.get("port")
+        baudrate = int(self.config.get("baudrate", 9600))
+        timeout = float(self.config.get("timeout", 1))
+        self._serial = serial.Serial(port, baudrate=baudrate, timeout=timeout)
+        LOGGER.debug("Opened serial sensor %s on %s @ %s", self.name, port, baudrate)
+
+    def read(self) -> Any:
+        line = getattr(self, "_serial").readline().decode("utf-8", "ignore").strip()
+        return line
+
+
+class SerialCommandActuator(ActuatorPlugin):
+    """Serial actuator writing commands using :mod:`pyserial`."""
+
+    plugin_name = "serial.command"
+
+    def setup(self) -> None:
+        try:
+            import serial  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("pyserial is required for SerialCommandActuator") from exc
+        port = self.config.get("port")
+        baudrate = int(self.config.get("baudrate", 9600))
+        timeout = float(self.config.get("timeout", 1))
+        self._serial = serial.Serial(port, baudrate=baudrate, timeout=timeout)
+        LOGGER.debug("Opened serial actuator %s on %s @ %s", self.name, port, baudrate)
+
+    def perform(self, command: str, payload: Optional[Dict[str, Any]] = None) -> Any:
+        message = payload.get("message") if payload else command
+        data = f"{message}\n".encode("utf-8")
+        getattr(self, "_serial").write(data)
+        return {"written": message}
+
+
+class SMBusSensor(SensorPlugin):
+    """I2C sensor using :mod:`smbus2`."""
+
+    plugin_name = "i2c.smbus"
+
+    def setup(self) -> None:
+        try:
+            from smbus2 import SMBus  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("smbus2 is required for SMBusSensor") from exc
+        bus_id = int(self.config.get("bus", 1))
+        address = int(self.config.get("address"), 0)
+        self._bus = SMBus(bus_id)
+        self._address = address
+        LOGGER.debug("Initialised SMBus sensor %s on bus %s address 0x%X", self.name, bus_id, address)
+
+    def read(self) -> Any:
+        register = int(self.config.get("register", 0))
+        length = int(self.config.get("length", 2))
+        data = getattr(self, "_bus").read_i2c_block_data(self._address, register, length)
+        return data
+
+
+class VirtualRandomSensor(SensorPlugin):
+    """Virtual sensor emitting pseudo-random values for development and testing."""
+
+    plugin_name = "virtual.random"
+
+    def read(self) -> Any:
+        low = float(self.config.get("low", 0))
+        high = float(self.config.get("high", 1))
+        precision = int(self.config.get("precision", 3))
+        value = random.uniform(low, high)
+        return round(value, precision)
+
+
+def register_builtin_sensors(registry: SensorRegistry) -> None:
+    """Register built-in sensor plugins with ``registry``."""
+
+    for plugin in (
+        GPIOZeroDigitalSensor,
+        SerialLineSensor,
+        SMBusSensor,
+        VirtualRandomSensor,
+    ):
+        try:
+            registry.register(plugin)
+        except Exception:  # pragma: no cover - defensive logging
+            LOGGER.exception("Failed to register sensor plugin %s", plugin)
+
+
+def register_builtin_actuators(registry: ActuatorRegistry) -> None:
+    """Register built-in actuator plugins with ``registry``."""
+
+    for plugin in (
+        GPIOZeroDigitalActuator,
+        SerialCommandActuator,
+    ):
+        try:
+            registry.register(plugin)
+        except Exception:  # pragma: no cover - defensive logging
+            LOGGER.exception("Failed to register actuator plugin %s", plugin)
+
+
+__all__ = [
+    "GPIOZeroDigitalActuator",
+    "GPIOZeroDigitalSensor",
+    "SerialCommandActuator",
+    "SerialLineSensor",
+    "SMBusSensor",
+    "VirtualRandomSensor",
+    "register_builtin_actuators",
+    "register_builtin_sensors",
+]
+

--- a/monkey_head/hardware/manager.py
+++ b/monkey_head/hardware/manager.py
@@ -1,0 +1,240 @@
+"""Sensor manager coordinating plugin lifecycle and telemetry logging."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import uuid
+from contextlib import suppress
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from monkey_head.honeycomb_storage import HoneycombStorage
+
+from .plugins import (
+    ActuatorPlugin,
+    ActuatorRegistry,
+    SensorPlugin,
+    SensorReading,
+    SensorRegistry,
+    load_plugins_from_definitions,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+class SensorManager:
+    """Runtime container for configured sensor plugins."""
+
+    def __init__(
+        self,
+        *,
+        storage: Optional[HoneycombStorage] = None,
+        registry: Optional[SensorRegistry] = None,
+    ) -> None:
+        self.storage = storage or HoneycombStorage()
+        self.registry = registry or SensorRegistry()
+        self._sensors: Dict[str, SensorPlugin] = {}
+        self._lock = threading.RLock()
+        self._subscribers: List[Tuple[Optional[str], asyncio.Queue[SensorReading]]] = []
+
+    # ------------------------------------------------------------------
+    # Sensor lifecycle
+    # ------------------------------------------------------------------
+    def add_sensor(self, plugin_name: str, name: str, config: Optional[Dict[str, Any]] = None) -> SensorPlugin:
+        """Instantiate and register a sensor using ``plugin_name``."""
+
+        with self._lock:
+            plugin = self.registry.create(plugin_name, name, config)
+            plugin.setup()
+            self._sensors[name] = plugin
+        LOGGER.info("Registered sensor %s using plugin %s", name, plugin_name)
+        return plugin
+
+    def add_plugins(self, definitions: Iterable[Tuple[str, str, Dict[str, Any]]]) -> List[SensorPlugin]:
+        """Bulk register sensors from configuration definitions."""
+
+        sensors = load_plugins_from_definitions(definitions, registry=self.registry)
+        for sensor in sensors:
+            self.register_instance(sensor)
+        return sensors
+
+    def register_instance(self, sensor: SensorPlugin) -> None:
+        """Register an already instantiated ``sensor``."""
+
+        with self._lock:
+            sensor.setup()
+            self._sensors[sensor.name] = sensor
+        LOGGER.info("Registered sensor %s using pre-instantiated plugin", sensor.name)
+
+    def remove_sensor(self, name: str) -> None:
+        """Remove a sensor from the manager."""
+
+        with self._lock:
+            sensor = self._sensors.pop(name, None)
+        if sensor:
+            with suppress(Exception):
+                sensor.shutdown()
+            LOGGER.info("Removed sensor %s", name)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+    def list_sensors(self) -> List[Dict[str, Any]]:
+        """Return metadata about configured sensors."""
+
+        with self._lock:
+            sensors = list(self._sensors.values())
+        return [sensor.provenance | {"name": sensor.name} for sensor in sensors]
+
+    def get_sensor(self, name: str) -> Optional[SensorPlugin]:
+        with self._lock:
+            return self._sensors.get(name)
+
+    # ------------------------------------------------------------------
+    # Data acquisition
+    # ------------------------------------------------------------------
+    def poll_sensor(self, name: str) -> SensorReading:
+        sensor = self.get_sensor(name)
+        if not sensor:
+            raise KeyError(f"Unknown sensor {name}")
+        reading = sensor.capture()
+        self._record_reading(reading)
+        return reading
+
+    def poll_all(self) -> List[SensorReading]:
+        readings: List[SensorReading] = []
+        with self._lock:
+            sensors = list(self._sensors.values())
+        for sensor in sensors:
+            try:
+                reading = sensor.capture()
+            except Exception:
+                LOGGER.exception("Sensor %s failed to capture reading", sensor.name)
+                continue
+            self._record_reading(reading)
+            readings.append(reading)
+        return readings
+
+    def _record_reading(self, reading: SensorReading) -> None:
+        payload = {
+            "name": reading.name,
+            "value": reading.value,
+            "timestamp": reading.timestamp,
+            "provenance": reading.provenance,
+        }
+        key = f"telemetry/sensor/{reading.name}/{uuid.uuid4().hex}"
+        self.storage.store(key, payload)
+        self._broadcast(reading)
+
+    # ------------------------------------------------------------------
+    # Streaming helpers
+    # ------------------------------------------------------------------
+    def subscribe(self, sensor_name: Optional[str] = None) -> asyncio.Queue[SensorReading]:
+        queue: asyncio.Queue[SensorReading] = asyncio.Queue()
+        self._subscribers.append((sensor_name, queue))
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[SensorReading]) -> None:
+        self._subscribers = [item for item in self._subscribers if item[1] is not queue]
+
+    def _broadcast(self, reading: SensorReading) -> None:
+        for sensor_name, queue in list(self._subscribers):
+            if sensor_name and sensor_name != reading.name:
+                continue
+            try:
+                queue.put_nowait(reading)
+            except asyncio.QueueFull:  # pragma: no cover - best effort delivery
+                LOGGER.debug("Dropping sensor reading for %s due to full queue", reading.name)
+
+    # ------------------------------------------------------------------
+    # Historical queries
+    # ------------------------------------------------------------------
+    def load_history(self, sensor_name: str, *, limit: int = 50) -> List[Dict[str, Any]]:
+        prefix = f"telemetry/sensor/{sensor_name}/"
+        keys = self.storage.list_keys(prefix=prefix)
+        if limit:
+            keys = keys[-limit:]
+        history: List[Dict[str, Any]] = []
+        for key in keys:
+            record = self.storage.get_record(key)
+            if not record:
+                continue
+            payload = record.data
+            payload.setdefault("key", key)
+            history.append(payload)
+        history.sort(key=lambda item: item.get("timestamp", 0))
+        return history
+
+
+class ActuatorManager:
+    """Lightweight manager for actuator plugins."""
+
+    def __init__(self, *, registry: Optional[ActuatorRegistry] = None) -> None:
+        self.registry = registry or ActuatorRegistry()
+        self._actuators: Dict[str, ActuatorPlugin] = {}
+        self._lock = threading.RLock()
+
+    def add_actuator(self, plugin_name: str, name: str, config: Optional[Dict[str, Any]] = None) -> ActuatorPlugin:
+        with self._lock:
+            plugin = self.registry.create(plugin_name, name, config)
+            plugin.setup()
+            self._actuators[name] = plugin
+        LOGGER.info("Registered actuator %s using plugin %s", name, plugin_name)
+        return plugin
+
+    def register_instance(self, actuator: ActuatorPlugin) -> None:
+        with self._lock:
+            actuator.setup()
+            self._actuators[actuator.name] = actuator
+        LOGGER.info("Registered actuator %s using pre-instantiated plugin", actuator.name)
+
+    def remove_actuator(self, name: str) -> None:
+        with self._lock:
+            actuator = self._actuators.pop(name, None)
+        if actuator:
+            with suppress(Exception):
+                actuator.shutdown()
+            LOGGER.info("Removed actuator %s", name)
+
+    def list_actuators(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            actuators = list(self._actuators.values())
+        return [actuator.provenance | {"name": actuator.name} for actuator in actuators]
+
+    def perform(self, name: str, command: str, payload: Optional[Dict[str, Any]] = None) -> Any:
+        with self._lock:
+            actuator = self._actuators.get(name)
+        if actuator is None:
+            raise KeyError(f"Unknown actuator {name}")
+        with actuator._lock:  # type: ignore[attr-defined]
+            return actuator.perform(command, payload)
+
+
+def create_default_sensor_manager() -> SensorManager:
+    """Create a :class:`SensorManager` with built-in plugins registered."""
+
+    from . import drivers  # Local import to avoid circular dependency
+
+    registry = SensorRegistry()
+    drivers.register_builtin_sensors(registry)
+    return SensorManager(storage=HoneycombStorage(), registry=registry)
+
+
+def create_default_actuator_manager() -> ActuatorManager:
+    """Create an :class:`ActuatorManager` with built-in plugins registered."""
+
+    from . import drivers  # Local import to avoid circular dependency
+
+    registry = ActuatorRegistry()
+    drivers.register_builtin_actuators(registry)
+    return ActuatorManager(registry=registry)
+
+
+__all__ = [
+    "ActuatorManager",
+    "SensorManager",
+    "create_default_actuator_manager",
+    "create_default_sensor_manager",
+]
+

--- a/monkey_head/hardware/plugins.py
+++ b/monkey_head/hardware/plugins.py
@@ -1,0 +1,249 @@
+"""Plugin infrastructure for HueyOS hardware integrations."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import threading
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type
+
+try:  # pragma: no cover - importlib.metadata name differs pre-3.10
+    from importlib import metadata as importlib_metadata
+except ImportError:  # pragma: no cover - fallback for very old Python
+    import importlib_metadata  # type: ignore
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class SensorReading:
+    """Single sensor reading captured by :class:`SensorManager`."""
+
+    name: str
+    value: Any
+    timestamp: float
+    provenance: Dict[str, Any] = field(default_factory=dict)
+
+
+class BasePlugin(ABC):
+    """Common functionality shared between sensors and actuators."""
+
+    plugin_name: str = ""
+
+    def __init__(self, name: str, config: Optional[Dict[str, Any]] = None) -> None:
+        self.name = name
+        self.config = config.copy() if config else {}
+        self._lock = threading.RLock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+    def setup(self) -> None:
+        """Initialise the plugin.
+
+        Subclasses may override this method to perform expensive operations
+        (e.g., opening serial ports).  The default implementation does nothing.
+        """
+
+    def shutdown(self) -> None:
+        """Release any resources allocated during :meth:`setup`."""
+
+    # ------------------------------------------------------------------
+    # Provenance information
+    # ------------------------------------------------------------------
+    @property
+    def provenance(self) -> Dict[str, Any]:
+        """Metadata describing the plugin implementation."""
+
+        return {
+            "plugin": self.plugin_name or self.__class__.__name__,
+            "module": f"{self.__class__.__module__}.{self.__class__.__qualname__}",
+            "config": self.config,
+        }
+
+
+class SensorPlugin(BasePlugin):
+    """Base class for sensor plugins."""
+
+    @abstractmethod
+    def read(self) -> Any:
+        """Collect a reading from the sensor."""
+
+    def capture(self) -> SensorReading:
+        """Return a :class:`SensorReading` enriched with provenance data."""
+
+        with self._lock:
+            value = self.read()
+        return SensorReading(
+            name=self.name,
+            value=value,
+            timestamp=time.time(),
+            provenance=self.provenance,
+        )
+
+
+class ActuatorPlugin(BasePlugin):
+    """Base class for actuator plugins."""
+
+    @abstractmethod
+    def perform(self, command: str, payload: Optional[Dict[str, Any]] = None) -> Any:
+        """Execute a command against the actuator."""
+
+
+class SensorRegistry:
+    """Registry and plugin loader for sensors."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, Type[SensorPlugin]] = {}
+        self._loaded_entry_points = False
+
+    # ------------------------------------------------------------------
+    def register(self, plugin: Type[SensorPlugin]) -> None:
+        """Register ``plugin`` under its :attr:`SensorPlugin.plugin_name`."""
+
+        name = getattr(plugin, "plugin_name", None) or plugin.__name__
+        if not name:
+            raise ValueError("Sensor plugins must define plugin_name")
+        if name in self._plugins:
+            LOGGER.debug("Replacing existing sensor plugin for name %s", name)
+        self._plugins[name] = plugin
+
+    # ------------------------------------------------------------------
+    def get(self, name: str) -> Type[SensorPlugin]:
+        """Return the plugin class registered as ``name``."""
+
+        self._ensure_entry_points_loaded()
+        if name not in self._plugins:
+            raise KeyError(f"Unknown sensor plugin: {name}")
+        return self._plugins[name]
+
+    # ------------------------------------------------------------------
+    def available(self) -> List[str]:
+        """Return a sorted list of registered sensor plugin names."""
+
+        self._ensure_entry_points_loaded()
+        return sorted(self._plugins)
+
+    # ------------------------------------------------------------------
+    def create(self, plugin_name: str, name: str, config: Optional[Dict[str, Any]] = None) -> SensorPlugin:
+        """Instantiate a sensor plugin by symbolic ``plugin_name``."""
+
+        plugin_cls = self.get(plugin_name)
+        return plugin_cls(name=name, config=config)
+
+    # ------------------------------------------------------------------
+    def _ensure_entry_points_loaded(self) -> None:
+        if self._loaded_entry_points:
+            return
+        self._loaded_entry_points = True
+        try:
+            entry_points = importlib_metadata.entry_points()
+        except Exception:  # pragma: no cover - defensive fallback
+            LOGGER.exception("Unable to enumerate sensor entry points")
+            return
+        groups = getattr(entry_points, "select", None)
+        if callable(groups):
+            sensors = groups(group="monkey_head.sensors")
+        else:  # pragma: no cover - importlib_metadata < 3.10 compatibility
+            sensors = entry_points.get("monkey_head.sensors", [])  # type: ignore[assignment]
+        for entry_point in sensors:
+            try:
+                plugin_cls = entry_point.load()
+            except Exception:  # pragma: no cover - plugin misbehaviour
+                LOGGER.exception("Failed to load sensor plugin from %s", entry_point)
+                continue
+            if not isinstance(plugin_cls, type):
+                LOGGER.warning(
+                    "Entry point %s did not return a class (got %r)", entry_point, plugin_cls
+                )
+                continue
+            if not issubclass(plugin_cls, SensorPlugin):
+                LOGGER.warning(
+                    "Entry point %s does not implement SensorPlugin", entry_point
+                )
+                continue
+            self.register(plugin_cls)
+
+
+def import_from_string(path: str) -> Type[SensorPlugin]:
+    """Import a class defined by ``path`` (``package.module:Class``)."""
+
+    if ":" in path:
+        module_path, cls_name = path.split(":", 1)
+    else:
+        module_path, cls_name = path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    cls = getattr(module, cls_name)
+    if not isinstance(cls, type) or not issubclass(cls, SensorPlugin):
+        raise TypeError(f"{path} is not a SensorPlugin subclass")
+    return cls
+
+
+def load_plugins_from_definitions(
+    definitions: Iterable[Tuple[str, str, Dict[str, Any]]],
+    registry: Optional[SensorRegistry] = None,
+) -> List[SensorPlugin]:
+    """Instantiate plugins described by ``definitions``.
+
+    Parameters
+    ----------
+    definitions:
+        Iterable of ``(plugin_name, instance_name, config)`` tuples.
+    registry:
+        Optional :class:`SensorRegistry` to use.  When ``None`` a temporary
+        registry that knows about entry points is used.
+    """
+
+    registry = registry or SensorRegistry()
+    instances: List[SensorPlugin] = []
+    for plugin_name, instance_name, config in definitions:
+        try:
+            plugin = registry.create(plugin_name, instance_name, config)
+        except KeyError:
+            # Allow fully qualified module paths as a fallback for ad-hoc sensors.
+            plugin_cls = import_from_string(plugin_name)
+            registry.register(plugin_cls)
+            plugin = plugin_cls(name=instance_name, config=config)
+        instances.append(plugin)
+        return instances
+
+
+class ActuatorRegistry:
+    """Simple registry for actuator plugins."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, Type[ActuatorPlugin]] = {}
+
+    def register(self, plugin: Type[ActuatorPlugin]) -> None:
+        name = getattr(plugin, "plugin_name", None) or plugin.__name__
+        if not name:
+            raise ValueError("Actuator plugins must define plugin_name")
+        self._plugins[name] = plugin
+
+    def get(self, name: str) -> Type[ActuatorPlugin]:
+        if name not in self._plugins:
+            raise KeyError(f"Unknown actuator plugin: {name}")
+        return self._plugins[name]
+
+    def available(self) -> List[str]:
+        return sorted(self._plugins)
+
+    def create(self, plugin_name: str, name: str, config: Optional[Dict[str, Any]] = None) -> ActuatorPlugin:
+        plugin_cls = self.get(plugin_name)
+        return plugin_cls(name=name, config=config)
+
+
+__all__ = [
+    "ActuatorPlugin",
+    "ActuatorRegistry",
+    "SensorPlugin",
+    "SensorReading",
+    "SensorRegistry",
+    "import_from_string",
+    "load_plugins_from_definitions",
+]
+

--- a/monkey_head/network/__init__.py
+++ b/monkey_head/network/__init__.py
@@ -1,0 +1,6 @@
+"""Network management utilities with wired-first preference."""
+
+from .manager import NetworkManager, NetworkStatus
+
+__all__ = ["NetworkManager", "NetworkStatus"]
+

--- a/monkey_head/network/manager.py
+++ b/monkey_head/network/manager.py
@@ -1,0 +1,157 @@
+"""Network manager that prefers wired connections with Wi-Fi failover."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - degrade gracefully
+    psutil = None  # type: ignore[assignment]
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+WIRED_PREFIXES = ("eth", "enp", "eno", "ens")
+WIFI_PREFIXES = ("wlan", "wlx", "wifi", "ath")
+
+
+@dataclass
+class NetworkStatus:
+    """Status snapshot returned by :class:`NetworkManager`."""
+
+    active_interface: Optional[str]
+    interfaces: Dict[str, Dict[str, Optional[float]]]
+    wired_available: bool
+    wifi_available: bool
+    connected: bool
+    last_checked: float
+
+
+class NetworkManager:
+    """Monitor connectivity and ensure wired-first network availability."""
+
+    def __init__(
+        self,
+        *,
+        check_host: str = "8.8.8.8",
+        check_port: int = 53,
+        check_timeout: float = 2.0,
+    ) -> None:
+        self.check_host = check_host
+        self.check_port = check_port
+        self.check_timeout = check_timeout
+        self._last_status: Optional[NetworkStatus] = None
+
+    # ------------------------------------------------------------------
+    def _interface_stats(self) -> Dict[str, Dict[str, Optional[float]]]:
+        info: Dict[str, Dict[str, Optional[float]]] = {}
+        if psutil is None:
+            return info
+        for name, stats in psutil.net_if_stats().items():
+            info[name] = {
+                "isup": float(stats.isup),
+                "speed": float(stats.speed or 0),
+                "duplex": float(getattr(stats, "duplex", 0) or 0),
+            }
+        return info
+
+    def _preferred_interface(self, interfaces: Dict[str, Dict[str, Optional[float]]]) -> Optional[str]:
+        wired = [name for name in interfaces if name.startswith(WIRED_PREFIXES) and interfaces[name]["isup"]]
+        wifi = [name for name in interfaces if name.startswith(WIFI_PREFIXES) and interfaces[name]["isup"]]
+        return wired[0] if wired else (wifi[0] if wifi else None)
+
+    def _attempt_connectivity(self) -> bool:
+        try:
+            with socket.create_connection(
+                (self.check_host, self.check_port), timeout=self.check_timeout
+            ):
+                return True
+        except OSError:
+            return False
+
+    def check_status(self) -> NetworkStatus:
+        interfaces = self._interface_stats()
+        preferred = self._preferred_interface(interfaces)
+        connected = self._attempt_connectivity()
+        status = NetworkStatus(
+            active_interface=preferred,
+            interfaces=interfaces,
+            wired_available=any(
+                name.startswith(WIRED_PREFIXES) and details.get("isup")
+                for name, details in interfaces.items()
+            ),
+            wifi_available=any(
+                name.startswith(WIFI_PREFIXES) and details.get("isup")
+                for name, details in interfaces.items()
+            ),
+            connected=connected,
+            last_checked=time.time(),
+        )
+        self._last_status = status
+        if not connected and status.wifi_available and preferred and preferred.startswith(WIFI_PREFIXES):
+            LOGGER.warning("Connectivity degraded while using Wi-Fi interface %s", preferred)
+        return status
+
+    # ------------------------------------------------------------------
+    def ensure_connectivity(self) -> NetworkStatus:
+        status = self.check_status()
+        if status.connected and status.active_interface and status.active_interface.startswith(WIRED_PREFIXES):
+            return status
+
+        if status.connected and status.wired_available:
+            # Wi-Fi is up but wired exists - attempt to switch.
+            wired_interface = self._find_first_available(WIRED_PREFIXES, status.interfaces)
+            if wired_interface and status.active_interface != wired_interface:
+                self._bring_up_interface(wired_interface)
+                status = self.check_status()
+        elif not status.connected:
+            # Attempt Wi-Fi failover.
+            wifi_interface = self._find_first_available(WIFI_PREFIXES, status.interfaces)
+            if wifi_interface:
+                self._bring_up_interface(wifi_interface)
+                status = self.check_status()
+        return status
+
+    def _find_first_available(
+        self, prefixes: tuple[str, ...], interfaces: Dict[str, Dict[str, Optional[float]]]
+    ) -> Optional[str]:
+        for name, details in interfaces.items():
+            if name.startswith(prefixes) and details.get("isup"):
+                return name
+        return None
+
+    def _bring_up_interface(self, interface: str) -> None:
+        LOGGER.info("Attempting to prioritise interface %s", interface)
+        if shutil.which("nmcli"):
+            try:
+                subprocess.run(["nmcli", "device", "connect", interface], check=False, capture_output=True)
+            except Exception:  # pragma: no cover - environment specific
+                LOGGER.exception("Failed to invoke nmcli for interface %s", interface)
+        elif sys.platform.startswith("darwin") and shutil.which("networksetup"):
+            try:
+                subprocess.run(
+                    ["networksetup", "-setairportpower", interface, "on"],
+                    check=False,
+                    capture_output=True,
+                )
+            except Exception:  # pragma: no cover
+                LOGGER.exception("Failed to invoke networksetup for interface %s", interface)
+        else:
+            LOGGER.debug("No supported network management tool available")
+
+    @property
+    def last_status(self) -> Optional[NetworkStatus]:
+        return self._last_status
+
+
+__all__ = ["NetworkManager", "NetworkStatus"]
+

--- a/monkey_head/power/__init__.py
+++ b/monkey_head/power/__init__.py
@@ -1,0 +1,6 @@
+"""Power management utilities for HueyOS."""
+
+from .management import BatteryMonitor, PowerEvent
+
+__all__ = ["BatteryMonitor", "PowerEvent"]
+

--- a/monkey_head/power/management.py
+++ b/monkey_head/power/management.py
@@ -1,0 +1,96 @@
+"""Battery monitoring and safe shutdown routines."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - degrade gracefully
+    psutil = None  # type: ignore[assignment]
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class PowerEvent:
+    """Represents a power management action."""
+
+    timestamp: float
+    action: str
+    metadata: Dict[str, Any]
+
+
+class BatteryMonitor:
+    """High level helper for querying battery status and issuing shutdowns."""
+
+    def __init__(self, *, shutdown_threshold: float = 5.0) -> None:
+        self.shutdown_threshold = shutdown_threshold
+        self._last_event: Optional[PowerEvent] = None
+
+    def get_status(self) -> Dict[str, Any]:
+        """Return battery metrics using :mod:`psutil` when available."""
+
+        if psutil and hasattr(psutil, "sensors_battery"):
+            battery = psutil.sensors_battery()  # type: ignore[attr-defined]
+        else:  # pragma: no cover - running without psutil
+            battery = None
+        if battery is None:
+            return {
+                "percent": None,
+                "secs_left": None,
+                "power_plugged": None,
+                "estimated_runtime_minutes": None,
+            }
+        secs_left = battery.secsleft if battery.secsleft not in (psutil.POWER_TIME_UNKNOWN, psutil.POWER_TIME_UNLIMITED) else None  # type: ignore[attr-defined]
+        return {
+            "percent": float(battery.percent),
+            "secs_left": secs_left,
+            "power_plugged": bool(battery.power_plugged),
+            "estimated_runtime_minutes": (secs_left / 60) if secs_left else None,
+        }
+
+    def should_shutdown(self) -> bool:
+        status = self.get_status()
+        percent = status.get("percent")
+        if percent is None:
+            return False
+        if status.get("power_plugged"):
+            return False
+        return percent <= self.shutdown_threshold
+
+    def initiate_shutdown(self) -> PowerEvent:
+        """Trigger a safe shutdown sequence using available system tools."""
+
+        timestamp = time.time()
+        metadata = {"threshold": self.shutdown_threshold}
+        if shutil.which("systemctl"):
+            cmd = ["systemctl", "poweroff"]
+        elif sys.platform.startswith("darwin"):
+            cmd = ["osascript", "-e", 'tell app "System Events" to shut down']
+        else:
+            cmd = ["shutdown", "-h", "now"]
+        metadata["command"] = cmd
+        try:
+            subprocess.Popen(cmd)  # pragma: no cover - side effect heavy
+        except Exception as exc:  # pragma: no cover - best effort logging
+            LOGGER.exception("Failed to execute shutdown command %s", cmd)
+            metadata["error"] = str(exc)
+        event = PowerEvent(timestamp=timestamp, action="shutdown", metadata=metadata)
+        self._last_event = event
+        return event
+
+    @property
+    def last_event(self) -> Optional[PowerEvent]:
+        return self._last_event
+
+
+__all__ = ["BatteryMonitor", "PowerEvent"]
+

--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -30,10 +30,14 @@ from monkey_head.core.task_scheduler import (
     TaskScheduler,
     TaskStatus,
 )
+from monkey_head.hardware import create_default_sensor_manager
+from monkey_head.hardware.plugins import SensorReading
 from monkey_head.honeycomb_index import HoneycombIndex
 from monkey_head.honeycomb_monitor import HoneycombMonitor
 from monkey_head.honeycomb_storage import HoneycombStorage
+from monkey_head.network import NetworkManager
 from monkey_head.pdf_utils import find_pdf, list_available_pdfs
+from monkey_head.power import BatteryMonitor
 from monkey_head.system_checks import system_check
 from monkey_head.utils.auto_sort import auto_sort_memory
 from monkey_head.utils.paths import get_memory_path
@@ -205,6 +209,93 @@ class AnalyzeTextResponse(BaseModel):
     )
 
 
+class SensorMetadata(BaseModel):
+    """Metadata describing a configured sensor plugin."""
+
+    name: str
+    plugin: str
+    module: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class SensorPluginsResponse(BaseModel):
+    """Response model listing available sensor plugins."""
+
+    plugins: List[str]
+
+
+class SensorListResponse(BaseModel):
+    """Response payload enumerating configured sensors."""
+
+    sensors: List[SensorMetadata]
+
+
+class SensorRegistrationRequest(BaseModel):
+    """Request body for registering a sensor instance."""
+
+    name: str
+    plugin: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class SensorRegistrationResponse(BaseModel):
+    """Response describing a registered sensor."""
+
+    name: str
+    plugin: str
+    config: Dict[str, Any]
+
+
+class SensorReadingResponse(BaseModel):
+    """Single sensor reading returned to API clients."""
+
+    name: str
+    value: Any
+    timestamp: float
+    provenance: Dict[str, Any]
+
+
+class SensorHistoryResponse(BaseModel):
+    """Historical readings for a specific sensor."""
+
+    sensor: str
+    readings: List[SensorReadingResponse]
+
+
+class SensorPollAllResponse(BaseModel):
+    """Response returned when polling all configured sensors."""
+
+    readings: List[SensorReadingResponse]
+
+
+class NetworkStatusResponse(BaseModel):
+    """Current network connectivity status."""
+
+    active_interface: Optional[str]
+    interfaces: Dict[str, Dict[str, Optional[float]]]
+    wired_available: bool
+    wifi_available: bool
+    connected: bool
+    last_checked: float
+
+
+class BatteryStatusResponse(BaseModel):
+    """Current battery metrics."""
+
+    percent: Optional[float]
+    secs_left: Optional[float]
+    power_plugged: Optional[bool]
+    estimated_runtime_minutes: Optional[float]
+
+
+class PowerEventResponse(BaseModel):
+    """Response describing a power management action."""
+
+    timestamp: float
+    action: str
+    metadata: Dict[str, Any]
+
+
 class ServiceStatus(BaseModel):
     """Runtime status for a managed HueyOS service."""
 
@@ -327,6 +418,30 @@ SCHEDULER = TaskScheduler()
 CRASH_MANAGER = CrashRecoveryManager()
 EMERGENCY_CONTROLLER = EmergencyGovernanceController()
 _SERVICE_STATES: Dict[str, ServiceStatus] = {}
+SENSOR_MANAGER = create_default_sensor_manager()
+NETWORK_MANAGER = NetworkManager()
+BATTERY_MONITOR = BatteryMonitor()
+
+
+def _reading_to_response(reading: SensorReading) -> SensorReadingResponse:
+    return SensorReadingResponse(
+        name=reading.name,
+        value=reading.value,
+        timestamp=reading.timestamp,
+        provenance=reading.provenance,
+    )
+
+
+async def _sensor_stream(sensor_name: Optional[str]):
+    queue = SENSOR_MANAGER.subscribe(sensor_name)
+    try:
+        while True:
+            reading = await queue.get()
+            payload = _reading_to_response(reading).json()
+            yield f"data: {payload}\n\n"
+    finally:
+        SENSOR_MANAGER.unsubscribe(queue)
+
 
 
 class ResourceProfileModel(BaseModel):
@@ -641,6 +756,167 @@ def system_status() -> SystemStatusResponse:
     """Return operating system, hardware, and configuration details for HueyOS."""
 
     return _build_system_status()
+
+
+@app.get("/sensors/plugins", response_model=SensorPluginsResponse, tags=["Sensors"])
+def sensor_plugins() -> SensorPluginsResponse:
+    """List available sensor plugin identifiers."""
+
+    plugins = SENSOR_MANAGER.registry.available()
+    return SensorPluginsResponse(plugins=plugins)
+
+
+@app.get("/sensors", response_model=SensorListResponse, tags=["Sensors"])
+def list_sensors() -> SensorListResponse:
+    """Enumerate configured sensors."""
+
+    metadata: List[SensorMetadata] = []
+    for entry in SENSOR_MANAGER.list_sensors():
+        metadata.append(
+            SensorMetadata(
+                name=entry["name"],
+                plugin=str(entry.get("plugin")),
+                module=str(entry.get("module")),
+                config=dict(entry.get("config") or {}),
+            )
+        )
+    return SensorListResponse(sensors=metadata)
+
+
+@app.post(
+    "/sensors/register",
+    response_model=SensorRegistrationResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["Sensors"],
+)
+def register_sensor(request: SensorRegistrationRequest) -> SensorRegistrationResponse:
+    """Register a new sensor plugin instance at runtime."""
+
+    try:
+        SENSOR_MANAGER.add_sensor(request.plugin, request.name, request.config)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown sensor plugin {request.plugin!r}",
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return SensorRegistrationResponse(
+        name=request.name,
+        plugin=request.plugin,
+        config=dict(request.config),
+    )
+
+
+@app.delete("/sensors/{sensor_name}", tags=["Sensors"])
+def remove_sensor(sensor_name: str) -> Dict[str, str]:
+    """Remove a configured sensor instance."""
+
+    if SENSOR_MANAGER.get_sensor(sensor_name) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sensor not found")
+    SENSOR_MANAGER.remove_sensor(sensor_name)
+    return {"status": "removed", "sensor": sensor_name}
+
+
+@app.post(
+    "/sensors/{sensor_name}/poll",
+    response_model=SensorReadingResponse,
+    tags=["Sensors"],
+)
+def poll_sensor(sensor_name: str) -> SensorReadingResponse:
+    """Poll a single sensor and store the reading in honeycomb storage."""
+
+    try:
+        reading = SENSOR_MANAGER.poll_sensor(sensor_name)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sensor not found") from exc
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+    return _reading_to_response(reading)
+
+
+@app.post("/sensors/poll", response_model=SensorPollAllResponse, tags=["Sensors"])
+def poll_all_sensors() -> SensorPollAllResponse:
+    """Poll every configured sensor."""
+
+    readings = [_reading_to_response(reading) for reading in SENSOR_MANAGER.poll_all()]
+    return SensorPollAllResponse(readings=readings)
+
+
+@app.get(
+    "/sensors/{sensor_name}/history",
+    response_model=SensorHistoryResponse,
+    tags=["Sensors"],
+)
+def sensor_history(
+    sensor_name: str,
+    limit: int = Query(50, ge=1, le=500, description="Maximum number of readings to return"),
+) -> SensorHistoryResponse:
+    """Return historical sensor readings from honeycomb storage."""
+
+    if SENSOR_MANAGER.get_sensor(sensor_name) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sensor not found")
+    history = SENSOR_MANAGER.load_history(sensor_name, limit=limit)
+    readings = [SensorReadingResponse(**record) for record in history]
+    return SensorHistoryResponse(sensor=sensor_name, readings=readings)
+
+
+@app.get("/sensors/{sensor_name}/stream", tags=["Sensors"])
+async def stream_sensor(sensor_name: str) -> StreamingResponse:
+    """Stream real-time readings for ``sensor_name`` using server-sent events."""
+
+    if SENSOR_MANAGER.get_sensor(sensor_name) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sensor not found")
+    return StreamingResponse(_sensor_stream(sensor_name), media_type="text/event-stream")
+
+
+@app.get("/sensors/stream", tags=["Sensors"])
+async def stream_all_sensors() -> StreamingResponse:
+    """Stream readings for all sensors using server-sent events."""
+
+    return StreamingResponse(_sensor_stream(None), media_type="text/event-stream")
+
+
+@app.get("/network/status", response_model=NetworkStatusResponse, tags=["Network"])
+def network_status() -> NetworkStatusResponse:
+    """Return the most recent network connectivity snapshot."""
+
+    status_snapshot = NETWORK_MANAGER.check_status()
+    return NetworkStatusResponse(**status_snapshot.__dict__)
+
+
+@app.post("/network/ensure", response_model=NetworkStatusResponse, tags=["Network"])
+def ensure_network_connectivity() -> NetworkStatusResponse:
+    """Ensure wired connectivity is preferred with Wi-Fi failover."""
+
+    status_snapshot = NETWORK_MANAGER.ensure_connectivity()
+    return NetworkStatusResponse(**status_snapshot.__dict__)
+
+
+@app.get("/power/battery", response_model=BatteryStatusResponse, tags=["Power"])
+def battery_status() -> BatteryStatusResponse:
+    """Expose the current battery status."""
+
+    status = BATTERY_MONITOR.get_status()
+    return BatteryStatusResponse(**status)
+
+
+@app.get("/power/should-shutdown", tags=["Power"])
+def power_should_shutdown() -> Dict[str, Any]:
+    """Return whether the system recommends a safe shutdown."""
+
+    return {
+        "should_shutdown": BATTERY_MONITOR.should_shutdown(),
+        "threshold": BATTERY_MONITOR.shutdown_threshold,
+    }
+
+
+@app.post("/power/shutdown", response_model=PowerEventResponse, tags=["Power"])
+def trigger_shutdown() -> PowerEventResponse:
+    """Initiate a safe shutdown sequence."""
+
+    event = BATTERY_MONITOR.initiate_shutdown()
+    return PowerEventResponse(timestamp=event.timestamp, action=event.action, metadata=event.metadata)
 
 
 @app.get(

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -202,6 +202,107 @@ async def test_emergency_endpoints_require_quorum(monkeypatch):
         assert entered.status_code == 200
         assert entered.json()["state"] == "emergency"
 
+
+@pytest.mark.asyncio
+async def test_sensor_network_and_power_endpoints(monkeypatch, tmp_path):
+    from monkey_head.hardware import drivers
+    from monkey_head.hardware.manager import SensorManager
+    from monkey_head.hardware.plugins import SensorRegistry
+    from monkey_head.honeycomb_storage import HoneycombStorage
+    from monkey_head.network.manager import NetworkStatus
+    from monkey_head.power.management import PowerEvent
+
+    storage = HoneycombStorage(base_dir=tmp_path)
+    registry = SensorRegistry()
+    drivers.register_builtin_sensors(registry)
+    sensor_manager = SensorManager(storage=storage, registry=registry)
+    monkeypatch.setattr(api_module, "SENSOR_MANAGER", sensor_manager, raising=False)
+
+    class DummyNetworkManager:
+        def __init__(self) -> None:
+            self.status = NetworkStatus(
+                active_interface="eth0",
+                interfaces={"eth0": {"isup": 1.0, "speed": 1000.0, "duplex": 1.0}},
+                wired_available=True,
+                wifi_available=False,
+                connected=True,
+                last_checked=123.0,
+            )
+
+        def check_status(self) -> NetworkStatus:
+            return self.status
+
+        def ensure_connectivity(self) -> NetworkStatus:
+            return self.status
+
+    monkeypatch.setattr(api_module, "NETWORK_MANAGER", DummyNetworkManager(), raising=False)
+
+    class DummyBatteryMonitor:
+        shutdown_threshold = 5.0
+
+        def get_status(self) -> dict[str, float | bool | None]:
+            return {
+                "percent": 42.0,
+                "secs_left": 1200.0,
+                "power_plugged": False,
+                "estimated_runtime_minutes": 20.0,
+            }
+
+        def should_shutdown(self) -> bool:
+            return False
+
+        def initiate_shutdown(self) -> PowerEvent:
+            return PowerEvent(timestamp=456.0, action="shutdown", metadata={"initiated": True})
+
+    monkeypatch.setattr(api_module, "BATTERY_MONITOR", DummyBatteryMonitor(), raising=False)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        sensors_initial = await client.get("/sensors")
+        assert sensors_initial.status_code == 200
+        assert sensors_initial.json()["sensors"] == []
+
+        registration = await client.post(
+            "/sensors/register",
+            json={"name": "dev-entropy", "plugin": "virtual.random", "config": {"precision": 2}},
+        )
+        assert registration.status_code == 201
+
+        poll_response = await client.post("/sensors/dev-entropy/poll")
+        assert poll_response.status_code == 200
+        poll_payload = poll_response.json()
+        assert poll_payload["name"] == "dev-entropy"
+        assert "timestamp" in poll_payload
+
+        history = await client.get("/sensors/dev-entropy/history", params={"limit": 5})
+        assert history.status_code == 200
+        history_payload = history.json()
+        assert history_payload["sensor"] == "dev-entropy"
+        assert history_payload["readings"]
+
+        plugins = await client.get("/sensors/plugins")
+        assert plugins.status_code == 200
+        assert "virtual.random" in plugins.json()["plugins"]
+
+        net_status = await client.get("/network/status")
+        assert net_status.status_code == 200
+        assert net_status.json()["active_interface"] == "eth0"
+
+        net_ensure = await client.post("/network/ensure")
+        assert net_ensure.status_code == 200
+
+        battery = await client.get("/power/battery")
+        assert battery.status_code == 200
+        assert battery.json()["percent"] == 42.0
+
+        should_shutdown = await client.get("/power/should-shutdown")
+        assert should_shutdown.status_code == 200
+        assert should_shutdown.json()["should_shutdown"] is False
+
+        shutdown = await client.post("/power/shutdown")
+        assert shutdown.status_code == 200
+        assert shutdown.json()["metadata"]["initiated"] is True
+
         authorised = await client.post(
             "/governance/emergency/action",
             json={"actor": "spark", "approvals": ["zap"], "action": "shed-load"},


### PR DESCRIPTION
## Summary
- add a pluggable hardware layer with sensor/actuator registries, built-in drivers, and honeycomb telemetry logging
- surface sensor management, streaming telemetry, network status, and battery health endpoints through the HueyOS API
- provide network and power management helpers with wired-first failover and safe shutdown orchestration

## Testing
- pytest *(fails: repository lacks optional dependencies such as httpx and pydantic required by existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a1ccae68832b9cacb0ce202d78de