### PR TITLE
Add pygpt integration shims and CLI entry point

### DIFF
--- a/monkey_head/core/__init__.py
+++ b/monkey_head/core/__init__.py
@@ -2,6 +2,19 @@
 
 from __future__ import annotations
 
-from . import messaging, system_checks, task_scheduler
+from importlib import import_module
+from typing import Any
 
 __all__ = ["messaging", "system_checks", "task_scheduler"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin import proxy
+    if name in __all__:
+        module = import_module(f"monkey_head.core.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - convenience helper
+    return sorted(set(__all__) | set(globals()))

--- a/monkey_head/pygpt_custom_cli.py
+++ b/monkey_head/pygpt_custom_cli.py
@@ -1,0 +1,78 @@
+"""Lightweight CLI integration mimicking the legacy PyGPT launcher."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from .pygpt_memory import Memory
+
+
+class CustomPyGPT:
+    """A minimal chatbot used when full PyGPT dependencies are unavailable."""
+
+    def __init__(self, prompt_file: str | Path | None = None):
+        if prompt_file is None:
+            prompt_file = (
+                Path(__file__).resolve().parent.parent
+                / "huey"
+                / "memory"
+                / "PY"
+                / "prompts"
+                / "huey_main_prompt.txt"
+            )
+        self.prompt_file = Path(prompt_file)
+        self.memory = Memory()
+        self.main_prompt = self.load_main_prompt()
+
+    def load_main_prompt(self) -> str:
+        """Load the default main prompt from ``self.prompt_file`` if it exists."""
+
+        try:
+            return self.prompt_file.read_text(encoding="utf-8").strip()
+        except FileNotFoundError:
+            return ""
+
+    def generate_reply(self, message: str) -> str:
+        """Generate a trivial echo-style reply."""
+
+        return f"Echo: {message}"
+
+    def _handle_list_pdfs(self) -> Iterable[str]:
+        """Return available PDF names by deferring to :mod:`monkey_head.pdf_utils`."""
+
+        from .pdf_utils import list_available_pdfs
+
+        yield from list_available_pdfs()
+
+    def run_cli(self) -> None:
+        """Run an interactive CLI loop suitable for simple testing."""
+
+        print("Custom PyGPT CLI. Type 'exit' to quit.")
+        user_prompt = input(
+            "Enter main prompt or press Enter to use default:\n"
+            f"{self.main_prompt}\n> "
+        ).strip()
+        if user_prompt:
+            self.main_prompt = user_prompt
+        print("Chat starting...")
+        while True:
+            try:
+                user_input = input("You: ")
+            except EOFError:  # pragma: no cover - interactive convenience
+                break
+            command = user_input.strip().lower()
+            if command == "list pdfs":
+                print("Available PDFs:")
+                for name in self._handle_list_pdfs():
+                    print(f"- {name}")
+                continue
+            if command in {"exit", "quit"}:
+                break
+            self.memory.add_user_message(user_input)
+            reply = self.generate_reply(user_input)
+            self.memory.add_assistant_message(reply)
+            print(f"Bot: {reply}")
+
+
+__all__ = ["CustomPyGPT"]

--- a/monkey_head/pygpt_memory.py
+++ b/monkey_head/pygpt_memory.py
@@ -1,0 +1,30 @@
+"""Simplified conversation memory helpers for Monkey Head's PyGPT integration."""
+
+from __future__ import annotations
+
+
+class Memory:
+    """A minimal conversation buffer compatible with the legacy PyGPT tooling."""
+
+    def __init__(self) -> None:
+        self._messages: list[dict[str, str]] = []
+
+    def add_user_message(self, content: str) -> None:
+        """Store a user-authored message in the conversation history."""
+
+        self._messages.append({"role": "user", "content": content})
+
+    def add_assistant_message(self, content: str) -> None:
+        """Store an assistant-authored message in the conversation history."""
+
+        self._messages.append({"role": "assistant", "content": content})
+
+    def get_messages(self) -> list[dict[str, str]]:
+        """Return a shallow copy of the stored conversation history."""
+
+        return list(self._messages)
+
+    def clear(self) -> None:
+        """Remove all stored conversation history."""
+
+        self._messages.clear()

--- a/monkey_head/pygpt_net/__init__.py
+++ b/monkey_head/pygpt_net/__init__.py
@@ -1,0 +1,44 @@
+"""Lightweight shim providing access to mirrored PyGPT components."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+import sys
+
+__all__ = ["__getattr__", "__dir__"]
+
+_PYGPT_PACKAGE: ModuleType | None = None
+
+
+def _prepare_sys_path() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    candidates = [
+        project_root / "pygpt" / "src",
+        project_root / "pygpt",
+        project_root / "repo" / "pygpt-MHP" / "src",
+    ]
+    for path in candidates:
+        if path.exists():
+            resolved = str(path.resolve())
+            if resolved not in sys.path:
+                sys.path.insert(0, resolved)
+
+
+def _load_package() -> ModuleType:
+    global _PYGPT_PACKAGE
+    if _PYGPT_PACKAGE is None:
+        _prepare_sys_path()
+        _PYGPT_PACKAGE = import_module("pygpt_net")
+    return _PYGPT_PACKAGE
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_load_package(), name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - convenience helper
+    package = _load_package()
+    return sorted(set(globals()) | set(dir(package)))

--- a/monkey_head/pygpt_net/controller/__init__.py
+++ b/monkey_head/pygpt_net/controller/__init__.py
@@ -1,0 +1,3 @@
+"""Controller shims for mirrored PyGPT configuration modules."""
+
+__all__ = []

--- a/monkey_head/pygpt_net/controller/config/__init__.py
+++ b/monkey_head/pygpt_net/controller/config/__init__.py
@@ -1,0 +1,3 @@
+"""Configuration helpers for the mirrored PyGPT controller."""
+
+__all__ = ["placeholder"]

--- a/monkey_head/pygpt_net/controller/config/placeholder.py
+++ b/monkey_head/pygpt_net/controller/config/placeholder.py
@@ -1,0 +1,37 @@
+"""Placeholder utilities mirrored from the PyGPT configuration tree."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+
+class Placeholder:
+    """Provide minimal preset discovery compatible with PyGPT widgets."""
+
+    def __init__(self, window: Any) -> None:
+        self.window = window
+
+    def _iter_presets(self) -> Iterable[tuple[str, Any]]:
+        core = getattr(self.window, "core", None)
+        presets = getattr(core, "presets", None)
+        if presets is None:
+            return []
+        try:
+            items = presets.get_all()
+        except Exception:  # pragma: no cover - defensive fallback
+            return []
+        if isinstance(items, dict):
+            return items.items()
+        return []
+
+    def get_presets(self) -> List[Dict[str, str]]:
+        """Return presets formatted for selector widgets."""
+
+        results: List[Dict[str, str]] = [{"_": "---"}]
+        for filename, preset in self._iter_presets():
+            name = getattr(preset, "name", str(filename))
+            results.append({str(filename): str(name)})
+        return results
+
+
+__all__ = ["Placeholder"]

--- a/monkey_head/pygpt_net/tools/__init__.py
+++ b/monkey_head/pygpt_net/tools/__init__.py
@@ -1,0 +1,7 @@
+"""Tool shims that integrate Monkey Head with the PyGPT stub."""
+
+from __future__ import annotations
+
+from .manager import MonkeyManager
+
+__all__ = ["MonkeyManager"]

--- a/monkey_head/pygpt_net/tools/manager.py
+++ b/monkey_head/pygpt_net/tools/manager.py
@@ -1,0 +1,21 @@
+"""Minimal Monkey Head manager tool for the PyGPT stub environment."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+class MonkeyManager:
+    """Expose Monkey Head automation hooks inside the PyGPT GUI."""
+
+    def __init__(self) -> None:
+        self.id = "monkey_manager"
+        self.window = None
+
+    def setup_menu(self) -> Dict[str, object]:  # pragma: no cover - simple mapping
+        """Return a dictionary describing actions; currently empty."""
+
+        return {}
+
+
+__all__ = ["MonkeyManager"]

--- a/monkey_head/run.py
+++ b/monkey_head/run.py
@@ -1,0 +1,279 @@
+"""Runtime entry points integrating the PyGPT stack with Monkey Head."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+
+def minimal_run() -> None:
+    """Run the lightweight CLI without importing heavy GUI dependencies."""
+
+    os.environ["MONKEY_HEAD_LIGHT_IMPORTS"] = "1"
+    from .pygpt_custom_cli import CustomPyGPT
+
+    CustomPyGPT().run_cli()
+
+
+def run_sys_code(cmd: str) -> None:
+    """Execute ``cmd`` in a subprocess and stream stdout/stderr."""
+
+    result = subprocess.run(
+        cmd,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.stdout:
+        print(result.stdout.decode(), end="")
+    if result.stderr:
+        print(result.stderr.decode(), end="", file=sys.stderr)
+    if result.returncode != 0:
+        raise RuntimeError(f"Command failed with exit code {result.returncode}")
+
+
+def run_module(target: str) -> None:
+    """Import ``module[:func]`` and call the resulting callable."""
+
+    module_name, _, func_name = target.partition(":")
+    if not func_name:
+        func_name = "main"
+    module = importlib.import_module(module_name)
+    try:
+        func = getattr(module, func_name)
+    except AttributeError as exc:  # pragma: no cover - invalid func
+        raise ImportError(f"Function {func_name} not found in {module_name}") from exc
+    func()
+
+
+def _candidate_src_paths() -> list[Path]:
+    """Return candidate directories that may contain the PyGPT ``src`` tree."""
+
+    project_root = Path(__file__).resolve().parent.parent
+    return [
+        project_root / "pygpt",
+        project_root / "pygpt" / "src",
+        project_root / "huey" / "memory" / "PY" / "src",
+        project_root / "repo" / "pygpt-MHP" / "src",
+    ]
+
+
+def _load_cli() -> Callable[..., None]:
+    """Import and return the canonical PyGPT CLI runner.
+
+    Falls back to :func:`minimal_run` if the CLI cannot be imported due to
+    missing dependencies.
+    """
+
+    try:
+        from pygpt_net.app import run as cli_run
+    except Exception:  # pragma: no cover - fallback to bundled sources
+        for candidate in _candidate_src_paths():
+            if not candidate.exists():
+                continue
+            resolved = str(candidate.resolve())
+            if resolved not in sys.path:
+                sys.path.insert(0, resolved)
+            try:
+                from pygpt_net.app import run as cli_run
+            except Exception:  # pragma: no cover - keep searching
+                continue
+            else:
+                break
+        else:  # pragma: no cover - nothing worked
+            return minimal_run
+    return cli_run
+
+
+def launch_gui() -> None:
+    """Start the PyGPT GUI with the Monkey Head manager tool enabled."""
+
+    from pygpt_net.app import run as pygpt_run
+    from .pygpt_net.tools.manager import MonkeyManager
+
+    pygpt_run(tools=[MonkeyManager()])
+
+
+def launch_manager_ui() -> None:
+    """Start the Tkinter-based program manager shipped with Monkey Head."""
+
+    from gui.main_ui import MainUI
+
+    try:
+        import tkinter as tk
+    except Exception as exc:  # pragma: no cover - missing tkinter
+        raise RuntimeError("tkinter is not available") from exc
+
+    root = tk.Tk()
+    MainUI(root)
+    root.mainloop()
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point used by the ``run`` wrapper script."""
+
+    parser = argparse.ArgumentParser(description="Launch the Monkey Head Project")
+    parser.add_argument("--cli", action="store_true", help="Run CLI instead of GUI")
+    parser.add_argument(
+        "--minimal",
+        action="store_true",
+        help="Run lightweight CustomPyGPT CLI",
+    )
+    parser.add_argument(
+        "--simple-chat",
+        action="store_true",
+        help="Run simple chat demonstration GUI",
+    )
+    parser.add_argument(
+        "--module",
+        type=str,
+        help="Run specified module optionally with :func",
+    )
+    parser.add_argument(
+        "--version", action="store_true", help="Print pygpt_net version and exit"
+    )
+    parser.add_argument(
+        "--list-pdfs", action="store_true", help="List PDF files available to the app"
+    )
+    parser.add_argument(
+        "--system-check",
+        action="store_true",
+        help="Run environment checks and exit",
+    )
+    parser.add_argument(
+        "--docker-compose",
+        action="store_true",
+        help="Build image and start Docker Compose stack",
+    )
+    parser.add_argument(
+        "--kubernetes",
+        action="store_true",
+        help="Deploy resources using manifests in k8s/",
+    )
+    parser.add_argument(
+        "--manager-ui",
+        action="store_true",
+        help="Launch the Tkinter program manager",
+    )
+    parser.add_argument(
+        "--sys-code",
+        type=str,
+        metavar="CMD",
+        help="Execute system command and exit",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        help="Path to CONFIG.txt for logging",
+    )
+    parser.add_argument(
+        "--workdir",
+        type=str,
+        help="Set the working directory (default: project directory)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.config:
+        os.environ["MONKEY_HEAD_CONFIG"] = os.path.abspath(args.config)
+
+    if args.workdir:
+        os.environ["PYGPT_WORKDIR"] = os.path.abspath(args.workdir)
+    elif "PYGPT_WORKDIR" not in os.environ:
+        os.environ["PYGPT_WORKDIR"] = str(Path(__file__).resolve().parent.parent)
+
+    if args.module:
+        run_module(args.module)
+        return
+
+    if args.minimal:
+        minimal_run()
+        return
+
+    if args.sys_code:
+        run_sys_code(args.sys_code)
+        return
+
+    if args.list_pdfs:
+        from .pdf_utils import list_available_pdfs
+
+        for path in list_available_pdfs():
+            print(path)
+        return
+
+    if args.system_check:
+        from .system_checks import system_check
+
+        system_check()
+        return
+
+    if args.docker_compose:
+        try:
+            from .services import container_management
+        except ImportError:  # pragma: no cover - fallback to legacy package
+            from huey.memory.PY import container_management  # type: ignore
+
+        container_management.manage_containers()
+        return
+
+    if args.kubernetes:
+        try:
+            from .services import container_management
+        except ImportError:  # pragma: no cover - fallback to legacy package
+            from huey.memory.PY import container_management  # type: ignore
+
+        container_management.deploy_kubernetes()
+        return
+
+    if args.manager_ui:
+        launch_manager_ui()
+        return
+
+    cli_run = _load_cli()
+
+    from .system_checks import check_os_support, check_python_version
+
+    check_os_support()
+    check_python_version()
+
+    if args.version:
+        try:
+            from pygpt_net import __version__
+        except Exception:  # pragma: no cover - pygpt missing
+            __version__ = "unknown"
+        print(f"pygpt_net version: {__version__}")
+        return
+
+    if args.cli:
+        cli_run()
+        return
+
+    if args.simple_chat:
+        try:
+            from .legacy.simple_chat import main as simple_chat_main
+        except ImportError as exc:  # pragma: no cover - optional legacy feature
+            raise RuntimeError("Simple chat UI is not available") from exc
+
+        simple_chat_main()
+        return
+
+    try:
+        launch_gui()
+    except Exception as exc:  # pragma: no cover - fallback to CLI
+        print(f"GUI failed to launch: {exc}\nFalling back to CLI mode.")
+        cli_run()
+
+
+__all__ = [
+    "_load_cli",
+    "launch_gui",
+    "launch_manager_ui",
+    "main",
+    "minimal_run",
+    "run_module",
+    "run_sys_code",
+]

--- a/monkey_head/services/__init__.py
+++ b/monkey_head/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer utilities for Monkey Head."""
+
+from __future__ import annotations
+
+__all__ = ["container_management"]

--- a/monkey_head/services/container_management.py
+++ b/monkey_head/services/container_management.py
@@ -1,0 +1,178 @@
+"""Utility helpers for orchestrating external container and cluster tooling."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_K8S_MANIFEST = Path("k8s") / "deployment.yaml"
+
+
+def _project_root() -> Path:
+    env = os.getenv("MONKEY_HEAD_WORKDIR")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parents[2]
+
+
+def _run_command(command: Iterable[str], description: str, cwd: Path | None = None) -> subprocess.CompletedProcess[bytes]:
+    command = list(command)
+    LOGGER.info("%s", description)
+    if cwd is None:
+        cwd = _project_root()
+    executable = command[0]
+    if shutil.which(executable) is None:
+        LOGGER.warning("Skipping '%s' because the executable is not available.", " ".join(command))
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+    result = subprocess.run(
+        command,
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        LOGGER.error(
+            "Command '%s' failed with exit code %s", " ".join(command), result.returncode
+        )
+    else:
+        LOGGER.debug("Command '%s' completed successfully", " ".join(command))
+    return result
+
+
+def build_docker_image(tag: str = "monkey-head-project:latest") -> None:
+    """Build the project's Docker image if Docker is available."""
+
+    _run_command(["docker", "build", "-t", tag, "."], "Building Docker image")
+
+
+def manage_containers() -> None:
+    """Start the docker-compose stack for the project."""
+
+    workdir = _project_root()
+    _run_command(
+        ["docker-compose", "up", "-d"], "Starting Docker containers", cwd=workdir
+    )
+    _run_command(["docker", "ps"], "Listing running containers", cwd=workdir)
+
+
+def stop_containers() -> None:
+    """Stop the docker-compose stack for the project."""
+
+    workdir = _project_root()
+    _run_command(["docker-compose", "down"], "Stopping Docker containers", cwd=workdir)
+
+
+def cleanup_images() -> None:
+    """Remove dangling Docker images to free space."""
+
+    _run_command(["docker", "image", "prune", "-f"], "Pruning Docker images")
+
+
+def manage_volumes() -> None:
+    """List and prune Docker volumes."""
+
+    _run_command(["docker", "volume", "ls"], "Listing Docker volumes")
+    _run_command(["docker", "volume", "prune", "-f"], "Pruning Docker volumes")
+
+
+def manage_networks() -> None:
+    """List and prune Docker networks."""
+
+    _run_command(["docker", "network", "ls"], "Listing Docker networks")
+    _run_command(["docker", "network", "prune", "-f"], "Pruning Docker networks")
+
+
+def _manifest_path(manifest: str | Path | None = None) -> Path:
+    if manifest is None:
+        manifest = DEFAULT_K8S_MANIFEST
+    manifest_path = Path(manifest)
+    if not manifest_path.is_absolute():
+        manifest_path = _project_root() / manifest_path
+    return manifest_path
+
+
+def deploy_kubernetes(manifest: str | Path | None = None) -> None:
+    """Apply the Kubernetes manifests to the current cluster."""
+
+    manifest_path = _manifest_path(manifest)
+    _run_command(
+        ["kubectl", "apply", "-f", str(manifest_path)],
+        f"Deploying Kubernetes resources from {manifest_path}",
+    )
+    _run_command(["kubectl", "get", "pods"], "Fetching Kubernetes pods")
+
+
+def cleanup_kubernetes(manifest: str | Path | None = None) -> None:
+    """Delete resources defined by the Kubernetes manifest."""
+
+    manifest_path = _manifest_path(manifest)
+    _run_command(
+        ["kubectl", "delete", "-f", str(manifest_path)],
+        f"Cleaning up Kubernetes resources from {manifest_path}",
+    )
+
+
+def scale_deployment(name: str, replicas: int) -> None:
+    """Scale a deployment to the given number of replicas."""
+
+    _run_command(
+        ["kubectl", "scale", "deployment", name, f"--replicas={replicas}"],
+        f"Scaling deployment {name} to {replicas} replicas",
+    )
+
+
+def kubernetes_management() -> None:
+    """Inspect cluster resources such as nodes and services."""
+
+    _run_command(["kubectl", "get", "nodes"], "Listing Kubernetes nodes")
+    _run_command(["kubectl", "get", "services"], "Listing Kubernetes services")
+
+
+def list_containers() -> str:
+    """Return the output of ``docker ps`` if Docker is available."""
+
+    result = _run_command(["docker", "ps"], "Listing Docker containers")
+    return (result.stdout or b"").decode()
+
+
+def get_container_logs(container_name: str) -> str:
+    """Return logs for the specified Docker container."""
+
+    result = _run_command(
+        ["docker", "logs", container_name],
+        f"Fetching logs for container {container_name}",
+    )
+    return (result.stdout or b"").decode()
+
+
+def get_pod_logs(pod_name: str) -> str:
+    """Return logs for the specified Kubernetes pod."""
+
+    result = _run_command(
+        ["kubectl", "logs", pod_name],
+        f"Fetching logs for pod {pod_name}",
+    )
+    return (result.stdout or b"").decode()
+
+
+__all__ = [
+    "build_docker_image",
+    "cleanup_images",
+    "cleanup_kubernetes",
+    "deploy_kubernetes",
+    "get_container_logs",
+    "get_pod_logs",
+    "kubernetes_management",
+    "list_containers",
+    "manage_containers",
+    "manage_networks",
+    "manage_volumes",
+    "scale_deployment",
+    "stop_containers",
+]

--- a/pygpt_net/__init__.py
+++ b/pygpt_net/__init__.py
@@ -1,0 +1,7 @@
+"""Minimal stub of the :mod:`pygpt_net` package for integration tests."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.0.0-dev"

--- a/pygpt_net/app.py
+++ b/pygpt_net/app.py
@@ -1,0 +1,14 @@
+"""Stub application runner compatible with Monkey Head integration tests."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def run(*, tools: Iterable[object] | None = None) -> None:
+    """Simulate launching the PyGPT GUI with the provided tools."""
+
+    for tool in tools or ():
+        setup = getattr(tool, "setup_menu", None)
+        if callable(setup):
+            setup()

--- a/pygpt_net/item/__init__.py
+++ b/pygpt_net/item/__init__.py
@@ -1,0 +1,7 @@
+"""Expose simple data structures used by Monkey Head tests."""
+
+from __future__ import annotations
+
+from .preset import PresetItem
+
+__all__ = ["PresetItem"]

--- a/pygpt_net/item/preset.py
+++ b/pygpt_net/item/preset.py
@@ -1,0 +1,15 @@
+"""Simplified preset data model used for testing integrations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class PresetItem:
+    """Minimal representation of a PyGPT preset definition."""
+
+    name: str = ""
+    filename: str = ""
+    config: Dict[str, Any] = field(default_factory=dict)

--- a/run.py
+++ b/run.py
@@ -8,13 +8,14 @@ from typing import Any, Callable
 _module = import_module("monkey_head.run")
 
 __all__ = getattr(_module, "__all__", [name for name in dir(_module) if not name.startswith("_")])
-for _name in ("main", "launch_gui", "launch_manager_ui", "_load_cli"):
+for _name in ("main", "launch_gui", "launch_manager_ui", "_load_cli", "minimal_run"):
     if _name not in __all__:
         __all__.append(_name)
 
 _launch_manager_ui_impl: Callable[..., Any] = getattr(_module, "launch_manager_ui")
 _launch_gui_impl: Callable[..., Any] = getattr(_module, "launch_gui")
 _load_cli_impl: Callable[..., Any] = getattr(_module, "_load_cli")
+_minimal_run_impl: Callable[..., Any] = getattr(_module, "minimal_run")
 
 
 def __getattr__(name: str) -> Any:  # pragma: no cover - proxy
@@ -36,7 +37,16 @@ def launch_gui(*args: Any, **kwargs: Any) -> Any:
 def _load_cli(*args: Any, **kwargs: Any) -> Any:
     """Proxy to the real ``_load_cli`` implementation."""
 
-    return _load_cli_impl(*args, **kwargs)
+    loader = _load_cli_impl(*args, **kwargs)
+    if loader is _minimal_run_impl:
+        return minimal_run
+    return loader
+
+
+def minimal_run(*args: Any, **kwargs: Any) -> Any:
+    """Proxy to the lightweight CLI launcher."""
+
+    return _minimal_run_impl(*args, **kwargs)
 
 
 def main(*args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
(https://github.com/szczyglis-dev/py-gpt)

## Summary
- add lightweight PyGPT memory and CLI helpers to the `monkey_head` package
- introduce shim packages for `monkey_head.pygpt_net` and a minimal `pygpt_net` stub used by the entrypoints
- extend the run wrappers and new service layer to expose container and Kubernetes utilities without heavy dependencies

## Testing
- pytest tests/test_memory.py tests/test_custom_pygpt_cli.py tests/test_run_minimal.py tests/test_run_container_opts.py tests/test_placeholder.py tests/test_load_cli.py


------
https://chatgpt.com/codex/tasks/task_e_68e5ad06e14c832b9131eee577ed3da7