### PR TITLE
Enhance AI tooling GUIs and add PySide6 dashboard

### DIFF
--- a/huey/memory/PY/ai_tools_gui.py
+++ b/huey/memory/PY/ai_tools_gui.py
@@ -6,7 +6,7 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.12.2025
 # ==================================================
-"""Simple Tkinter interface for :class:`AIProcessor`."""
+"""Feature rich Tkinter console for :class:`AIProcessor` and system tooling."""
 
 from __future__ import annotations
 
@@ -14,35 +14,172 @@ import os
 
 try:  # pragma: no cover - optional dependency
     import tkinter as tk
-    from tkinter import messagebox
+    from tkinter import filedialog, messagebox, scrolledtext, ttk
 except Exception:  # pragma: no cover - can't import GUI libs
     tk = None
     messagebox = None
+    filedialog = None
+    scrolledtext = None
+    ttk = None
 
 from .gui_scaling import apply_scaling
 from .license_gui import DARK_BG, LIGHT_FG, ACCENT_PURPLE
 
+try:  # pragma: no cover - psutil optional dependency
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - psutil missing at runtime
+    psutil = None  # type: ignore[assignment]
+
+from pathlib import Path
+import platform
+import shutil
+import socket
+import time
+from typing import Dict, List
+
+from monkey_head.agents.llm import LLMAdapter, LLMProvider
+from monkey_head.utils.paths import ensure_subdirectory, get_memory_path
+
+from .config_manager import ConfigManager
+
+
+def _format_bytes(size: float | int | None) -> str:
+    """Return ``size`` formatted as a human readable string."""
+
+    if size is None:
+        return "Unknown"
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(size)
+    for unit in units:
+        if size < 1024.0:
+            return f"{size:0.2f} {unit}"
+        size /= 1024.0
+    return f"{size:0.2f} PB"
+
+
+def _gather_system_status() -> Dict[str, str]:
+    """Collect system metrics for display in the GUI."""
+
+    uname = platform.uname()
+    data: Dict[str, str] = {
+        "hostname": socket.gethostname(),
+        "system": uname.system,
+        "release": uname.release,
+        "python": platform.python_version(),
+    }
+
+    if psutil is not None:  # pragma: no branch - determined at import time
+        try:
+            data["cpu"] = f"{psutil.cpu_percent(interval=0.05):0.1f}%"
+        except Exception:
+            data["cpu"] = "Unavailable"
+        try:
+            virtual = psutil.virtual_memory()
+            data["memory"] = (
+                f"{_format_bytes(virtual.used)} used / {_format_bytes(virtual.total)}"
+            )
+            if virtual.total:
+                percent = (virtual.used / virtual.total) * 100
+                data["memory_percent"] = f"{percent:0.1f}"
+        except Exception:
+            data["memory"] = "Unavailable"
+        try:
+            boot_time = getattr(psutil, "boot_time", lambda: None)()
+        except Exception:
+            boot_time = None
+        if boot_time:
+            uptime = max(0.0, time.time() - float(boot_time))
+            hours = int(uptime // 3600)
+            minutes = int((uptime % 3600) // 60)
+            data["uptime"] = f"{hours}h {minutes}m"
+    else:
+        data["cpu"] = "psutil not installed"
+        data["memory"] = "psutil not installed"
+
+    try:
+        disk = shutil.disk_usage(Path("/"))
+        data["disk"] = (
+            f"{_format_bytes(disk.used)} used / {_format_bytes(disk.total)}"
+        )
+    except Exception:
+        data["disk"] = "Unavailable"
+
+    memory_dir = get_memory_path(create=True)
+    data["memory_path"] = str(memory_dir)
+    try:
+        total_size = 0
+        for entry in memory_dir.rglob("*"):
+            if entry.is_file():
+                total_size += entry.stat().st_size
+        data["memory_dir_size"] = _format_bytes(total_size)
+    except Exception:
+        data["memory_dir_size"] = "Unavailable"
+
+    return data
+
+
+def _list_memory_uploads(target_dir: Path) -> List[str]:
+    """Return a list of uploaded files inside ``target_dir``."""
+
+    items: List[str] = []
+    try:
+        for entry in sorted(target_dir.glob("**/*")):
+            if entry.is_file():
+                relative = entry.relative_to(target_dir)
+                items.append(f"{relative} ({_format_bytes(entry.stat().st_size)})")
+    except Exception:
+        items = ["Unable to read uploads directory"]
+    if not items:
+        items.append("No uploaded files yet")
+    return items
+
 
 def run_ai_tools() -> None:
-    """Launch a basic GUI exposing :class:`AIProcessor` methods."""
-    if tk is None or messagebox is None:
+    """Launch an enhanced GUI exposing system insights and AI helpers."""
+
+    if tk is None or messagebox is None or ttk is None or scrolledtext is None:
         raise RuntimeError("tkinter is not available")
 
-    # Import here so missing scientific libs don't break module import
     from .ai_processor import AIProcessor  # pragma: no cover - optional
 
     proc = AIProcessor()
+    config = ConfigManager("config/pygpt_net/config.json")
+    uploads_dir = ensure_subdirectory("GUI", "uploads")
 
     root = tk.Tk()
     apply_scaling(root, os.environ.get("SCREEN_MODE", "1080p"))
-    root.title("AI Tools")
+    root.title("AI Tools Console")
     root.configure(bg=DARK_BG)
 
-    tk.Label(root, text="Input Text", bg=DARK_BG, fg=LIGHT_FG).pack(padx=5, pady=5)
-    text_entry = tk.Entry(
-        root, width=50, bg=DARK_BG, fg=LIGHT_FG, insertbackground=LIGHT_FG
+    style = ttk.Style(root)
+    try:
+        style.theme_use("clam")
+    except Exception:
+        pass
+    style.configure("TNotebook", background=DARK_BG)
+    style.configure("TNotebook.Tab", background=ACCENT_PURPLE, foreground=LIGHT_FG)
+    style.map(
+        "TNotebook.Tab",
+        background=[("selected", DARK_BG)],
+        foreground=[("selected", LIGHT_FG)],
     )
-    text_entry.pack(padx=5, pady=5)
+
+    notebook = ttk.Notebook(root)
+    notebook.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+    # ------------------------------------------------------------------
+    # Processing tab
+    # ------------------------------------------------------------------
+    process_frame = tk.Frame(notebook, bg=DARK_BG)
+    notebook.add(process_frame, text="Processing")
+
+    tk.Label(process_frame, text="Input Text", bg=DARK_BG, fg=LIGHT_FG).pack(
+        padx=5, pady=(5, 2), anchor=tk.W
+    )
+    text_entry = tk.Entry(
+        process_frame, width=60, bg=DARK_BG, fg=LIGHT_FG, insertbackground=LIGHT_FG
+    )
+    text_entry.pack(padx=5, pady=2, fill=tk.X)
 
     def on_process() -> None:
         text = text_entry.get()
@@ -50,16 +187,23 @@ def run_ai_tools() -> None:
         messagebox.showinfo("Processed", result)
 
     tk.Button(
-        root, text="Process", command=on_process, bg=ACCENT_PURPLE, fg=LIGHT_FG
-    ).pack(pady=5)
+        process_frame,
+        text="Process",
+        command=on_process,
+        bg=ACCENT_PURPLE,
+        fg=LIGHT_FG,
+    ).pack(pady=5, anchor=tk.E, padx=5)
 
-    tk.Label(root, text="Numbers (comma separated)", bg=DARK_BG, fg=LIGHT_FG).pack(
-        padx=5, pady=5
-    )
+    tk.Label(
+        process_frame,
+        text="Numbers (comma separated)",
+        bg=DARK_BG,
+        fg=LIGHT_FG,
+    ).pack(padx=5, pady=(15, 2), anchor=tk.W)
     num_entry = tk.Entry(
-        root, width=50, bg=DARK_BG, fg=LIGHT_FG, insertbackground=LIGHT_FG
+        process_frame, width=60, bg=DARK_BG, fg=LIGHT_FG, insertbackground=LIGHT_FG
     )
-    num_entry.pack(padx=5, pady=5)
+    num_entry.pack(padx=5, pady=2, fill=tk.X)
 
     def on_mean() -> None:
         raw = num_entry.get()
@@ -69,11 +213,266 @@ def run_ai_tools() -> None:
             messagebox.showerror("Error", "Please enter valid numbers")
             return
         result = proc.compute_mean(nums) if nums else 0.0
-        messagebox.showinfo("Mean", str(result))
+        messagebox.showinfo("Mean", f"{result:0.4f}")
 
     tk.Button(
-        root, text="Compute Mean", command=on_mean, bg=ACCENT_PURPLE, fg=LIGHT_FG
-    ).pack(pady=5)
+        process_frame,
+        text="Compute Mean",
+        command=on_mean,
+        bg=ACCENT_PURPLE,
+        fg=LIGHT_FG,
+    ).pack(pady=5, anchor=tk.E, padx=5)
+
+    # ------------------------------------------------------------------
+    # System tab
+    # ------------------------------------------------------------------
+    system_frame = tk.Frame(notebook, bg=DARK_BG)
+    notebook.add(system_frame, text="System Status")
+
+    status_vars: Dict[str, tk.StringVar] = {
+        "hostname": tk.StringVar(value=""),
+        "system": tk.StringVar(value=""),
+        "release": tk.StringVar(value=""),
+        "python": tk.StringVar(value=""),
+        "cpu": tk.StringVar(value=""),
+        "memory": tk.StringVar(value=""),
+        "disk": tk.StringVar(value=""),
+        "uptime": tk.StringVar(value=""),
+        "memory_path": tk.StringVar(value=""),
+        "memory_dir_size": tk.StringVar(value=""),
+    }
+
+    for row, (label, var) in enumerate(status_vars.items()):
+        tk.Label(
+            system_frame,
+            text=label.title().replace("_", " "),
+            bg=DARK_BG,
+            fg=LIGHT_FG,
+        ).grid(row=row, column=0, sticky=tk.W, padx=10, pady=3)
+        tk.Label(system_frame, textvariable=var, bg=DARK_BG, fg=LIGHT_FG).grid(
+            row=row, column=1, sticky=tk.W, padx=10, pady=3
+        )
+
+    mem_progress = ttk.Progressbar(system_frame, length=250)
+    mem_progress.grid(row=5, column=2, padx=10, pady=3, sticky=tk.W)
+
+    def refresh_system() -> None:
+        status = _gather_system_status()
+        for key, var in status_vars.items():
+            var.set(status.get(key, ""))
+        percent = status.get("memory_percent")
+        try:
+            mem_progress.configure(value=float(percent))
+        except Exception:
+            mem_progress.configure(value=0)
+
+    ttk.Button(
+        system_frame,
+        text="Refresh",
+        command=refresh_system,
+    ).grid(row=len(status_vars), column=0, columnspan=2, padx=10, pady=10, sticky=tk.W)
+
+    refresh_system()
+
+    # ------------------------------------------------------------------
+    # Memory tab
+    # ------------------------------------------------------------------
+    memory_frame = tk.Frame(notebook, bg=DARK_BG)
+    notebook.add(memory_frame, text="Memory")
+
+    tk.Label(
+        memory_frame,
+        text=f"Uploads directory: {uploads_dir}",
+        bg=DARK_BG,
+        fg=LIGHT_FG,
+        wraplength=500,
+        justify=tk.LEFT,
+    ).pack(padx=10, pady=(10, 5), anchor=tk.W)
+
+    uploads_list = tk.Listbox(memory_frame, width=70, height=10, bg=DARK_BG, fg=LIGHT_FG)
+    uploads_list.pack(padx=10, pady=5, fill=tk.BOTH, expand=True)
+
+    def populate_uploads() -> None:
+        uploads_list.delete(0, tk.END)
+        for item in _list_memory_uploads(uploads_dir):
+            uploads_list.insert(tk.END, item)
+
+    def on_upload() -> None:
+        if filedialog is None:
+            messagebox.showerror("File Upload", "File dialog not available")
+            return
+        filenames = filedialog.askopenfilenames(title="Select files to upload")
+        if not filenames:
+            return
+        for name in filenames:
+            src = Path(name)
+            if not src.exists():
+                continue
+            destination = uploads_dir / src.name
+            try:
+                shutil.copy2(src, destination)
+            except Exception as exc:
+                messagebox.showerror("Upload failed", str(exc))
+                return
+        messagebox.showinfo("Upload", "Files uploaded to memory")
+        populate_uploads()
+
+    def on_open_memory() -> None:
+        path = get_memory_path(create=True)
+        messagebox.showinfo("Memory Path", str(path))
+
+    btn_frame = tk.Frame(memory_frame, bg=DARK_BG)
+    btn_frame.pack(pady=5)
+    tk.Button(
+        btn_frame,
+        text="Upload Files",
+        command=on_upload,
+        bg=ACCENT_PURPLE,
+        fg=LIGHT_FG,
+    ).pack(side=tk.LEFT, padx=5)
+    tk.Button(
+        btn_frame,
+        text="Open Memory Path",
+        command=on_open_memory,
+        bg=ACCENT_PURPLE,
+        fg=LIGHT_FG,
+    ).pack(side=tk.LEFT, padx=5)
+    tk.Button(
+        btn_frame,
+        text="Refresh",
+        command=populate_uploads,
+        bg=ACCENT_PURPLE,
+        fg=LIGHT_FG,
+    ).pack(side=tk.LEFT, padx=5)
+
+    populate_uploads()
+
+    # ------------------------------------------------------------------
+    # LLM tab
+    # ------------------------------------------------------------------
+    llm_frame = tk.Frame(notebook, bg=DARK_BG)
+    notebook.add(llm_frame, text="LLM Console")
+
+    tk.Label(llm_frame, text="Provider", bg=DARK_BG, fg=LIGHT_FG).grid(
+        row=0, column=0, padx=10, pady=5, sticky=tk.W
+    )
+
+    default_provider = config.get_setting(
+        "agent.llama.provider", LLMProvider.OPENAI.value
+    )
+    try:
+        default_provider = LLMProvider(default_provider).value
+    except ValueError:
+        default_provider = LLMProvider.OPENAI.value
+
+    provider_var = tk.StringVar(value=default_provider)
+    provider_menu = ttk.Combobox(
+        llm_frame,
+        textvariable=provider_var,
+        values=[provider.value for provider in LLMProvider],
+        state="readonly",
+    )
+    provider_menu.grid(row=0, column=1, padx=10, pady=5, sticky=tk.W)
+
+    tk.Label(llm_frame, text="Model", bg=DARK_BG, fg=LIGHT_FG).grid(
+        row=0, column=2, padx=10, pady=5, sticky=tk.W
+    )
+    model_var = tk.StringVar(
+        value=config.get_setting("agent.llama.model", "gpt-4o-mini") or "gpt-4o-mini"
+    )
+    tk.Entry(
+        llm_frame,
+        textvariable=model_var,
+        bg=DARK_BG,
+        fg=LIGHT_FG,
+        insertbackground=LIGHT_FG,
+    ).grid(row=0, column=3, padx=10, pady=5, sticky=tk.W)
+
+    chat_display = scrolledtext.ScrolledText(
+        llm_frame,
+        width=80,
+        height=15,
+        bg=DARK_BG,
+        fg=LIGHT_FG,
+        state=tk.DISABLED,
+        insertbackground=LIGHT_FG,
+    )
+    chat_display.grid(row=1, column=0, columnspan=4, padx=10, pady=10, sticky="nsew")
+
+    llm_frame.grid_rowconfigure(1, weight=1)
+    llm_frame.grid_columnconfigure(0, weight=1)
+    llm_frame.grid_columnconfigure(1, weight=0)
+    llm_frame.grid_columnconfigure(2, weight=0)
+    llm_frame.grid_columnconfigure(3, weight=1)
+
+    input_var = tk.StringVar()
+    input_entry = tk.Entry(
+        llm_frame,
+        textvariable=input_var,
+        bg=DARK_BG,
+        fg=LIGHT_FG,
+        insertbackground=LIGHT_FG,
+    )
+    input_entry.grid(row=2, column=0, columnspan=3, padx=10, pady=5, sticky="ew")
+    input_entry.bind("<Return>", lambda event: on_send())
+
+    conversation: List[Dict[str, str]] = []
+
+    def append_chat(prefix: str, text: str) -> None:
+        chat_display.configure(state=tk.NORMAL)
+        chat_display.insert(tk.END, f"{prefix}: {text}\n")
+        chat_display.configure(state=tk.DISABLED)
+        chat_display.see(tk.END)
+
+    def on_send() -> None:
+        message = input_var.get().strip()
+        if not message:
+            return
+        input_var.set("")
+        append_chat("You", message)
+        conversation.append({"role": "user", "content": message})
+        provider_value = provider_var.get()
+        try:
+            provider = LLMProvider(provider_value)
+        except ValueError:
+            provider = LLMProvider.OPENAI
+        settings = config.get_setting(f"llm.{provider.value}.settings", {})
+        if not isinstance(settings, dict):
+            settings = {}
+        try:
+            adapter = LLMAdapter(
+                provider,
+                model=model_var.get() or "gpt-4o-mini",
+                settings=settings,
+            )
+            response = adapter.generate(prompt=message, messages=conversation)
+        except Exception as exc:  # pragma: no cover - depends on optional libs
+            response = f"Failed to reach provider: {exc}"
+        conversation.append({"role": "assistant", "content": response})
+        append_chat(provider.value, response)
+
+    def on_clear() -> None:
+        conversation.clear()
+        chat_display.configure(state=tk.NORMAL)
+        chat_display.delete("1.0", tk.END)
+        chat_display.configure(state=tk.DISABLED)
+
+    tk.Button(
+        llm_frame,
+        text="Send",
+        command=on_send,
+        bg=ACCENT_PURPLE,
+        fg=LIGHT_FG,
+    ).grid(row=2, column=3, padx=10, pady=5, sticky=tk.E)
+    tk.Button(
+        llm_frame,
+        text="Clear",
+        command=on_clear,
+        bg=ACCENT_PURPLE,
+        fg=LIGHT_FG,
+    ).grid(row=3, column=3, padx=10, pady=(0, 10), sticky=tk.E)
+
+    notebook.select(process_frame)
 
     root.mainloop()
 

--- a/huey/memory/PY/dashboard.py
+++ b/huey/memory/PY/dashboard.py
@@ -1,0 +1,438 @@
+# ==================================================
+# This file is a part of the 'Monkey Head Project'
+# Website:   https://dlrp.ca
+# GitHub:  https://github.com/DylanLRPollock/Monkey-Head-Project
+# License:   https://opensource.org/license/gpl-3-0
+# Overseen By:   Dylan L.R. Pollock
+# Updated: 06.12.2025
+# ==================================================
+"""PySide6 dashboard providing a consolidated operational overview."""
+
+from __future__ import annotations
+
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+try:  # pragma: no cover - optional GUI dependencies
+    from PySide6.QtCore import QTimer, Qt
+    from PySide6.QtWidgets import (
+        QApplication,
+        QGridLayout,
+        QHBoxLayout,
+        QHeaderView,
+        QInputDialog,
+        QLabel,
+        QMainWindow,
+        QMessageBox,
+        QPushButton,
+        QProgressBar,
+        QTableWidget,
+        QTableWidgetItem,
+        QTabWidget,
+        QTreeWidget,
+        QTreeWidgetItem,
+        QVBoxLayout,
+        QWidget,
+    )
+except Exception:  # pragma: no cover - GUI not available
+    QApplication = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional theming
+    from qt_material import apply_stylesheet
+except Exception:  # pragma: no cover - theme not installed
+    apply_stylesheet = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - psutil optional
+    import psutil  # type: ignore
+except Exception:  # pragma: no cover - psutil missing at runtime
+    psutil = None  # type: ignore[assignment]
+
+from monkey_head.core.task_scheduler import (
+    Agent,
+    TaskPriority,
+    TaskScheduler,
+    TaskStatus,
+)
+from monkey_head.utils.paths import get_memory_path
+
+
+def _format_bytes(value: float | int | None) -> str:
+    """Return ``value`` formatted as a human readable string."""
+
+    if value is None:
+        return "Unknown"
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(value)
+    for unit in units:
+        if size < 1024.0:
+            return f"{size:0.2f} {unit}"
+        size /= 1024.0
+    return f"{size:0.2f} PB"
+
+
+def _directory_size(path: Path, *, depth: int = 1) -> Tuple[float, int]:
+    """Return ``(size, item_count)`` for ``path`` limited by ``depth``."""
+
+    total = 0
+    count = 0
+    try:
+        if path.is_file():
+            return float(path.stat().st_size), 1
+        if depth < 0:
+            return 0.0, 0
+        for entry in path.iterdir():
+            if entry.name.startswith("."):
+                continue
+            if entry.is_dir():
+                size, items = _directory_size(entry, depth=depth - 1)
+                total += size
+                count += items
+            else:
+                total += float(entry.stat().st_size)
+                count += 1
+    except Exception:
+        return 0.0, 0
+    return total, count
+
+
+def _memory_summary(path: Path) -> List[Tuple[str, float, int]]:
+    """Return aggregated stats for the top-level entries inside ``path``."""
+
+    results: List[Tuple[str, float, int]] = []
+    try:
+        for entry in sorted(path.iterdir(), key=lambda e: e.name.lower()):
+            size, items = _directory_size(entry, depth=1)
+            results.append((entry.name, size, items))
+    except Exception:
+        return []
+    return results
+
+
+def _system_metrics() -> Dict[str, str]:
+    """Gather host metrics for display."""
+
+    metrics: Dict[str, str] = {}
+    if psutil is not None:  # pragma: no branch
+        try:
+            metrics["CPU Load"] = f"{psutil.cpu_percent(interval=0.05):0.1f}%"
+        except Exception:
+            metrics["CPU Load"] = "Unavailable"
+        try:
+            vm = psutil.virtual_memory()
+            metrics["Memory"] = f"{_format_bytes(vm.used)} / {_format_bytes(vm.total)}"
+            metrics["MemoryPercent"] = f"{(vm.used / vm.total) * 100:0.1f}" if vm.total else "0.0"
+        except Exception:
+            metrics["Memory"] = "Unavailable"
+            metrics["MemoryPercent"] = "0.0"
+        try:
+            disk = psutil.disk_usage(str(Path("/")))
+            metrics["Disk"] = f"{_format_bytes(disk.used)} / {_format_bytes(disk.total)}"
+        except Exception:
+            metrics["Disk"] = "Unavailable"
+        try:
+            boot = getattr(psutil, "boot_time", lambda: None)()
+        except Exception:
+            boot = None
+        if boot:
+            uptime = max(0.0, time.time() - float(boot))
+            hours = int(uptime // 3600)
+            minutes = int((uptime % 3600) // 60)
+            metrics["Uptime"] = f"{hours}h {minutes}m"
+    else:
+        metrics.update({
+            "CPU Load": "psutil unavailable",
+            "Memory": "psutil unavailable",
+            "MemoryPercent": "0.0",
+            "Disk": "psutil unavailable",
+            "Uptime": "Unknown",
+        })
+    return metrics
+
+
+class DashboardWindow(QMainWindow):
+    """Main window hosting the dashboard tabs."""
+
+    def __init__(self, scheduler: TaskScheduler | None = None) -> None:
+        if QApplication is None:  # pragma: no cover - GUI environment missing
+            raise RuntimeError("PySide6 is not available")
+
+        super().__init__()
+        self.scheduler = scheduler or TaskScheduler()
+        self.setWindowTitle("Monkey Head Dashboard")
+        self.resize(1100, 720)
+
+        central = QWidget(self)
+        self.setCentralWidget(central)
+        layout = QVBoxLayout(central)
+
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        self._setup_system_tab()
+        self._setup_memory_tab()
+        self._setup_task_tab()
+        self._setup_agent_tab()
+
+        self._timer = QTimer(self)
+        self._timer.timeout.connect(self.refresh_all)
+        self._timer.start(5000)
+        self.refresh_all()
+
+    # ------------------------------------------------------------------
+    # Tab setup helpers
+    # ------------------------------------------------------------------
+    def _setup_system_tab(self) -> None:
+        self.system_tab = QWidget()
+        grid = QGridLayout(self.system_tab)
+        self.system_labels: Dict[str, QLabel] = {}
+
+        labels = ["CPU Load", "Memory", "Disk", "Uptime"]
+        for row, label in enumerate(labels):
+            grid.addWidget(QLabel(label + ":"), row, 0, Qt.AlignLeft)
+            value_label = QLabel("…")
+            grid.addWidget(value_label, row, 1, Qt.AlignLeft)
+            self.system_labels[label] = value_label
+
+        self.memory_bar = QProgressBar()
+        self.memory_bar.setRange(0, 100)
+        grid.addWidget(QLabel("Memory Utilisation:"), len(labels), 0, Qt.AlignLeft)
+        grid.addWidget(self.memory_bar, len(labels), 1)
+
+        refresh_btn = QPushButton("Refresh")
+        refresh_btn.clicked.connect(self.refresh_system_metrics)
+        grid.addWidget(refresh_btn, len(labels) + 1, 0)
+
+        self.tabs.addTab(self.system_tab, "System Metrics")
+
+    def _setup_memory_tab(self) -> None:
+        self.memory_tab = QWidget()
+        layout = QVBoxLayout(self.memory_tab)
+
+        self.memory_summary = QLabel("Scanning memory path…")
+        layout.addWidget(self.memory_summary)
+
+        self.memory_tree = QTreeWidget()
+        self.memory_tree.setColumnCount(3)
+        self.memory_tree.setHeaderLabels(["Name", "Size", "Items"])
+        self.memory_tree.header().setSectionResizeMode(0, QHeaderView.Stretch)
+        self.memory_tree.header().setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        self.memory_tree.header().setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        layout.addWidget(self.memory_tree)
+
+        button_row = QHBoxLayout()
+        refresh_btn = QPushButton("Refresh")
+        refresh_btn.clicked.connect(self.refresh_memory_view)
+        button_row.addWidget(refresh_btn)
+        layout.addLayout(button_row)
+
+        self.tabs.addTab(self.memory_tab, "Memory")
+
+    def _setup_task_tab(self) -> None:
+        self.task_tab = QWidget()
+        layout = QVBoxLayout(self.task_tab)
+
+        self.task_table = QTableWidget(0, 7)
+        self.task_table.setHorizontalHeaderLabels(
+            [
+                "Task ID",
+                "Command",
+                "Priority",
+                "Status",
+                "Requested Agent",
+                "Assigned Agent",
+                "Updated",
+            ]
+        )
+        self.task_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeToContents)
+        self.task_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch)
+        for idx in range(2, 6):
+            self.task_table.horizontalHeader().setSectionResizeMode(idx, QHeaderView.ResizeToContents)
+        self.task_table.horizontalHeader().setSectionResizeMode(6, QHeaderView.ResizeToContents)
+        layout.addWidget(self.task_table)
+
+        buttons = QHBoxLayout()
+        submit_btn = QPushButton("Submit Task")
+        submit_btn.clicked.connect(self._submit_task_dialog)
+        buttons.addWidget(submit_btn)
+
+        reconcile_btn = QPushButton("Reconcile")
+        reconcile_btn.clicked.connect(self._reconcile_tasks)
+        buttons.addWidget(reconcile_btn)
+
+        refresh_btn = QPushButton("Refresh")
+        refresh_btn.clicked.connect(self.refresh_task_table)
+        buttons.addWidget(refresh_btn)
+
+        complete_btn = QPushButton("Complete Selected")
+        complete_btn.clicked.connect(self._complete_selected_task)
+        buttons.addWidget(complete_btn)
+
+        layout.addLayout(buttons)
+
+        self.tabs.addTab(self.task_tab, "Task Management")
+
+    def _setup_agent_tab(self) -> None:
+        self.agent_tab = QWidget()
+        layout = QVBoxLayout(self.agent_tab)
+
+        self.agent_table = QTableWidget(0, 4)
+        self.agent_table.setHorizontalHeaderLabels(
+            ["Agent", "Running", "Pending", "Completed"]
+        )
+        self.agent_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        layout.addWidget(self.agent_table)
+
+        self.tabs.addTab(self.agent_tab, "Agent Status")
+
+    # ------------------------------------------------------------------
+    # Refresh helpers
+    # ------------------------------------------------------------------
+    def refresh_all(self) -> None:
+        self.refresh_system_metrics()
+        self.refresh_memory_view()
+        self.refresh_task_table()
+        self.refresh_agent_table()
+
+    def refresh_system_metrics(self) -> None:
+        metrics = _system_metrics()
+        for key, label in self.system_labels.items():
+            label.setText(metrics.get(key, "Unknown"))
+        try:
+            percent = float(metrics.get("MemoryPercent", "0.0"))
+        except ValueError:
+            percent = 0.0
+        self.memory_bar.setValue(int(percent))
+
+    def refresh_memory_view(self) -> None:
+        memory_path = get_memory_path(create=True)
+        summary = _memory_summary(memory_path)
+        self.memory_tree.clear()
+        total_size = 0.0
+        total_items = 0
+        for name, size, items in summary:
+            item = QTreeWidgetItem([name, _format_bytes(size), str(items)])
+            self.memory_tree.addTopLevelItem(item)
+            total_size += size
+            total_items += items
+        self.memory_summary.setText(
+            f"Memory root: {memory_path} — Total {_format_bytes(total_size)} across {total_items} items"
+        )
+
+    def refresh_task_table(self) -> None:
+        records = self.scheduler.list_tasks()
+        self.task_table.setRowCount(len(records))
+        for row, record in enumerate(records):
+            values = [
+                record.task_id,
+                record.command,
+                record.priority.name,
+                record.status.value,
+                record.requested_agent.value if record.requested_agent else "—",
+                record.assigned_agent.value if record.assigned_agent else "—",
+                time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(record.updated_at)),
+            ]
+            for col, value in enumerate(values):
+                self.task_table.setItem(row, col, QTableWidgetItem(str(value)))
+        self.task_table.resizeRowsToContents()
+
+    def refresh_agent_table(self) -> None:
+        records = self.scheduler.list_tasks()
+        stats: Dict[Agent, Dict[str, int]] = defaultdict(lambda: {"running": 0, "pending": 0, "completed": 0})
+        for record in records:
+            agent = record.assigned_agent or record.requested_agent
+            if agent is None:
+                continue
+            if record.status is TaskStatus.RUNNING:
+                stats[agent]["running"] += 1
+            elif record.status is TaskStatus.PENDING:
+                stats[agent]["pending"] += 1
+            elif record.status is TaskStatus.COMPLETED:
+                stats[agent]["completed"] += 1
+
+        self.agent_table.setRowCount(len(Agent))
+        for row, agent in enumerate(Agent):
+            data = stats.get(agent, {"running": 0, "pending": 0, "completed": 0})
+            self.agent_table.setItem(row, 0, QTableWidgetItem(agent.value))
+            self.agent_table.setItem(row, 1, QTableWidgetItem(str(data["running"])))
+            self.agent_table.setItem(row, 2, QTableWidgetItem(str(data["pending"])))
+            self.agent_table.setItem(row, 3, QTableWidgetItem(str(data["completed"])))
+        self.agent_table.resizeRowsToContents()
+
+    # ------------------------------------------------------------------
+    # Task management actions
+    # ------------------------------------------------------------------
+    def _submit_task_dialog(self) -> None:
+        command, ok = QInputDialog.getText(self, "Submit Task", "Command")
+        if not ok or not command.strip():
+            return
+        priorities = [priority.name for priority in TaskPriority]
+        priority_name, ok = QInputDialog.getItem(
+            self,
+            "Task Priority",
+            "Select priority",
+            priorities,
+            editable=False,
+        )
+        if not ok or not priority_name:
+            return
+        priority = TaskPriority[priority_name]
+        record = self.scheduler.submit_task(command=command.strip(), priority=priority)
+        QMessageBox.information(
+            self,
+            "Task Submitted",
+            f"Task {record.task_id} queued with priority {priority.name}.",
+        )
+        self.refresh_all()
+
+    def _reconcile_tasks(self) -> None:
+        dispatched = self.scheduler.reconcile()
+        QMessageBox.information(
+            self,
+            "Reconcile",
+            f"Re-dispatched {len(dispatched)} task(s).",
+        )
+        self.refresh_all()
+
+    def _complete_selected_task(self) -> None:
+        row = self.task_table.currentRow()
+        if row < 0:
+            QMessageBox.warning(self, "Complete Task", "Select a task to mark as complete.")
+            return
+        task_id_item = self.task_table.item(row, 0)
+        if task_id_item is None:
+            return
+        task_id = task_id_item.text()
+        try:
+            self.scheduler.complete_task(task_id)
+        except KeyError as exc:
+            QMessageBox.warning(self, "Complete Task", str(exc))
+        else:
+            QMessageBox.information(self, "Task Completed", f"Task {task_id} marked completed.")
+        self.refresh_all()
+
+
+def launch_dashboard(scheduler: TaskScheduler | None = None) -> None:
+    """Launch the dashboard application."""
+
+    if QApplication is None:
+        raise RuntimeError("PySide6 is not available")
+
+    app = QApplication.instance()
+    owns_app = False
+    if app is None:
+        app = QApplication(sys.argv)
+        owns_app = True
+    if apply_stylesheet is not None:
+        apply_stylesheet(app, theme="dark_teal.xml")
+
+    window = DashboardWindow(scheduler=scheduler)
+    window.show()
+
+    if owns_app:
+        app.exec()
+
+
+__all__ = ["launch_dashboard", "DashboardWindow"]

--- a/huey/memory/PY/license_gui.py
+++ b/huey/memory/PY/license_gui.py
@@ -6,6 +6,10 @@
 # Overseen By:   Dylan L.R. Pollock
 # Updated: 06.11.2025
 # ==================================================
+from __future__ import annotations
+
+from datetime import datetime
+from hashlib import sha256
 from pathlib import Path
 
 try:  # pragma: no cover - optional dependency
@@ -25,19 +29,37 @@ LIGHT_FG = "#00ff00"  # green text
 ACCENT_PURPLE = "#2d2b57"  # dark purple accent
 
 
-def accept_license(config_path: str | Path) -> None:
-    """Set the ``license.accepted`` flag in the given config file."""
+def accept_license(config_path: str | Path, license_hash: str | None = None) -> None:
+    """Persist the acceptance state and timestamp for the license dialog."""
+
     manager = ConfigManager(str(config_path))
-    manager.set_setting("license.accepted", True)
+    payload = {
+        "license.accepted": True,
+        "license.accepted_at": datetime.utcnow().isoformat(timespec="seconds"),
+    }
+    if license_hash is not None:
+        payload["license.hash"] = license_hash
+    manager.update_settings(payload)
 
 
 def show_license_gui(config_path: str | Path = "config/pygpt_net/config.json") -> None:
     """Display a simple license agreement dialog."""
-    if tk is None:
+
+    if tk is None or scrolledtext is None:
         raise RuntimeError("tkinter is not available")
 
     manager = ConfigManager(str(config_path))
-    if manager.get_setting("license.accepted"):
+
+    license_path = Path(__file__).resolve().parents[3] / "LICENSE"
+    try:
+        license_text = license_path.read_text(encoding="utf-8")
+    except Exception:
+        license_text = "License file not found."
+    license_hash = sha256(license_text.encode("utf-8")).hexdigest()
+
+    accepted = bool(manager.get_setting("license.accepted"))
+    accepted_hash = manager.get_setting("license.hash")
+    if accepted and accepted_hash == license_hash:
         return
 
     root = tk.Tk()
@@ -63,16 +85,12 @@ def show_license_gui(config_path: str | Path = "config/pygpt_net/config.json") -
         highlightcolor=ACCENT_PURPLE,
         highlightthickness=2,
     )
-    try:
-        license_text = Path("docs/LICENSE").read_text(encoding="utf-8")
-    except Exception:
-        license_text = "License file not found."
     text.insert(tk.END, license_text)
     text.config(state=tk.DISABLED)
     text.pack(padx=10, pady=10)
 
     def on_accept() -> None:
-        accept_license(config_path)
+        accept_license(config_path, license_hash)
         messagebox.showinfo("License", "License accepted")
         messagebox.showwarning(
             "Experimental",

--- a/huey/memory/PY/main_ui.py
+++ b/huey/memory/PY/main_ui.py
@@ -41,6 +41,7 @@ from monkey_head.scripts.preload_data import preload_all
 from monkey_head.gui_scaling import apply_scaling
 from monkey_head.simple_chat_gui import run_simple_chat
 from monkey_head.ai_tools_gui import run_ai_tools
+from monkey_head.dashboard import launch_dashboard
 from monkey_head.config_toggle_gui import run_config_toggle_gui
 from monkey_head.services.container_management import (
     build_docker_image,
@@ -198,6 +199,7 @@ class MainUI:
         ai_menu = tk.Menu(menu_bar, tearoff=0, bg=DARK_BG, fg=LIGHT_FG)
         ai_menu.add_command(label="Simple Chat", command=self.launch_simple_chat)
         ai_menu.add_command(label="AI Processor Demo", command=self.launch_ai_tools)
+        ai_menu.add_command(label="Dashboard", command=self.launch_dashboard)
         menu_bar.add_cascade(label="AI", menu=ai_menu)
 
         docker_menu = tk.Menu(menu_bar, tearoff=0, bg=DARK_BG, fg=LIGHT_FG)
@@ -508,6 +510,14 @@ class MainUI:
         """Open the AI tools window in a background thread."""
         self.log_message("Launching AI tools...")
         self._submit_task(run_ai_tools)
+
+    def launch_dashboard(self):
+        """Open the PySide dashboard."""
+        self.log_message("Launching dashboard...")
+        try:
+            launch_dashboard()
+        except RuntimeError as exc:
+            messagebox.showerror("Dashboard", str(exc))
 
     def on_close(self):
         """Shutdown the executor and close the UI."""

--- a/tests/test_license_gui.py
+++ b/tests/test_license_gui.py
@@ -21,12 +21,14 @@ class TestLicenseGui(unittest.TestCase):
         with temp_path.open("w", encoding="utf-8") as f:
             json.dump(data, f)
 
-        accept_license(temp_path)
+        accept_license(temp_path, "dummy-hash")
 
         with temp_path.open(encoding="utf-8") as f:
             updated = json.load(f)
 
         self.assertTrue(updated.get("license.accepted"))
+        self.assertIn("license.accepted_at", updated)
+        self.assertEqual(updated.get("license.hash"), "dummy-hash")
         os.remove(temp_path)
 
 


### PR DESCRIPTION
## Summary
- Expand the AI Tools Tkinter interface with system metrics, memory uploads, and an integrated LLM console leveraging existing adapters.
- Display the project LICENSE in the acceptance dialog, persist acceptance metadata via ConfigManager, and skip repeat prompts once accepted.
- Add a themed PySide6 dashboard covering metrics, memory usage, task management, and agent status, plus surface it from the main UI.
- Align the license GUI test with the new acceptance metadata expectations.

## Testing
- pytest *(fails: environment lacks optional dependencies such as httpx and pydantic needed by the full suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a5a04768832bbfe1a6fe7416a0f0