### PR TITLE
Add compatibility wrappers for Monkey Head namespace

### DIFF
--- a/src/monkey_head/core/__init__.py
+++ b/src/monkey_head/core/__init__.py
@@ -1,0 +1,11 @@
+"""Core orchestration primitives for the Monkey Head compatibility layer."""
+
+from __future__ import annotations
+
+from . import resilience, system_checks, task_scheduler
+
+__all__ = [
+    "resilience",
+    "system_checks",
+    "task_scheduler",
+]

--- a/src/monkey_head/core/resilience.py
+++ b/src/monkey_head/core/resilience.py
@@ -1,0 +1,31 @@
+"""Compatibility wrapper for :mod:`huey.core.resilience`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.core.resilience")
+
+__all__ = list(getattr(_impl, "__all__", ()))
+if not __all__:
+    __all__ = [
+        "CrashEvent",
+        "CrashRecoveryManager",
+        "EmergencyGovernanceController",
+        "EmergencyState",
+        "HealthCheck",
+        "MonitoredProcess",
+        "RestartCallback",
+        "SystemdWatchdogClient",
+    ]
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/core/system_checks.py
+++ b/src/monkey_head/core/system_checks.py
@@ -1,0 +1,37 @@
+"""Compatibility wrapper for :mod:`huey.system_checks`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.system_checks")
+
+__all__ = list(getattr(_impl, "__all__", ()))
+if not __all__:
+    __all__ = [
+        "check_os_support",
+        "check_python_version",
+        "ensure_admin",
+        "logger",
+        "system_check",
+    ]
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+# Expose supporting modules that callers monkeypatch in tests and CLI utilities.
+platform = getattr(_impl, "platform")
+shutil = getattr(_impl, "shutil")
+sys = getattr(_impl, "sys")
+distro = getattr(_impl, "distro", None)
+
+__all__.extend(["platform", "shutil", "sys", "distro"])
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/core/task_scheduler.py
+++ b/src/monkey_head/core/task_scheduler.py
@@ -1,0 +1,32 @@
+"""Compatibility wrapper for :mod:`huey.core.task_scheduler`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.core.task_scheduler")
+
+__all__ = list(getattr(_impl, "__all__", ()))
+if not __all__:
+    __all__ = [
+        "Agent",
+        "HealthProvider",
+        "ResourceProfile",
+        "ResourceSnapshot",
+        "TaskLogEntry",
+        "TaskPriority",
+        "TaskRecord",
+        "TaskScheduler",
+        "TaskStatus",
+    ]
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/hardware/__init__.py
+++ b/src/monkey_head/hardware/__init__.py
@@ -1,0 +1,36 @@
+"""Compatibility package for hardware integrations."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+from .manager import (
+    ActuatorManager,
+    SensorManager,
+    create_default_actuator_manager,
+    create_default_sensor_manager,
+)
+from .plugins import (
+    ActuatorPlugin,
+    ActuatorRegistry,
+    SensorPlugin,
+    SensorReading,
+    SensorRegistry,
+)
+
+_drivers = import_module("huey.hardware.drivers")
+
+drivers = _drivers
+
+__all__ = [
+    "ActuatorManager",
+    "ActuatorPlugin",
+    "ActuatorRegistry",
+    "SensorManager",
+    "SensorPlugin",
+    "SensorReading",
+    "SensorRegistry",
+    "create_default_actuator_manager",
+    "create_default_sensor_manager",
+    "drivers",
+]

--- a/src/monkey_head/hardware/manager.py
+++ b/src/monkey_head/hardware/manager.py
@@ -1,0 +1,27 @@
+"""Compatibility wrapper for :mod:`huey.hardware.manager`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.hardware.manager")
+
+__all__ = list(getattr(_impl, "__all__", ()))
+if not __all__:
+    __all__ = [
+        "ActuatorManager",
+        "SensorManager",
+        "create_default_actuator_manager",
+        "create_default_sensor_manager",
+    ]
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/hardware/plugins.py
+++ b/src/monkey_head/hardware/plugins.py
@@ -1,0 +1,29 @@
+"""Compatibility wrapper for :mod:`huey.hardware.plugins`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.hardware.plugins")
+
+__all__ = list(getattr(_impl, "__all__", ()))
+if not __all__:
+    __all__ = [
+        "ActuatorPlugin",
+        "ActuatorRegistry",
+        "SensorPlugin",
+        "SensorReading",
+        "SensorRegistry",
+        "load_plugins_from_definitions",
+    ]
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/honeycomb_index.py
+++ b/src/monkey_head/honeycomb_index.py
@@ -1,0 +1,25 @@
+"""Compatibility wrapper for :mod:`huey.honeycomb_index`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.honeycomb_index")
+
+__all__ = list(getattr(_impl, "__all__", ()))
+if not __all__:
+    __all__ = [
+        "HoneycombIndex",
+        "HoneycombIndexRecord",
+    ]
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/honeycomb_monitor.py
+++ b/src/monkey_head/honeycomb_monitor.py
@@ -1,0 +1,24 @@
+"""Compatibility wrapper for :mod:`huey.honeycomb_monitor`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.honeycomb_monitor")
+
+__all__ = list(getattr(_impl, "__all__", ()))
+if not __all__:
+    __all__ = [
+        "HoneycombMonitor",
+    ]
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/honeycomb_storage.py
+++ b/src/monkey_head/honeycomb_storage.py
@@ -1,0 +1,22 @@
+"""Compatibility wrapper for :mod:`huey.honeycomb_storage`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.honeycomb_storage")
+
+__all__ = list(getattr(_impl, "__all__", ()))
+if not __all__:
+    __all__ = ["HoneycombRecord", "HoneycombStorage", "SCHEMA_VERSION"]
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/network.py
+++ b/src/monkey_head/network.py
@@ -1,0 +1,27 @@
+"""Network management helpers bridging to :mod:`huey.network.manager`."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_impl = import_module("huey.network.manager")
+
+__all__ = list(getattr(_impl, "__all__", ("NetworkManager", "NetworkStatus")))
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+_manager_module = ModuleType(f"{__name__}.manager")
+for exported in __all__:
+    setattr(_manager_module, exported, globals()[exported])
+_manager_module.__all__ = list(__all__)
+_manager_module.__doc__ = _impl.__doc__
+sys.modules[f"{__name__}.manager"] = _manager_module

--- a/src/monkey_head/pdf_utils.py
+++ b/src/monkey_head/pdf_utils.py
@@ -1,0 +1,20 @@
+"""PDF helper functions used by the HueyOS API."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.pdf_utils")
+
+__all__ = ["find_pdf", "list_available_pdfs"]
+
+list_available_pdfs = getattr(_impl, "list_available_pdfs")
+find_pdf = getattr(_impl, "find_pdf")
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/power.py
+++ b/src/monkey_head/power.py
@@ -1,0 +1,27 @@
+"""Power management helpers bridging to :mod:`huey.power.management`."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+_impl = import_module("huey.power.management")
+
+__all__ = list(getattr(_impl, "__all__", ("BatteryMonitor", "PowerEvent")))
+
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+_management_module = ModuleType(f"{__name__}.management")
+for exported in __all__:
+    setattr(_management_module, exported, globals()[exported])
+_management_module.__all__ = list(__all__)
+_management_module.__doc__ = _impl.__doc__
+sys.modules[f"{__name__}.management"] = _management_module

--- a/src/monkey_head/system_checks.py
+++ b/src/monkey_head/system_checks.py
@@ -1,0 +1,8 @@
+"""Public system checks module bridging to :mod:`huey.system_checks`."""
+
+from __future__ import annotations
+
+from .core.system_checks import *  # noqa: F403
+from .core.system_checks import __all__ as _CORE_ALL
+
+__all__ = list(_CORE_ALL)

--- a/src/monkey_head/utils/auto_sort.py
+++ b/src/monkey_head/utils/auto_sort.py
@@ -1,0 +1,20 @@
+"""Compatibility wrapper around :mod:`huey.utils.auto_sort`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.utils.auto_sort")
+
+__all__ = ["auto_sort_memory", "get_extension_map"]
+
+auto_sort_memory = getattr(_impl, "auto_sort_memory")
+get_extension_map = getattr(_impl, "get_extension_map")
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__

--- a/src/monkey_head/utils/paths.py
+++ b/src/monkey_head/utils/paths.py
@@ -1,0 +1,27 @@
+"""Compatibility wrapper around :mod:`huey.utils.paths`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.utils.paths")
+
+__all__ = [
+    "ensure_subdirectory",
+    "get_logs_dir",
+    "get_memory_path",
+    "memory_candidates",
+]
+
+ensure_subdirectory = getattr(_impl, "ensure_subdirectory")
+get_logs_dir = getattr(_impl, "get_logs_dir")
+get_memory_path = getattr(_impl, "get_memory_path")
+memory_candidates = getattr(_impl, "memory_candidates")
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = _impl.__doc__


### PR DESCRIPTION
## Summary
- add compatibility wrappers mapping the monkey_head core namespace to the maintained Huey implementations
- expose hardware, honeycomb, network, power, pdf, and utility shims expected by the API surface

## Testing
- PYTHONPATH=src pytest tests/test_system_checks_module.py tests/test_task_scheduler.py tests/test_honeycomb_storage.py tests/test_honeycomb_management.py tests/test_list_available_pdfs.py tests/test_auto_sort.py


------
https://chatgpt.com/codex/tasks/task_e_68e61358a500832bab231df5d0265698