### PR TITLE
Add HueyOS CLI entry point and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,27 @@ make test
 pytest -vv
 ```
 
+**Command-line interface**
+```bash
+# Prepare the shared memory workspace and run compatibility checks
+huey init --run-checks --verbose
+
+# Launch HueyOS with optional ML + cloud profiles enabled
+huey run --ml --cloud
+
+# Inspect host readiness with detailed output
+huey system-check --verbose
+
+# Deploy core services via Docker and Kubernetes manifests
+huey deploy --mode all --compose-file docker-compose.yml --manifest k8s.yaml
+
+# Summarise agent workload and resource health as JSON
+huey agent-status --json
+
+# Sort collected artefacts without modifying the filesystem
+huey memory-sort --dry-run --json
+```
+
 ---
 
 ## Contributing

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,13 @@
 - Storage: Bees & Honey
   - [Honeycomb storage operations](honeycomb-storage.md)
 - Orchestration Node (X9QRI-F+), Nodes (BD795I-SE), Black Box
+
+## CLI quick reference
+
+```bash
+huey run --ml --cloud             # launch runtime with ML + cloud profiles
+huey system-check --verbose       # detailed diagnostics
+huey deploy --mode docker         # docker-only deployment
+huey agent-status --json          # scheduler snapshot as JSON
+huey memory-sort --dry-run --json # dry-run memory organiser
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ dev = [
 ]
 
 [project.scripts]
+huey = "huey.cli:main"
 huey-api = "huey.api:app"
 
 [build-system]

--- a/src/huey/cli.py
+++ b/src/huey/cli.py
@@ -1,0 +1,459 @@
+"""Top-level command line interface for HueyOS."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Sequence
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="huey",
+        description="Command line interface for HueyOS runtime and utilities.",
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.required = True
+
+    init_cmd = sub.add_parser(
+        "init",
+        help="Initialise the HueyOS workspace and memory directories.",
+    )
+    init_cmd.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print the directories that were created during initialisation.",
+    )
+    init_cmd.add_argument(
+        "--run-checks",
+        action="store_true",
+        help="Run system compatibility checks after creating directories.",
+    )
+    init_cmd.set_defaults(handler=_cmd_init)
+
+    run_cmd = sub.add_parser("run", help="Launch the HueyOS runtime.")
+    run_cmd.add_argument(
+        "--cli",
+        action="store_true",
+        help="Launch the command line interface instead of the GUI.",
+    )
+    run_cmd.add_argument(
+        "--gui",
+        action="store_true",
+        help="Explicitly launch the GUI even if other flags request CLI mode.",
+    )
+    run_cmd.add_argument(
+        "--minimal",
+        action="store_true",
+        help="Use the lightweight CustomPyGPT CLI without GUI dependencies.",
+    )
+    run_cmd.add_argument(
+        "--manager-ui",
+        action="store_true",
+        help="Launch the Tkinter program manager UI instead of the main runtime.",
+    )
+    run_cmd.add_argument(
+        "--ml",
+        action="store_true",
+        help="Enable the ML optional dependency profile before launching.",
+    )
+    run_cmd.add_argument(
+        "--cloud",
+        action="store_true",
+        help="Enable the cloud optional dependency profile before launching.",
+    )
+    run_cmd.add_argument(
+        "--profile",
+        action="append",
+        default=[],
+        help="Additional runtime profiles to export via HUEY_PROFILES.",
+    )
+    run_cmd.add_argument(
+        "--skip-checks",
+        action="store_true",
+        help="Skip operating system and Python compatibility checks.",
+    )
+    run_cmd.add_argument(
+        "--no-fallback",
+        action="store_true",
+        help="Do not fall back to the CLI if the GUI fails to launch.",
+    )
+    run_cmd.set_defaults(handler=_cmd_run)
+
+    sys_cmd = sub.add_parser(
+        "system-check", help="Run environment diagnostics and compatibility checks."
+    )
+    sys_cmd.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the collected results as JSON.",
+    )
+    sys_cmd.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Always print each individual check result.",
+    )
+    sys_cmd.set_defaults(handler=_cmd_system_check)
+
+    deploy_cmd = sub.add_parser(
+        "deploy", help="Deploy HueyOS services using Docker and/or Kubernetes."
+    )
+    deploy_cmd.add_argument(
+        "--mode",
+        choices=["docker", "kubernetes", "all"],
+        default="all",
+        help="Select which deployment targets to execute.",
+    )
+    deploy_cmd.add_argument(
+        "--compose-file",
+        default="docker-compose.yml",
+        help="Path to the Docker Compose file to apply.",
+    )
+    deploy_cmd.add_argument(
+        "--manifest",
+        default="k8s.yaml",
+        help="Path to the Kubernetes manifest to apply.",
+    )
+    deploy_cmd.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing them.",
+    )
+    deploy_cmd.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show command output even when commands succeed.",
+    )
+    deploy_cmd.set_defaults(handler=_cmd_deploy)
+
+    agent_cmd = sub.add_parser(
+        "agent-status",
+        help="Report scheduler task counts and recent resource observations.",
+    )
+    agent_cmd.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the status payload as JSON.",
+    )
+    agent_cmd.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Include details for each tracked task in the output.",
+    )
+    agent_cmd.set_defaults(handler=_cmd_agent_status)
+
+    sort_cmd = sub.add_parser(
+        "memory-sort", help="Organise the shared memory directory by file type."
+    )
+    sort_cmd.add_argument(
+        "--source",
+        help="Source directory containing unsorted files (defaults to memory/RAW).",
+    )
+    sort_cmd.add_argument(
+        "--destination",
+        help="Destination root directory (defaults to the configured memory path).",
+    )
+    sort_cmd.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report planned moves without modifying the filesystem.",
+    )
+    sort_cmd.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the summary as JSON.",
+    )
+    sort_cmd.set_defaults(handler=_cmd_memory_sort)
+
+    return parser
+
+
+def _cmd_init(args: argparse.Namespace) -> int:
+    from monkey_head.utils.auto_sort import get_extension_map
+    from monkey_head.utils.paths import ensure_subdirectory, get_memory_path
+
+    memory_path = get_memory_path(create=True)
+    created: List[str] = []
+
+    # Always ensure RAW and LOGS directories exist.
+    for part in ("RAW", "LOGS"):
+        path = ensure_subdirectory(part)
+        created.append(str(path))
+
+    categories = sorted({category for category in get_extension_map().values()})
+    for category in categories:
+        path = ensure_subdirectory(category)
+        created.append(str(path))
+
+    unique_created = list(dict.fromkeys(created))
+    print(f"Memory initialised at {memory_path}")
+    if args.verbose:
+        for item in unique_created:
+            print(f"  - {item}")
+
+    if args.run_checks:
+        from monkey_head.system_checks import system_check
+
+        results = system_check()
+        print("System check results:")
+        for key, value in sorted(results.items()):
+            status = "OK" if value else "WARN"
+            print(f"  {key}: {status}")
+
+    return 0
+
+
+def _normalise_profiles(profiles: Iterable[str]) -> List[str]:
+    seen: Dict[str, None] = {}
+    for profile in profiles:
+        name = profile.strip()
+        if not name:
+            continue
+        if name not in seen:
+            seen[name] = None
+    return list(seen.keys())
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    import run as runtime
+
+    requested_profiles: List[str] = []
+    if args.ml:
+        requested_profiles.append("ml")
+    if args.cloud:
+        requested_profiles.append("cloud")
+    for value in args.profile:
+        requested_profiles.extend(part.strip() for part in value.split(","))
+
+    profiles = _normalise_profiles(requested_profiles)
+    if profiles:
+        os.environ["HUEY_PROFILES"] = ",".join(profiles)
+
+    if not args.skip_checks:
+        from monkey_head.core.system_checks import check_os_support, check_python_version
+
+        check_os_support()
+        check_python_version()
+
+    try:
+        if args.manager_ui:
+            runtime.launch_manager_ui()
+            return 0
+
+        if args.minimal:
+            try:
+                from huey.memory.PY.run import minimal_run
+            except ImportError as exc:  # pragma: no cover - legacy path missing
+                raise RuntimeError("Minimal CLI mode is not available.") from exc
+            minimal_run()
+            return 0
+
+        cli_requested = args.cli and not args.gui
+        if cli_requested:
+            runner = runtime._load_cli()
+            runner()
+            return 0
+
+        try:
+            runtime.launch_gui()
+            return 0
+        except Exception:
+            if args.no_fallback:
+                raise
+            print("GUI launch failed; falling back to CLI mode.")
+            runner = runtime._load_cli()
+            runner()
+            return 0
+    except KeyboardInterrupt:  # pragma: no cover - interactive usage
+        return 130
+
+    return 0
+
+
+def _cmd_system_check(args: argparse.Namespace) -> int:
+    from monkey_head.system_checks import system_check
+
+    results = system_check()
+    if args.json:
+        print(json.dumps(results, indent=2, sort_keys=True))
+    else:
+        if args.verbose:
+            print("System check results:")
+        for key, value in sorted(results.items()):
+            status = "OK" if value else "WARN"
+            if args.verbose:
+                print(f"  {key}: {status}")
+            else:
+                print(f"{key}: {status}")
+    return 0
+
+
+def _run_command(
+    command: Sequence[str], *, dry_run: bool, verbose: bool
+) -> subprocess.CompletedProcess[str] | None:
+    if dry_run:
+        print(f"[dry-run] {' '.join(command)}")
+        return None
+
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            text=True,
+            capture_output=not verbose,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"Command not found: {command[0]}") from exc
+
+    if verbose:
+        if result.stdout:
+            print(result.stdout, end="")
+        if result.stderr:
+            print(result.stderr, end="", file=sys.stderr)
+    else:
+        if result.stdout:
+            print(result.stdout.strip())
+        if result.stderr:
+            print(result.stderr.strip(), file=sys.stderr)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command {' '.join(command)} exited with {result.returncode}"
+        )
+    return result
+
+
+def _cmd_deploy(args: argparse.Namespace) -> int:
+    tasks: List[tuple[str, Sequence[str]]] = []
+
+    if args.mode in ("docker", "all"):
+        compose_path = Path(args.compose_file).expanduser().resolve()
+        if not compose_path.exists():
+            raise RuntimeError(f"Docker compose file not found: {compose_path}")
+        tasks.append(
+            (
+                "docker", [
+                    "docker",
+                    "compose",
+                    "-f",
+                    str(compose_path),
+                    "up",
+                    "-d",
+                ],
+            )
+        )
+
+    if args.mode in ("kubernetes", "all"):
+        manifest_path = Path(args.manifest).expanduser().resolve()
+        if not manifest_path.exists():
+            raise RuntimeError(f"Kubernetes manifest not found: {manifest_path}")
+        tasks.append(("kubectl", ["kubectl", "apply", "-f", str(manifest_path)]))
+
+    for label, command in tasks:
+        if label == "docker" and shutil.which("docker") is None:
+            raise RuntimeError("Docker executable not found on PATH.")
+        if label == "kubectl" and shutil.which("kubectl") is None:
+            raise RuntimeError("kubectl executable not found on PATH.")
+        _run_command(command, dry_run=args.dry_run, verbose=args.verbose)
+
+    if not tasks:
+        print("No deployment tasks selected.")
+    return 0
+
+
+def _cmd_agent_status(args: argparse.Namespace) -> int:
+    from huey.api import SCHEDULER
+    from monkey_head.core.task_scheduler import Agent, TaskStatus
+
+    records = SCHEDULER.list_tasks()
+    status_counts: Dict[str, int] = {status.value: 0 for status in TaskStatus}
+    agent_counts: Dict[str, int] = {agent.value: 0 for agent in Agent}
+
+    for record in records:
+        status_counts[record.status.value] = status_counts.get(record.status.value, 0) + 1
+        if record.assigned_agent:
+            agent_counts[record.assigned_agent.value] = (
+                agent_counts.get(record.assigned_agent.value, 0) + 1
+            )
+
+    snapshot = SCHEDULER.health_provider()
+    snapshot_payload = {
+        "timestamp": getattr(snapshot, "timestamp", None),
+        "cpu_percent": getattr(snapshot, "cpu_percent", None),
+        "memory_available": getattr(snapshot, "memory_available", None),
+        "memory_total": getattr(snapshot, "memory_total", None),
+        "battery_percent": getattr(snapshot, "battery_percent", None),
+        "notes": getattr(snapshot, "notes", None),
+    }
+
+    payload: Dict[str, Any] = {
+        "total_tasks": len(records),
+        "tasks_by_status": {k: v for k, v in sorted(status_counts.items())},
+        "tasks_by_agent": {k: v for k, v in sorted(agent_counts.items())},
+        "resource_snapshot": snapshot_payload,
+    }
+
+    if args.verbose:
+        payload["tasks"] = [record.to_dict() for record in records]
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"Total tasks: {payload['total_tasks']}")
+        for status, count in payload["tasks_by_status"].items():
+            print(f"  {status}: {count}")
+        for agent, count in payload["tasks_by_agent"].items():
+            print(f"  agent {agent}: {count}")
+        notes = snapshot_payload.get("notes")
+        cpu = snapshot_payload.get("cpu_percent")
+        mem_avail = snapshot_payload.get("memory_available")
+        mem_total = snapshot_payload.get("memory_total")
+        if cpu is not None:
+            print(f"  cpu_percent: {cpu}")
+        if mem_avail is not None and mem_total is not None and mem_total:
+            percent_free = (mem_avail / mem_total) * 100
+            print(f"  memory_free: {percent_free:.1f}%")
+        if notes:
+            print(f"  notes: {notes}")
+    return 0
+
+
+def _cmd_memory_sort(args: argparse.Namespace) -> int:
+    from monkey_head.utils.auto_sort import auto_sort_memory
+
+    summary = auto_sort_memory(
+        source_dir=args.source,
+        destination_root=args.destination,
+        dry_run=args.dry_run,
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"Source: {summary['source']}")
+        print(f"Destination: {summary['destination']}")
+        print(f"Moved {len(summary['moved'])} file(s)")
+        if summary["skipped"]:
+            print(f"Skipped {len(summary['skipped'])} file(s):")
+            for item in summary["skipped"]:
+                print(f"  - {item}")
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    handler: Callable[[argparse.Namespace], int] = getattr(args, "handler")
+    try:
+        return handler(args)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - manual CLI usage
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,131 @@
+"""Tests for the top-level huey CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from huey import cli
+
+
+def test_system_check_json(monkeypatch, capsys):
+    called: Dict[str, Any] = {}
+
+    def fake_system_check() -> Dict[str, bool]:
+        called["done"] = True
+        return {"os_supported": True, "python_supported": True}
+
+    monkeypatch.setattr(
+        "monkey_head.system_checks.system_check", fake_system_check, raising=True
+    )
+
+    exit_code = cli.main(["system-check", "--json"])
+    assert exit_code == 0
+    assert called["done"] is True
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload == {"os_supported": True, "python_supported": True}
+
+
+def test_memory_sort_dry_run(tmp_path: Path, capsys):
+    source = tmp_path / "RAW"
+    source.mkdir()
+    (source / "report.pdf").write_text("dummy")
+    (source / "notes.txt").write_text("dummy")
+    destination = tmp_path / "memory"
+
+    exit_code = cli.main(
+        [
+            "memory-sort",
+            "--source",
+            str(source),
+            "--destination",
+            str(destination),
+            "--dry-run",
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["source"] == str(source.resolve())
+    assert payload["destination"] == str(destination.resolve())
+    assert payload["moved"]
+    assert payload["skipped"] == []
+
+
+def test_init_respects_memory_path(tmp_path: Path, monkeypatch, capsys):
+    memory_root = tmp_path / "custom-memory"
+    monkeypatch.setenv("MEMORY_PATH", str(memory_root))
+
+    exit_code = cli.main(["init", "--verbose"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert f"Memory initialised at {memory_root.resolve()}" in captured.out
+    for required in ("RAW", "LOGS", "PDF", "JSON"):
+        assert (memory_root / required).exists()
+
+
+class _FakeRecord:
+    def __init__(
+        self,
+        *,
+        task_id: str,
+        status: Any,
+        assigned_agent: Optional[Any],
+    ) -> None:
+        self.task_id = task_id
+        self.status = status
+        self.assigned_agent = assigned_agent
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "status": self.status.value,
+            "assigned_agent": getattr(self.assigned_agent, "value", None),
+        }
+
+
+class _FakeScheduler:
+    def __init__(self, records: Iterable[_FakeRecord]) -> None:
+        self._records = list(records)
+
+    def list_tasks(self) -> List[_FakeRecord]:
+        return list(self._records)
+
+    def health_provider(self) -> Any:
+        class Snapshot:
+            timestamp = 123.0
+            cpu_percent = 42.0
+            memory_available = 512
+            memory_total = 1024
+            battery_percent = None
+            notes = "psutil not available"
+
+        return Snapshot()
+
+
+def test_agent_status_json(monkeypatch, capsys):
+    from monkey_head.core.task_scheduler import Agent, TaskStatus
+
+    records = [
+        _FakeRecord(task_id="1", status=TaskStatus.RUNNING, assigned_agent=Agent.SPARK),
+        _FakeRecord(task_id="2", status=TaskStatus.PENDING, assigned_agent=None),
+    ]
+    fake_scheduler = _FakeScheduler(records)
+
+    import huey.api as huey_api
+
+    monkeypatch.setattr(huey_api, "SCHEDULER", fake_scheduler)
+
+    exit_code = cli.main(["agent-status", "--json", "--verbose"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["total_tasks"] == 2
+    assert payload["tasks_by_status"]["running"] == 1
+    assert payload["tasks_by_agent"]["spark"] == 1
+    assert payload["resource_snapshot"]["cpu_percent"] == 42.0
+    assert payload["tasks"]


### PR DESCRIPTION
## Summary
- add a new `huey` command-line interface with init, run, system-check, deploy, agent-status, and memory-sort subcommands
- register the CLI entry point, cover behaviour with focused unit tests, and document usage in the README and docs index

## Testing
- pytest -q *(fails: missing optional test dependencies such as httpx and pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b0217354832b9417c3874a8a00d0