### PR TITLE
Enhance sensor manager streaming and plugin metadata

### DIFF
--- a/huey/hardware/__init__.py
+++ b/huey/hardware/__init__.py
@@ -12,17 +12,29 @@ from .manager import (
     create_default_actuator_manager,
     create_default_sensor_manager,
 )
-from .plugins import ActuatorPlugin, ActuatorRegistry, SensorPlugin, SensorReading, SensorRegistry
+from .plugins import (
+    ActuatorPlugin,
+    ActuatorRegistry,
+    DummyTemperatureSensor,
+    SensorPlugin,
+    SensorReading,
+    SensorRegistry,
+    list_sensor_plugin_metadata,
+    list_sensor_plugins,
+)
 
 __all__ = [
     "ActuatorManager",
     "ActuatorPlugin",
     "ActuatorRegistry",
+    "DummyTemperatureSensor",
     "SensorManager",
     "create_default_actuator_manager",
     "SensorPlugin",
     "SensorReading",
     "SensorRegistry",
+    "list_sensor_plugin_metadata",
+    "list_sensor_plugins",
     "create_default_sensor_manager",
 ]
 

--- a/huey/hardware/manager.py
+++ b/huey/hardware/manager.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import threading
 import uuid
+from collections.abc import AsyncIterator
 from contextlib import suppress
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
@@ -35,6 +36,7 @@ class SensorManager:
         self.storage = storage or HoneycombStorage()
         self.registry = registry or SensorRegistry()
         self._sensors: Dict[str, SensorPlugin] = {}
+        self._configs: Dict[str, Dict[str, Any]] = {}
         self._lock = threading.RLock()
         self._subscribers: List[Tuple[Optional[str], asyncio.Queue[SensorReading]]] = []
 
@@ -48,6 +50,7 @@ class SensorManager:
             plugin = self.registry.create(plugin_name, name, config)
             plugin.setup()
             self._sensors[name] = plugin
+            self._configs[name] = plugin.config.copy()
         LOGGER.info("Registered sensor %s using plugin %s", name, plugin_name)
         return plugin
 
@@ -65,6 +68,7 @@ class SensorManager:
         with self._lock:
             sensor.setup()
             self._sensors[sensor.name] = sensor
+            self._configs[sensor.name] = sensor.config.copy()
         LOGGER.info("Registered sensor %s using pre-instantiated plugin", sensor.name)
 
     def remove_sensor(self, name: str) -> None:
@@ -72,6 +76,7 @@ class SensorManager:
 
         with self._lock:
             sensor = self._sensors.pop(name, None)
+            self._configs.pop(name, None)
         if sensor:
             with suppress(Exception):
                 sensor.shutdown()
@@ -83,9 +88,15 @@ class SensorManager:
     def list_sensors(self) -> List[Dict[str, Any]]:
         """Return metadata about configured sensors."""
 
+        metadata: List[Dict[str, Any]] = []
         with self._lock:
-            sensors = list(self._sensors.values())
-        return [sensor.provenance | {"name": sensor.name} for sensor in sensors]
+            for sensor in self._sensors.values():
+                config_copy = sensor.config.copy()
+                self._configs[sensor.name] = config_copy
+                metadata.append(
+                    sensor.provenance | {"name": sensor.name, "config": config_copy}
+                )
+        return metadata
 
     def get_sensor(self, name: str) -> Optional[SensorPlugin]:
         with self._lock:
@@ -146,6 +157,21 @@ class SensorManager:
                 queue.put_nowait(reading)
             except asyncio.QueueFull:  # pragma: no cover - best effort delivery
                 LOGGER.debug("Dropping sensor reading for %s due to full queue", reading.name)
+
+    async def stream(self, sensor_name: Optional[str] = None) -> AsyncIterator[SensorReading]:
+        """Yield readings in real-time for ``sensor_name`` or all sensors.
+
+        This helper wraps :meth:`subscribe` to provide an asynchronous iterator
+        that automatically unsubscribes when the consumer stops iterating.
+        """
+
+        queue = self.subscribe(sensor_name)
+        try:
+            while True:
+                reading = await queue.get()
+                yield reading
+        finally:
+            self.unsubscribe(queue)
 
     # ------------------------------------------------------------------
     # Historical queries

--- a/huey/hardware/plugins.py
+++ b/huey/hardware/plugins.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 import threading
 import time
@@ -129,6 +130,41 @@ class SensorRegistry:
         return sorted(self._plugins)
 
     # ------------------------------------------------------------------
+    def describe(self, name: str) -> Dict[str, Any]:
+        """Return metadata describing the plugin registered as ``name``."""
+
+        plugin_cls = self.get(name)
+        description = inspect.cleandoc(plugin_cls.__doc__ or "")
+        config_keys: List[str] = []
+        try:
+            sample = plugin_cls(name="__describe__")
+        except Exception:  # pragma: no cover - plugin misbehaviour
+            LOGGER.debug("Failed to instantiate sensor plugin %s for metadata", name, exc_info=True)
+        else:
+            config_keys = sorted(sample.config.keys())
+            del sample
+        return {
+            "name": name,
+            "module": f"{plugin_cls.__module__}.{plugin_cls.__qualname__}",
+            "description": description,
+            "plugin": getattr(plugin_cls, "plugin_name", name),
+            "config_keys": config_keys,
+        }
+
+    # ------------------------------------------------------------------
+    def describe_all(self) -> List[Dict[str, Any]]:
+        """Return metadata for every registered plugin."""
+
+        self._ensure_entry_points_loaded()
+        metadata = []
+        for name in self.available():
+            try:
+                metadata.append(self.describe(name))
+            except Exception:  # pragma: no cover - defensive logging
+                LOGGER.exception("Failed to describe sensor plugin %s", name)
+        return metadata
+
+    # ------------------------------------------------------------------
     def create(self, plugin_name: str, name: str, config: Optional[Dict[str, Any]] = None) -> SensorPlugin:
         """Instantiate a sensor plugin by symbolic ``plugin_name``."""
 
@@ -209,7 +245,31 @@ def load_plugins_from_definitions(
             registry.register(plugin_cls)
             plugin = plugin_cls(name=instance_name, config=config)
         instances.append(plugin)
-        return instances
+    return instances
+
+
+class DummyTemperatureSensor(SensorPlugin):
+    """Simple example sensor returning a fixed temperature value."""
+
+    plugin_name = "dummy.temperature"
+
+    def read(self) -> Any:
+        baseline = float(self.config.get("baseline", 21.0))
+        return baseline
+
+
+def list_sensor_plugins(registry: Optional[SensorRegistry] = None) -> List[str]:
+    """Convenience wrapper returning available sensor plugin identifiers."""
+
+    registry = registry or SensorRegistry()
+    return registry.available()
+
+
+def list_sensor_plugin_metadata(registry: Optional[SensorRegistry] = None) -> List[Dict[str, Any]]:
+    """Return metadata for every available sensor plugin."""
+
+    registry = registry or SensorRegistry()
+    return registry.describe_all()
 
 
 class ActuatorRegistry:
@@ -240,10 +300,13 @@ class ActuatorRegistry:
 __all__ = [
     "ActuatorPlugin",
     "ActuatorRegistry",
+    "DummyTemperatureSensor",
     "SensorPlugin",
     "SensorReading",
     "SensorRegistry",
     "import_from_string",
+    "list_sensor_plugin_metadata",
+    "list_sensor_plugins",
     "load_plugins_from_definitions",
 ]
 

--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -33,7 +33,11 @@ from monkey_head.core.task_scheduler import (
     TaskStatus,
 )
 from monkey_head.hardware import create_default_sensor_manager
-from monkey_head.hardware.plugins import SensorReading
+from monkey_head.hardware.plugins import (
+    SensorReading,
+    list_sensor_plugin_metadata,
+    list_sensor_plugins,
+)
 from monkey_head.honeycomb_index import HoneycombIndex
 from monkey_head.honeycomb_monitor import HoneycombMonitor
 from monkey_head.honeycomb_storage import HoneycombStorage
@@ -321,6 +325,9 @@ class SensorPluginsResponse(BaseModel):
     """Response model listing available sensor plugins."""
 
     plugins: List[str]
+    metadata: List[Dict[str, Any]] = Field(
+        default_factory=list, description="Detailed metadata for available plugins"
+    )
 
 
 class SensorListResponse(BaseModel):
@@ -861,8 +868,10 @@ def system_status() -> SystemStatusResponse:
 def sensor_plugins() -> SensorPluginsResponse:
     """List available sensor plugin identifiers."""
 
-    plugins = SENSOR_MANAGER.registry.available()
-    return SensorPluginsResponse(plugins=plugins)
+    registry = SENSOR_MANAGER.registry
+    plugins = list_sensor_plugins(registry)
+    metadata = list_sensor_plugin_metadata(registry)
+    return SensorPluginsResponse(plugins=plugins, metadata=metadata)
 
 
 @app.get("/sensors", response_model=SensorListResponse, tags=["Sensors"])

--- a/src/monkey_head/hardware/__init__.py
+++ b/src/monkey_head/hardware/__init__.py
@@ -13,9 +13,12 @@ from .manager import (
 from .plugins import (
     ActuatorPlugin,
     ActuatorRegistry,
+    DummyTemperatureSensor,
     SensorPlugin,
     SensorReading,
     SensorRegistry,
+    list_sensor_plugin_metadata,
+    list_sensor_plugins,
 )
 
 _drivers = import_module("huey.hardware.drivers")
@@ -26,11 +29,14 @@ __all__ = [
     "ActuatorManager",
     "ActuatorPlugin",
     "ActuatorRegistry",
+    "DummyTemperatureSensor",
     "SensorManager",
     "SensorPlugin",
     "SensorReading",
     "SensorRegistry",
     "create_default_actuator_manager",
     "create_default_sensor_manager",
+    "list_sensor_plugin_metadata",
+    "list_sensor_plugins",
     "drivers",
 ]


### PR DESCRIPTION
## Summary
- track sensor configuration in the sensor manager and provide an async streaming helper
- add sensor plugin metadata helpers, a dummy temperature plugin, and fix bulk plugin loading
- surface plugin metadata in the `/sensors/plugins` response and re-export the new helpers

## Testing
- pytest tests/test_api_routes.py::test_sensor_network_and_power_endpoints -q *(fails: missing httpx dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e620a83840832b9622b938cc9e80ad