### PR TITLE
Provide monkey_head compatibility layer and helper modules

### DIFF
--- a/config/CONFIG.txt
+++ b/config/CONFIG.txt
@@ -1,0 +1,5 @@
+[logging]
+log_level = INFO
+log_file = LOGS/monkey_head.log
+log_max_bytes = 10485760
+log_backup_count = 5

--- a/src/monkey_head/__init__.py
+++ b/src/monkey_head/__init__.py
@@ -1,0 +1,60 @@
+"""Compatibility package mapping the legacy :mod:`monkey_head` namespace."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+from typing import Iterable, Set
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent
+_PROJECT_ROOT = _PACKAGE_ROOT.parents[1]
+_HUEY_ROOT = _PROJECT_ROOT / "huey"
+_LEGACY_ROOT = _HUEY_ROOT / "memory" / "PY"
+
+__path__ = [str(_PACKAGE_ROOT)]
+if _HUEY_ROOT.exists():
+    __path__.append(str(_HUEY_ROOT))
+if _LEGACY_ROOT.exists():
+    __path__.append(str(_LEGACY_ROOT))
+
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+def _discover_exports(paths: Iterable[str]) -> Set[str]:
+    names: Set[str] = set()
+    for entry in paths:
+        base = Path(entry)
+        if not base.exists():
+            continue
+        for item in base.iterdir():
+            if item.name.startswith("_"):
+                continue
+            if item.is_dir() and (item / "__init__.py").exists():
+                names.add(item.name)
+            elif item.suffix == ".py":
+                names.add(item.stem)
+    return names
+
+
+__all__ = sorted(_discover_exports(__path__))
+
+
+def __getattr__(name: str):  # pragma: no cover - thin import wrapper
+    for target in (
+        f"monkey_head.{name}",
+        f"huey.{name}",
+        f"huey.memory.PY.{name}",
+    ):
+        try:
+            module = import_module(target)
+        except ModuleNotFoundError:
+            continue
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:  # pragma: no cover - convenience helper
+    return sorted(set(__all__) | set(globals()))

--- a/src/monkey_head/scripts/__init__.py
+++ b/src/monkey_head/scripts/__init__.py
@@ -1,0 +1,18 @@
+"""Compatibility helpers for legacy management scripts."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import List
+
+_base = import_module("huey.scripts")
+
+__all__ = list(getattr(_base, "__all__", ()))
+for name in __all__:
+    globals()[name] = getattr(_base, name)
+
+__path__: List[str] = [str(Path(__file__).resolve().parent)]
+for candidate in getattr(_base, "__path__", []):
+    if candidate not in __path__:
+        __path__.append(candidate)

--- a/src/monkey_head/scripts/preload_data.py
+++ b/src/monkey_head/scripts/preload_data.py
@@ -1,0 +1,34 @@
+"""Utility helpers for preloading reference data used by the tests."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+__all__ = ["preload_all"]
+
+
+def _default_prompts() -> List[str]:
+    """Return a small collection of canned prompts."""
+
+    return [
+        "Summarise the latest telemetry report.",
+        "Draft a follow-up email to the operator.",
+    ]
+
+
+def _default_memory_snapshot() -> Dict[str, List[str]]:
+    """Return a lightweight snapshot of the shared memory structure."""
+
+    return {
+        "PDF": ["systems-overview.pdf", "emergency-playbook.pdf"],
+        "RAW": ["diagnostics.log"],
+    }
+
+
+def preload_all() -> Dict[str, object]:
+    """Return prompt and memory metadata required by the UI layer."""
+
+    return {
+        "prompts": _default_prompts(),
+        "memory": _default_memory_snapshot(),
+    }

--- a/src/monkey_head/services/__init__.py
+++ b/src/monkey_head/services/__init__.py
@@ -1,0 +1,27 @@
+"""Compatibility layer for service management helpers."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import List
+
+_base = import_module("huey.services")
+
+__all__ = list(getattr(_base, "__all__", ()))
+
+for name in list(__all__):
+    globals()[name] = import_module(f"huey.services.{name}")
+
+# Expose the compatibility modules implemented in this package as part of the
+# public API so that ``from monkey_head.services import environment_setup`` works
+# as it did historically.
+__all__.extend(["environment_setup", "home_assistant"])
+
+environment_setup = import_module("monkey_head.services.environment_setup")
+home_assistant = import_module("monkey_head.services.home_assistant")
+
+__path__: List[str] = [str(Path(__file__).resolve().parent)]
+for candidate in getattr(_base, "__path__", []):
+    if candidate not in __path__:
+        __path__.append(candidate)

--- a/src/monkey_head/services/environment_setup.py
+++ b/src/monkey_head/services/environment_setup.py
@@ -1,0 +1,92 @@
+"""Minimal project environment management helpers used in tests."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from typing import Sequence
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REPO_URL = "https://github.com/DylanLRPollock/Monkey-Head-Project.git"
+
+
+def run_command(command: Sequence[str], *, cwd: str | None = None, check: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run ``command`` via :func:`subprocess.run` and return the completed process."""
+
+    return subprocess.run(command, cwd=cwd, check=check, text=True)
+
+
+def _expand(path: str) -> str:
+    return os.path.expanduser(path)
+
+
+def clone_repository(repo_url: str = DEFAULT_REPO_URL, dest: str = "~/Source/repo") -> None:
+    """Clone ``repo_url`` into ``dest`` creating parent directories as required."""
+
+    dest_path = _expand(dest)
+    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+    try:
+        run_command(["git", "clone", repo_url, dest_path], check=True)
+    except Exception as exc:  # pragma: no cover - error path exercised in tests
+        git_dir = os.path.join(dest_path, ".git")
+        if os.path.isdir(git_dir):
+            logger.warning("Clone failed (%s). Using existing repository at %s", exc, dest_path)
+        else:
+            raise
+
+
+def setup_python_env(dest: str = "~/Source/repo") -> None:
+    """Create a virtual environment inside ``dest`` and install requirements."""
+
+    dest_path = _expand(dest)
+    venv_path = os.path.join(dest_path, "venv")
+    if not os.path.isdir(venv_path):
+        run_command(["python3", "-m", "venv", venv_path], check=True)
+
+    pip_exe = os.path.join(venv_path, "bin", "pip")
+    run_command([pip_exe, "install", "--upgrade", "pip"], cwd=dest_path, check=True)
+    run_command([pip_exe, "install", "-r", "requirements.txt"], cwd=dest_path, check=True)
+
+
+def configure_git(name: str = "Your Name", email: str = "your.email@example.com") -> None:
+    """Set the global git username and email values."""
+
+    run_command(["git", "config", "--global", "user.name", name], check=True)
+    run_command(["git", "config", "--global", "user.email", email], check=True)
+
+
+def checkout_branch(branch: str, dest: str = "~/Source/repo") -> None:
+    """Fetch the latest refs and checkout ``branch`` in ``dest``."""
+
+    dest_path = _expand(dest)
+    run_command(["git", "fetch"], cwd=dest_path)
+    run_command(["git", "checkout", branch], cwd=dest_path)
+
+
+def pull_latest(dest: str = "~/Source/repo") -> None:
+    """Pull the latest commits using ``--ff-only`` to avoid merge commits."""
+
+    dest_path = _expand(dest)
+    run_command(["git", "pull", "--ff-only"], cwd=dest_path)
+
+
+def commit_and_push(message: str, dest: str = "~/Source/repo", remote: str = "origin", branch: str = "main") -> None:
+    """Commit staged changes with ``message`` and push to ``remote`` ``branch``."""
+
+    dest_path = _expand(dest)
+    run_command(["git", "add", "."], cwd=dest_path)
+    run_command(["git", "commit", "-m", message], cwd=dest_path)
+    run_command(["git", "push", remote, branch], cwd=dest_path)
+
+
+__all__ = [
+    "clone_repository",
+    "setup_python_env",
+    "configure_git",
+    "checkout_branch",
+    "pull_latest",
+    "commit_and_push",
+    "run_command",
+]

--- a/src/monkey_head/services/home_assistant.py
+++ b/src/monkey_head/services/home_assistant.py
@@ -1,0 +1,56 @@
+"""Minimal Home Assistant API helpers used by the test-suite."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    import requests  # type: ignore[assignment]
+except Exception:  # pragma: no cover - import guard
+    requests = None  # type: ignore[assignment]
+
+__all__ = ["call_service", "get_state"]
+
+
+def _build_headers(token: str | None) -> Dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _require_requests() -> None:
+    if requests is None:
+        raise RuntimeError("The 'requests' package is required for Home Assistant integrations")
+
+
+def call_service(
+    domain: str,
+    service: str,
+    payload: Dict[str, Any] | None = None,
+    *,
+    base_url: str = "http://localhost:8123",
+    token: str | None = None,
+) -> Dict[str, Any]:
+    """Invoke a Home Assistant service and return the JSON payload."""
+
+    _require_requests()
+    url = f"{base_url.rstrip('/')}/api/services/{domain}/{service}"
+    response = requests.post(url, json=payload or {}, headers=_build_headers(token), timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def get_state(
+    entity_id: str,
+    *,
+    base_url: str = "http://localhost:8123",
+    token: str | None = None,
+) -> Dict[str, Any]:
+    """Return the state dictionary for ``entity_id``."""
+
+    _require_requests()
+    url = f"{base_url.rstrip('/')}/api/states/{entity_id}"
+    response = requests.get(url, headers=_build_headers(token), timeout=10)
+    response.raise_for_status()
+    return response.json()

--- a/src/monkey_head/utils/__init__.py
+++ b/src/monkey_head/utils/__init__.py
@@ -1,0 +1,30 @@
+"""Expose utility helpers while bridging legacy Monkey Head modules."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from typing import List
+
+_base = import_module("huey.utils")
+
+# Re-export the public API from the maintained implementation.
+auto_sort_memory = getattr(_base, "auto_sort_memory")
+ensure_subdirectory = getattr(_base, "ensure_subdirectory")
+get_logs_dir = getattr(_base, "get_logs_dir")
+get_memory_path = getattr(_base, "get_memory_path")
+
+__all__ = list(getattr(_base, "__all__", ()))
+
+# Extend the package search path so that imports such as
+# ``monkey_head.utils.sorting`` resolve to the legacy compatibility modules that
+# still live inside ``huey/memory/PY``.
+__path__: List[str] = [str(Path(__file__).resolve().parent)]
+for candidate in getattr(_base, "__path__", []):
+    if candidate not in __path__:
+        __path__.append(candidate)
+_legacy = Path(__file__).resolve().parents[3] / "huey" / "memory" / "PY"
+if _legacy.exists():
+    legacy_path = str(_legacy)
+    if legacy_path not in __path__:
+        __path__.append(legacy_path)


### PR DESCRIPTION
## Summary
- add a compatibility shim for the legacy `monkey_head` namespace that resolves modules from the maintained huey sources
- implement lightweight replacements for the legacy preload data, environment setup, and Home Assistant helpers used by the CLI and API
- include a default logging configuration so logging setup no longer fails when the compatibility layer loads

## Testing
- `PYTHONPATH=src pytest tests/test_task_scheduler.py`
- `PYTHONPATH=src pytest tests/test_preloader.py -q`
- `PYTHONPATH=src pytest tests/test_environment_setup_git.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68e608eed5b8832bb5fe4f445cd15829