### PR TITLE
Implement resilience event logging and emergency status dataclasses

### DIFF
--- a/huey/core/resilience.py
+++ b/huey/core/resilience.py
@@ -13,11 +13,25 @@ import os
 import socket
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
 LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "CrashEvent",
+    "MonitoredProcess",
+    "SystemdWatchdogClient",
+    "EmergencyState",
+    "RegisteredService",
+    "EmergencyServiceStatus",
+    "EmergencyGovernanceController",
+    "CrashRecoveryManager",
+    "HealthCheck",
+    "RestartCallback",
+]
 
 HealthCheck = Callable[[], bool]
 RestartCallback = Callable[[], None]
@@ -32,6 +46,17 @@ class CrashEvent:
     restarted: bool
     message: str
     metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the crash event."""
+
+        return {
+            "process": self.process,
+            "timestamp": self.timestamp,
+            "restarted": self.restarted,
+            "message": self.message,
+            "metadata": dict(self.metadata),
+        }
 
 
 @dataclass
@@ -122,6 +147,22 @@ class RegisteredService:
     stop: Callable[[], None]
     start: Optional[Callable[[], None]] = None
     essential: bool = False
+
+
+@dataclass
+class EmergencyServiceStatus:
+    """Serialisable status for a service managed by the controller."""
+
+    name: str
+    essential: bool
+    managed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "essential": self.essential,
+            "managed": self.managed,
+        }
 
 
 class EmergencyGovernanceController:
@@ -244,30 +285,39 @@ class EmergencyGovernanceController:
         """Return a serialisable snapshot of the emergency state."""
 
         with self._lock:
+            services = [
+                EmergencyServiceStatus(
+                    name=service.name,
+                    essential=service.essential,
+                    managed=True,
+                )
+                for service in self._services.values()
+            ]
             return {
                 "state": self.state.value,
                 "active_since": self.active_since,
                 "reason": self.reason,
                 "triggered_by": self.triggered_by,
                 "approvals": list(self.approvals),
-                "services": [
-                    {
-                        "name": service.name,
-                        "essential": service.essential,
-                        "managed": True,
-                    }
-                    for service in self._services.values()
-                ],
+                "services": [service.to_dict() for service in services],
             }
 
 
 class CrashRecoveryManager:
     """Monitor a set of processes and restart them when crashes occur."""
 
-    def __init__(self, watchdog: Optional[SystemdWatchdogClient] = None) -> None:
+    def __init__(
+        self,
+        watchdog: Optional[SystemdWatchdogClient] = None,
+        *,
+        history_limit: int = 100,
+    ) -> None:
+        if history_limit < 1:
+            raise ValueError("history_limit must be at least 1")
         self._watchdog = watchdog or SystemdWatchdogClient()
         self._processes: Dict[str, MonitoredProcess] = {}
         self._lock = threading.RLock()
+        self._event_log: deque[CrashEvent] = deque(maxlen=history_limit)
 
     def register_process(
         self,
@@ -329,6 +379,7 @@ class CrashRecoveryManager:
                     metadata=metadata,
                 )
                 events.append(event)
+                self._event_log.append(event)
                 LOGGER.warning(
                     "Crash detected for process %s (auto_restart=%s, restarted=%s)",
                     process.name,
@@ -343,8 +394,21 @@ class CrashRecoveryManager:
 
         return self._watchdog.ping()
 
-    def set_auto_restart(self, name: str, enabled: bool, *, reason: Optional[str] = None) -> None:
-        """Enable or disable automatic restarts for a monitored process."""
+    def _serialise_process(self, process: MonitoredProcess) -> Dict[str, Any]:
+        return {
+            "name": process.name,
+            "healthy": process.healthy,
+            "auto_restart": process.auto_restart_enabled,
+            "last_heartbeat": process.last_heartbeat,
+            "last_restart": process.last_restart,
+            "restart_attempts": process.restart_attempts,
+            "manual_override_reason": process.manual_override_reason,
+        }
+
+    def toggle_auto_restart(
+        self, name: str, enabled: bool, *, reason: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Enable or disable automatic restarts and return updated status."""
 
         with self._lock:
             process = self._processes.get(name)
@@ -358,6 +422,14 @@ class CrashRecoveryManager:
                 enabled,
                 reason,
             )
+            return self._serialise_process(process)
+
+    def set_auto_restart(
+        self, name: str, enabled: bool, *, reason: Optional[str] = None
+    ) -> None:
+        """Compatibility wrapper for :meth:`toggle_auto_restart`."""
+
+        self.toggle_auto_restart(name, enabled, reason=reason)
 
     def manual_restart(self, name: str) -> None:
         """Force restart a process even when auto-restart is disabled."""
@@ -373,21 +445,16 @@ class CrashRecoveryManager:
         """Return serialisable status information for each process."""
 
         with self._lock:
-            return [
-                {
-                    "name": process.name,
-                    "healthy": process.healthy,
-                    "auto_restart": process.auto_restart_enabled,
-                    "last_heartbeat": process.last_heartbeat,
-                    "last_restart": process.last_restart,
-                    "restart_attempts": process.restart_attempts,
-                    "manual_override_reason": process.manual_override_reason,
-                }
-                for process in self._processes.values()
-            ]
+            return [self._serialise_process(process) for process in self._processes.values()]
 
     def has_process(self, name: str) -> bool:
         """Return ``True`` when a process is registered."""
 
         with self._lock:
             return name in self._processes
+
+    def event_log(self) -> List[CrashEvent]:
+        """Return a copy of the recorded crash events."""
+
+        with self._lock:
+            return list(self._event_log)

--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -1038,10 +1038,12 @@ def override_monitored_process(name: str, request: ManualOverrideRequest) -> Mon
     """Enable or disable automatic crash recovery for the given process."""
 
     try:
-        CRASH_MANAGER.set_auto_restart(name, request.auto_restart, reason=request.reason)
+        status = CRASH_MANAGER.toggle_auto_restart(
+            name, request.auto_restart, reason=request.reason
+        )
     except KeyError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-    return _monitor_status(name)
+    return MonitoredProcessStatusModel(**status)
 
 
 @app.post(

--- a/src/monkey_head/core/resilience.py
+++ b/src/monkey_head/core/resilience.py
@@ -13,6 +13,7 @@ if not __all__:
         "CrashEvent",
         "CrashRecoveryManager",
         "EmergencyGovernanceController",
+        "EmergencyServiceStatus",
         "EmergencyState",
         "HealthCheck",
         "MonitoredProcess",

--- a/tests/test_resilience_core.py
+++ b/tests/test_resilience_core.py
@@ -3,6 +3,7 @@ import pytest
 from monkey_head.core.resilience import (
     CrashRecoveryManager,
     EmergencyGovernanceController,
+    EmergencyServiceStatus,
     EmergencyState,
 )
 
@@ -34,6 +35,10 @@ def test_crash_recovery_manager_restarts_crashed_process():
     assert events[0].restarted is True
     assert state["restart_calls"] == 1
 
+    history = manager.event_log()
+    assert history[-1].process == "spark-loop"
+    assert history[-1].restarted is True
+
     status = manager.statuses()[0]
     assert status["restart_attempts"] == 1
     assert status["auto_restart"] is True
@@ -50,7 +55,9 @@ def test_crash_recovery_manual_override_prevents_restart():
 
     manager = CrashRecoveryManager(watchdog=DummyWatchdog())
     manager.register_process("zap-loop", health_check=health_check, restart=restart)
-    manager.set_auto_restart("zap-loop", False, reason="maintenance window")
+    status = manager.toggle_auto_restart("zap-loop", False, reason="maintenance window")
+    assert status["auto_restart"] is False
+    assert status["manual_override_reason"] == "maintenance window"
 
     events = manager.poll()
     assert events[0].restarted is False
@@ -75,6 +82,12 @@ def test_emergency_governance_controller_requires_quorum():
     controller.enter_emergency_mode(triggered_by="spark", reason="grid", approvals=["zap"])
     assert controller.state is EmergencyState.EMERGENCY
     assert stop_calls == ["stop"]
+
+    snapshot = controller.status()
+    assert snapshot["state"] == "emergency"
+    service_status = EmergencyServiceStatus(**snapshot["services"][0])
+    assert service_status.name == "ollama"
+    assert service_status.managed is True
 
     controller.exit_emergency_mode(requested_by="spark", approvals=["zap"])
     assert controller.state is EmergencyState.NORMAL


### PR DESCRIPTION
## Summary
- record crash events with history tracking and expose a toggle helper for monitored processes
- provide dataclass-backed emergency service status snapshots for API consumers
- extend resilience tests to cover crash event logging, overrides, and emergency status reporting

## Testing
- PYTHONPATH=src pytest tests/test_resilience_core.py

------
https://chatgpt.com/codex/tasks/task_e_68e618f3e4dc832b89ed32efacfa7a74