### PR TITLE
docs: document governance workflows and API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - [Feature Matrix](#feature-matrix)
 - [Roadmap](#roadmap)
 - [License & Credits](#license--credits)
+- [Documentation portal](docs/index.md)
 
 ---
 
@@ -137,14 +138,34 @@ Selected chapters: `docs/governance/chapters/07-wartime.md`, `09-oversight.md`, 
 - x86‑64 (≥ 4 cores, 16 GB RAM, 256 GB disk, UEFI)  
 - **Python 3.12–3.13**
 
-### Source (venv)
+### Source installation
 ```bash
+git clone --recurse-submodules https://github.com/DylanLRPollock/Monkey-Head-Project.git
+cd Monkey-Head-Project
+
 python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
-pip install -r requirements.txt
-python run.py            # GUI
-python run.py --cli      # CLI
+pip install -e .              # core runtime
+# Optional extras
+pip install -e '.[ml]'       # machine-learning toolchain
+pip install -e '.[data]'     # vector DB integrations
+pip install -e '.[cloud]'    # Azure/AWS helpers
+
+# Configure environment secrets if needed
+cp huey.env.example .env
+```
+
+### First boot
+```bash
+# Prepare the memory hive and confirm compatibility
+huey init --run-checks --verbose
+
+# Launch the multi-agent runtime (CLI fallback enabled by default)
+huey run --ml --cloud
+
+# Start the FastAPI control surface on http://127.0.0.1:8000
+uvicorn huey.api:app --reload
 ```
 
 ### Docker
@@ -152,16 +173,15 @@ python run.py --cli      # CLI
 docker compose up -d
 ```
 
-### ISO / Kernel Builder
+### ISO / Kernel builder
 ```bash
 git clone --recurse-submodules https://github.com/DylanLRPollock/Monkey-Head-Project.git
 cd Monkey-Head-Project && make iso
 ```
 
-**Post‑install hardening:** update packages, enable AMDGPU/Broadcom firmware, create a non‑root SSH user, bind TigerVNC to localhost and tunnel via SSH.
+**Post-install hardening:** update packages, enable AMDGPU/Broadcom firmware, create a non-root SSH user, bind TigerVNC to localhost and tunnel via SSH.
 
-**Local models:** install **Ollama**, pull quantized models sized to your GPU’s VRAM, connect PyGPT‑net tools to local endpoints (ROCm recommended on AMD).
-
+**Local models:** install **Ollama**, pull quantized models sized to your GPU’s VRAM, connect PyGPT-net tools to local endpoints (ROCm recommended on AMD).
 ---
 
 ## Development Setup
@@ -221,6 +241,14 @@ huey agent-status --json
 # Sort collected artefacts without modifying the filesystem
 huey memory-sort --dry-run --json
 ```
+
+### API quick start
+
+Use `uvicorn huey.api:app --reload` to expose the FastAPI control surface on `http://127.0.0.1:8000`. The [API reference](docs/api-reference.md) includes `curl` recipes for every endpoint, covering task scheduling, sensor telemetry, honeycomb reports, governance workflows, and crash recovery tooling.
+
+### Sensor plugin development
+
+To extend HueyOS with custom telemetry, follow the workflow described in [`docs/sensor-plugins.md`](docs/sensor-plugins.md). The sensor manager persists readings into the honeycomb store automatically, making them available through the `/sensors/*` API family.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,767 @@
+# HueyOS API reference
+
+The FastAPI application in `huey.api:app` exposes HueyOS automation,
+telemetry, and governance capabilities. The examples below assume the server is
+running locally via `uvicorn huey.api:app --reload` on port `8000`.
+
+Each endpoint is grouped by tag and includes an example request with the shape
+of the JSON response produced by the default in-memory fixtures.
+
+## System
+
+### `GET /healthz`
+Lightweight readiness probe.
+
+```bash
+curl -s http://localhost:8000/healthz
+```
+
+```json
+{"status": "ok", "service": "hueyos"}
+```
+
+### `GET /system/status` (alias: `GET /status/system`)
+Returns host metrics, memory location, and OS details gathered by
+`_build_system_status()`.【F:src/huey/api.py†L704-L756】【F:src/huey/api.py†L818-L832】
+
+```bash
+curl -s http://localhost:8000/system/status
+```
+
+```json
+{
+  "system": "Linux",
+  "release": "6.6.0",
+  "version": "#1 SMP PREEMPT_DYNAMIC",
+  "architecture": "x86_64",
+  "hostname": "huey-core",
+  "python_version": "3.12.1",
+  "cpu_count": 16,
+  "memory_total": 34359738368,
+  "memory_available": 30146560000,
+  "uptime_seconds": 128734.42,
+  "boot_time": 1705408000.0,
+  "disk_free": 51234567890,
+  "memory_path": "/opt/hueyos/memory"
+}
+```
+
+## Task management
+
+### `POST /tasks`
+Submit a task to the cooperative scheduler.【F:src/huey/api.py†L832-L858】
+
+```bash
+curl -sX POST http://localhost:8000/tasks \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "command": "calibrate-lidar",
+    "priority": 5,
+    "requested_agent": "spark",
+    "metadata": {"source": "ops-console"},
+    "resource_profile": {"cpu": 0.5, "memory": 0.4, "battery": 0.2, "gpu": 0.1}
+  }'
+```
+
+```json
+{
+  "task_id": "tsk_01HZYQ6BQJ6ZQK6J7P3Y4YV7H6",
+  "command": "calibrate-lidar",
+  "priority": 5,
+  "requested_agent": "spark",
+  "assigned_agent": "spark",
+  "status": "queued",
+  "created_at": 1705412345.123,
+  "updated_at": 1705412345.123,
+  "attempts": 0,
+  "result": null,
+  "error": null,
+  "metadata": {"source": "ops-console"},
+  "resource_profile": {"cpu": 0.5, "memory": 0.4, "battery": 0.2, "gpu": 0.1},
+  "snapshot": {
+    "timestamp": 1705412345.0,
+    "cpu_percent": 18.2,
+    "memory_available": 30146560000,
+    "memory_total": 34359738368,
+    "battery_percent": 82.4,
+    "notes": "Nominal"
+  },
+  "history": [
+    {"timestamp": 1705412345.123, "status": "queued", "message": "Task created"}
+  ]
+}
+```
+
+### `GET /tasks`
+List scheduler tasks with optional `status` query filters.【F:src/huey/api.py†L858-L874】
+
+```bash
+curl -s 'http://localhost:8000/tasks?status=queued&status=running'
+```
+
+```json
+{
+  "tasks": [
+    {"task_id": "tsk_01HZYQ6B…", "command": "calibrate-lidar", "status": "queued", "priority": 5,
+     "requested_agent": "spark", "assigned_agent": "spark", "created_at": 1705412345.123,
+     "updated_at": 1705412345.123, "attempts": 0, "result": null, "error": null,
+     "metadata": {"source": "ops-console"},
+     "resource_profile": {"cpu": 0.5, "memory": 0.4, "battery": 0.2, "gpu": 0.1},
+     "snapshot": null,
+     "history": [{"timestamp": 1705412345.123, "status": "queued", "message": "Task created"}]}
+  ]
+}
+```
+
+### `GET /tasks/{task_id}`
+Retrieve a single task record.【F:src/huey/api.py†L874-L885】
+
+```bash
+curl -s http://localhost:8000/tasks/tsk_01HZYQ6BQJ6ZQK6J7P3Y4YV7H6
+```
+
+_Response identical to the submission payload above._
+
+### `POST /tasks/{task_id}/cancel`
+Cancel a pending or running task.【F:src/huey/api.py†L885-L898】
+
+```bash
+curl -sX POST http://localhost:8000/tasks/tsk_01HZYQ6B…/cancel
+```
+
+```json
+{
+  "task_id": "tsk_01HZYQ6B…",
+  "status": "cancelled",
+  "history": [
+    {"timestamp": 1705412345.123, "status": "queued", "message": "Task created"},
+    {"timestamp": 1705412400.456, "status": "cancelled", "message": "Operator requested cancellation"}
+  ],
+  "command": "calibrate-lidar",
+  "priority": 5,
+  "requested_agent": "spark",
+  "assigned_agent": "spark",
+  "created_at": 1705412345.123,
+  "updated_at": 1705412400.456,
+  "attempts": 0,
+  "result": null,
+  "error": null,
+  "metadata": {"source": "ops-console"},
+  "resource_profile": {"cpu": 0.5, "memory": 0.4, "battery": 0.2, "gpu": 0.1},
+  "snapshot": null
+}
+```
+
+## Sensors
+
+### `GET /sensors/plugins`
+Enumerate available sensor plugins and metadata.【F:src/huey/api.py†L904-L913】
+
+```bash
+curl -s http://localhost:8000/sensors/plugins
+```
+
+```json
+{
+  "plugins": ["dummy.temperature"],
+  "metadata": [
+    {
+      "name": "dummy.temperature",
+      "module": "huey.hardware.plugins.DummyTemperatureSensor",
+      "description": "Simple example sensor returning a fixed temperature value.",
+      "plugin": "dummy.temperature",
+      "config_keys": ["baseline"]
+    }
+  ]
+}
+```
+
+### `GET /sensors`
+List configured sensor instances, including provenance and configuration.
+【F:src/huey/api.py†L915-L930】
+
+```bash
+curl -s http://localhost:8000/sensors
+```
+
+```json
+{
+  "sensors": [
+    {
+      "name": "shop-temp-1",
+      "plugin": "dummy.temperature",
+      "module": "huey.hardware.plugins.DummyTemperatureSensor",
+      "config": {"baseline": 21.0}
+    }
+  ]
+}
+```
+
+### `POST /sensors/register`
+Register a new sensor instance.【F:src/huey/api.py†L932-L956】
+
+```bash
+curl -sX POST http://localhost:8000/sensors/register \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "ambient", "plugin": "dummy.temperature", "config": {"baseline": 19.5}}'
+```
+
+```json
+{"name": "ambient", "plugin": "dummy.temperature", "config": {"baseline": 19.5}}
+```
+
+### `DELETE /sensors/{sensor_name}`
+Remove a sensor instance from the manager.【F:src/huey/api.py†L958-L969】
+
+```bash
+curl -sX DELETE http://localhost:8000/sensors/ambient
+```
+
+```json
+{"status": "removed", "sensor": "ambient"}
+```
+
+### `POST /sensors/{sensor_name}/poll`
+Capture a fresh reading from a single sensor.【F:src/huey/api.py†L971-L989】
+
+```bash
+curl -sX POST http://localhost:8000/sensors/shop-temp-1/poll
+```
+
+```json
+{
+  "name": "shop-temp-1",
+  "value": 21.0,
+  "timestamp": 1705412450.321,
+  "provenance": {
+    "plugin": "dummy.temperature",
+    "module": "huey.hardware.plugins.DummyTemperatureSensor",
+    "config": {"baseline": 21.0}
+  }
+}
+```
+
+### `POST /sensors/poll`
+Poll every configured sensor.【F:src/huey/api.py†L991-L998】
+
+```bash
+curl -sX POST http://localhost:8000/sensors/poll
+```
+
+```json
+{
+  "readings": [
+    {
+      "name": "shop-temp-1",
+      "value": 21.0,
+      "timestamp": 1705412450.321,
+      "provenance": {
+        "plugin": "dummy.temperature",
+        "module": "huey.hardware.plugins.DummyTemperatureSensor",
+        "config": {"baseline": 21.0}
+      }
+    }
+  ]
+}
+```
+
+### `GET /sensors/{sensor_name}/history`
+Return honeycomb-backed history for a sensor.【F:src/huey/api.py†L1000-L1013】
+
+```bash
+curl -s 'http://localhost:8000/sensors/shop-temp-1/history?limit=3'
+```
+
+```json
+{
+  "sensor": "shop-temp-1",
+  "readings": [
+    {"name": "shop-temp-1", "value": 21.2, "timestamp": 1705412200.0,
+     "provenance": {"plugin": "dummy.temperature", "module": "…", "config": {"baseline": 21.0}}},
+    {"name": "shop-temp-1", "value": 21.0, "timestamp": 1705412300.0,
+     "provenance": {"plugin": "dummy.temperature", "module": "…", "config": {"baseline": 21.0}}},
+    {"name": "shop-temp-1", "value": 21.0, "timestamp": 1705412450.321,
+     "provenance": {"plugin": "dummy.temperature", "module": "…", "config": {"baseline": 21.0}}}
+  ]
+}
+```
+
+### `GET /sensors/{sensor_name}/stream`
+Server-sent events stream for a single sensor.【F:src/huey/api.py†L1015-L1025】
+
+```bash
+curl -N http://localhost:8000/sensors/shop-temp-1/stream
+```
+
+_Streamed lines in `data: {…}` format containing JSON readings._
+
+### `GET /sensors/stream`
+Server-sent events stream for all sensors.【F:src/huey/api.py†L1027-L1031】
+
+```bash
+curl -N http://localhost:8000/sensors/stream
+```
+
+## Network
+
+### `GET /network/status`
+Report connectivity status, interface inventory, and timestamps.【F:src/huey/api.py†L1033-L1040】
+
+```bash
+curl -s http://localhost:8000/network/status
+```
+
+```json
+{
+  "active_interface": "enp5s0",
+  "interfaces": {
+    "enp5s0": {"rssi": null, "throughput": 125.4},
+    "wlp3s0": {"rssi": -48.0, "throughput": 72.1}
+  },
+  "wired_available": true,
+  "wifi_available": true,
+  "connected": true,
+  "last_checked": 1705412405.987
+}
+```
+
+### `POST /network/ensure`
+Ensure wired connectivity with Wi-Fi failover.【F:src/huey/api.py†L1042-L1048】
+
+```bash
+curl -sX POST http://localhost:8000/network/ensure
+```
+
+```json
+{
+  "active_interface": "enp5s0",
+  "interfaces": {
+    "enp5s0": {"rssi": null, "throughput": 140.8},
+    "wlp3s0": {"rssi": -50.0, "throughput": 68.4}
+  },
+  "wired_available": true,
+  "wifi_available": true,
+  "connected": true,
+  "last_checked": 1705412406.112
+}
+```
+
+## Power
+
+### `GET /power/battery`
+Expose current battery metrics.【F:src/huey/api.py†L1050-L1056】
+
+```bash
+curl -s http://localhost:8000/power/battery
+```
+
+```json
+{
+  "percent": 82.4,
+  "secs_left": 5400.0,
+  "power_plugged": true,
+  "estimated_runtime_minutes": 135.0
+}
+```
+
+### `GET /power/should-shutdown`
+Report whether a safe shutdown is recommended.【F:src/huey/api.py†L1058-L1066】
+
+```bash
+curl -s http://localhost:8000/power/should-shutdown
+```
+
+```json
+{"should_shutdown": false, "threshold": 0.15}
+```
+
+### `POST /power/shutdown`
+Initiate a shutdown sequence via the battery monitor.【F:src/huey/api.py†L1068-L1074】
+
+```bash
+curl -sX POST http://localhost:8000/power/shutdown
+```
+
+```json
+{
+  "timestamp": 1705412500.512,
+  "action": "shutdown-requested",
+  "metadata": {"initiator": "operator", "method": "api"}
+}
+```
+
+## Memory
+
+### `GET /memory/pdfs`
+List PDFs accessible to HueyOS, optionally scoping the search directory.【F:src/huey/api.py†L1109-L1121】
+
+```bash
+curl -s http://localhost:8000/memory/pdfs
+```
+
+```json
+{
+  "pdfs": ["governance-overview.pdf", "hardware-manual.pdf"],
+  "directory": "/opt/hueyos/memory/DOCUMENTS"
+}
+```
+
+### `GET /memory/pdfs/{filename}`
+Resolve a filesystem path for a specific PDF.【F:src/huey/api.py†L1124-L1135】
+
+```bash
+curl -s http://localhost:8000/memory/pdfs/governance-overview.pdf
+```
+
+```json
+{
+  "filename": "governance-overview.pdf",
+  "found": true,
+  "path": "/opt/hueyos/memory/DOCUMENTS/governance-overview.pdf"
+}
+```
+
+### `POST /memory/auto-sort`
+Execute the auto-sort pipeline with optional dry-run support.【F:src/huey/api.py†L1138-L1155】
+
+```bash
+curl -sX POST http://localhost:8000/memory/auto-sort \
+  -H 'Content-Type: application/json' \
+  -d '{"source_dir": "memory/RAW", "destination_root": "memory", "dry_run": true}'
+```
+
+```json
+{
+  "source": "memory/RAW",
+  "destination": "memory",
+  "moved": ["memory/RAW/report.pdf -> memory/DOCUMENTS/report.pdf"],
+  "skipped": ["memory/RAW/README.txt"]
+}
+```
+
+### `GET /memory/honeycomb/usage`
+Return aggregated honeycomb utilisation metrics produced by `HoneycombMonitor`.
+【F:src/huey/api.py†L1158-L1185】
+
+```bash
+curl -s http://localhost:8000/memory/honeycomb/usage?window_days=14
+```
+
+```json
+{
+  "summary": [
+    {"comb": "telemetry/sensor", "cells": 128, "payload_bytes": 24576,
+     "oldest": 1703800000.0, "newest": 1705412400.0}
+  ],
+  "totals": {"cells": 512, "payload_bytes": 409600, "combs": 6, "last_update": 1705412400.0},
+  "content_types": [
+    {"content_type": "sensor", "cells": 256, "payload_bytes": 196608,
+     "oldest": 1703800000.0, "newest": 1705412400.0}
+  ],
+  "growth": [
+    {"date": "2025-01-14", "cells": 480},
+    {"date": "2025-01-15", "cells": 512}
+  ]
+}
+```
+
+## AI tools
+
+### `POST /ai/process-text`
+Process text with `AIProcessor`, optionally streaming chunks.【F:src/huey/api.py†L1189-L1230】
+
+```bash
+curl -sX POST http://localhost:8000/ai/process-text \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "HueyOS harmonises robotics and governance."}'
+```
+
+```json
+{
+  "processed_text": "[Processed] HueyOS harmonises robotics and governance."
+}
+```
+
+Enable streaming with `?stream=true` to receive chunked responses.
+
+### `POST /ai/compute-mean`
+Return the arithmetic mean of supplied numbers.【F:src/huey/api.py†L1232-L1245】
+
+```bash
+curl -sX POST http://localhost:8000/ai/compute-mean \
+  -H 'Content-Type: application/json' \
+  -d '{"numbers": [18, 24, 42]}'
+```
+
+```json
+{"mean": 28.0}
+```
+
+### `POST /ai/analyze-text`
+Expose lightweight analytics generated by the AI processor.【F:src/huey/api.py†L1247-L1265】
+
+```bash
+curl -sX POST http://localhost:8000/ai/analyze-text \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "Spark orchestrates collaborative autonomy."}'
+```
+
+```json
+{
+  "metrics": {
+    "characters": 44,
+    "words": 4,
+    "lines": 1
+  }
+}
+```
+
+## Governance
+
+### `GET /governance/emergency/status`
+Snapshot of the emergency governance controller including approvals and managed
+services.【F:src/huey/api.py†L1239-L1256】
+
+```bash
+curl -s http://localhost:8000/governance/emergency/status
+```
+
+```json
+{
+  "state": "normal",
+  "active_since": null,
+  "reason": null,
+  "triggered_by": null,
+  "approvals": [],
+  "services": [
+    {"name": "spark-agent", "essential": false, "managed": true},
+    {"name": "zap-agent", "essential": false, "managed": true},
+    {"name": "ollama", "essential": false, "managed": true}
+  ]
+}
+```
+
+### `POST /governance/emergency/enter`
+Activate emergency mode once quorum requirements are met.【F:src/huey/api.py†L1260-L1277】
+
+```bash
+curl -sX POST http://localhost:8000/governance/emergency/enter \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "triggered_by": "spark",
+        "reason": "Power instability",
+        "approvals": ["volt", "watt"]
+      }'
+```
+
+```json
+{
+  "state": "emergency",
+  "active_since": 1705412505.221,
+  "reason": "Power instability",
+  "triggered_by": "spark",
+  "approvals": ["spark", "volt", "watt"],
+  "services": [
+    {"name": "spark-agent", "essential": false, "managed": true},
+    {"name": "zap-agent", "essential": false, "managed": true},
+    {"name": "ollama", "essential": false, "managed": true}
+  ]
+}
+```
+
+### `POST /governance/emergency/exit`
+Return to normal operations with the required approvals.【F:src/huey/api.py†L1280-L1295】
+
+```bash
+curl -sX POST http://localhost:8000/governance/emergency/exit \
+  -H 'Content-Type: application/json' \
+  -d '{"requested_by": "spark", "approvals": ["volt", "watt"]}'
+```
+
+```json
+{
+  "state": "normal",
+  "active_since": null,
+  "reason": null,
+  "triggered_by": null,
+  "approvals": [],
+  "services": [
+    {"name": "spark-agent", "essential": false, "managed": true},
+    {"name": "zap-agent", "essential": false, "managed": true},
+    {"name": "ollama", "essential": false, "managed": true}
+  ]
+}
+```
+
+### `POST /governance/emergency/action`
+Validate a dual-authorised action during emergency mode.【F:src/huey/api.py†L1298-L1313】
+
+```bash
+curl -sX POST http://localhost:8000/governance/emergency/action \
+  -H 'Content-Type: application/json' \
+  -d '{"actor": "spark", "approvals": ["volt"], "action": "restart-reactor"}'
+```
+
+```json
+{"status": "authorised", "action": "restart-reactor"}
+```
+
+## Administration
+
+### `GET /admin/services`
+Return service state tracked by `_SERVICE_STATES`.【F:src/huey/api.py†L1316-L1321】
+
+```bash
+curl -s http://localhost:8000/admin/services
+```
+
+```json
+{
+  "services": [
+    {"name": "spark-agent", "status": "running", "last_changed": 1705412000.0},
+    {"name": "zap-agent", "status": "stopped", "last_changed": 1705412100.0}
+  ]
+}
+```
+
+### `POST /admin/services/{service_name}/start`
+Mark a service as running.【F:src/huey/api.py†L1323-L1332】
+
+```bash
+curl -sX POST http://localhost:8000/admin/services/zap-agent/start
+```
+
+```json
+{"name": "zap-agent", "status": "running", "last_changed": 1705412508.443}
+```
+
+### `POST /admin/services/{service_name}/stop`
+Mark a service as stopped.【F:src/huey/api.py†L1335-L1344】
+
+```bash
+curl -sX POST http://localhost:8000/admin/services/zap-agent/stop
+```
+
+```json
+{"name": "zap-agent", "status": "stopped", "last_changed": 1705412510.112}
+```
+
+### `POST /admin/system-check`
+Run the full system check suite and return pass/fail information.【F:src/huey/api.py†L1346-L1354】
+
+```bash
+curl -sX POST http://localhost:8000/admin/system-check
+```
+
+```json
+{
+  "results": {"python_version": true, "gpu_driver": true, "disk_space": true},
+  "passed": true
+}
+```
+
+### `POST /admin/health-check`
+Delegate to the `/healthz` endpoint for administrative contexts.【F:src/huey/api.py†L1356-L1360】
+
+```bash
+curl -sX POST http://localhost:8000/admin/health-check
+```
+
+```json
+{"status": "ok", "service": "hueyos"}
+```
+
+## Resilience
+
+### `GET /resilience/monitors`
+List monitored processes and their health metadata.【F:src/huey/api.py†L1035-L1044】
+
+```bash
+curl -s http://localhost:8000/resilience/monitors
+```
+
+```json
+[
+  {
+    "name": "ollama",
+    "healthy": true,
+    "auto_restart": true,
+    "last_heartbeat": 1705412300.0,
+    "last_restart": null,
+    "restart_attempts": 0,
+    "manual_override_reason": null
+  }
+]
+```
+
+### `POST /resilience/monitors/{name}/override`
+Toggle automatic restarts for a monitored process.【F:src/huey/api.py†L1046-L1060】
+
+```bash
+curl -sX POST http://localhost:8000/resilience/monitors/ollama/override \
+  -H 'Content-Type: application/json' \
+  -d '{"auto_restart": false, "reason": "maintenance"}'
+```
+
+```json
+{
+  "name": "ollama",
+  "healthy": true,
+  "auto_restart": false,
+  "last_heartbeat": 1705412300.0,
+  "last_restart": null,
+  "restart_attempts": 0,
+  "manual_override_reason": "maintenance"
+}
+```
+
+### `POST /resilience/monitors/{name}/restart`
+Force a manual restart, regardless of override state.【F:src/huey/api.py†L1063-L1075】
+
+```bash
+curl -sX POST http://localhost:8000/resilience/monitors/ollama/restart
+```
+
+```json
+{
+  "name": "ollama",
+  "healthy": true,
+  "auto_restart": false,
+  "last_heartbeat": 1705412305.512,
+  "last_restart": 1705412305.512,
+  "restart_attempts": 1,
+  "manual_override_reason": "maintenance"
+}
+```
+
+### `POST /resilience/poll`
+Return crash events detected since the previous poll.【F:src/huey/api.py†L1078-L1096】
+
+```bash
+curl -sX POST http://localhost:8000/resilience/poll
+```
+
+```json
+{
+  "events": [
+    {
+      "process": "ollama",
+      "timestamp": 1705412350.432,
+      "restarted": true,
+      "message": "Process restarted after crash",
+      "metadata": {}
+    }
+  ]
+}
+```
+
+### `POST /resilience/watchdog/ping`
+Send a heartbeat to the systemd watchdog client.【F:src/huey/api.py†L1099-L1106】
+
+```bash
+curl -sX POST http://localhost:8000/resilience/watchdog/ping
+```
+
+```json
+{"watchdog": true}
+```

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,51 @@
+# Governance and resilience
+
+HueyOS combines constitutional decision-making with automated resilience. The
+Cloud Pyramid model defines how authority flows between agents, while runtime
+controllers enforce emergency powers and crash recovery procedures.
+
+## Cloud Pyramid architecture
+
+The Cloud Pyramid is a multi-tier governance stack that anchors HueyOS to
+transparent, constitutional decision making. Authority starts at the populace
+(base tier), ascends through specialised chambers and councils, and culminates in
+the Founding Father AI that arbitrates final decisions.【F:README.md†L69-L108】
+By distributing responsibilities across the pyramid, HueyOS balances day-to-day
+operations with strategic oversight—operators can delegate tactical actions to
+agents such as Spark, Volt, and Zap while retaining high-level veto power.
+
+## Emergency mode lifecycle
+
+`EmergencyGovernanceController` coordinates the activation and exit of emergency
+powers. It requires a minimum quorum of distinct approvals, tracks which
+services are considered essential, and records who triggered the transition.
+【F:huey/core/resilience.py†L98-L200】 The FastAPI endpoints under
+`/governance/emergency/*` expose the workflow:
+
+1. **Status** – `/governance/emergency/status` returns the current state and the
+   managed services, making it easy to audit who authorised the last change.
+   【F:src/huey/api.py†L1239-L1256】
+2. **Enter mode** – `/governance/emergency/enter` validates approvals, stops
+   non-essential services, and timestamps activation.【F:src/huey/api.py†L1260-L1277】
+3. **Exit mode** – `/governance/emergency/exit` restarts managed services and
+   clears approvals once the quorum agrees to return to normal operations.
+   【F:src/huey/api.py†L1280-L1295】
+4. **Authorised actions** – `/governance/emergency/action` checks dual control
+   for sensitive operations before they proceed.【F:src/huey/api.py†L1298-L1313】
+
+This flow ensures emergency measures are deliberate, auditable, and reversible.
+
+## Crash recovery and watchdog integration
+
+`CrashRecoveryManager` monitors background processes, invokes health checks, and
+attempts automatic restarts when failures occur. Events are recorded and exposed
+through `/resilience/poll`, allowing observability pipelines to track incidents.
+【F:huey/core/resilience.py†L200-L332】【F:src/huey/api.py†L1078-L1096】 Operators
+can toggle automatic restarts per process or perform manual restarts using the
+`/resilience/monitors/*` endpoints.【F:src/huey/api.py†L1035-L1075】 When running
+under systemd, the `/resilience/watchdog/ping` endpoint proxies heartbeats to the
+watchdog socket so supervisors know HueyOS is responsive.【F:huey/core/resilience.py†L42-L95】【F:src/huey/api.py†L1099-L1106】
+
+Together, the emergency controller and crash manager enforce the governance
+contract defined by the Cloud Pyramid, keeping HueyOS accountable, recoverable,
+and transparent.

--- a/docs/honeycomb-storage.md
+++ b/docs/honeycomb-storage.md
@@ -1,75 +1,87 @@
 # Honeycomb Storage Operations
 
-HueyOS stores long lived data inside a resilient honeycomb structure backed by
-SQLite. This document explains how the new memory index, backup procedures,
-monitoring, and retention policies work together to keep the hive healthy.
+HueyOS stores long-lived data inside a resilient honeycomb structure backed by
+SQLite. The honeycomb abstracts the storage of telemetry, documents, and other
+payloads into **combs** (namespaces) and **cells** (individual records). This
+section explains how the storage layer is implemented, how it interacts with the
+sensor manager, and which tooling is available for monitoring, backups, and
+retention.
 
-## Content-aware memory index
+## Storage model
 
-The honeycomb index maps high level content types (images, documents, logs,
-telemetry sensor data, etc.) onto deterministic comb and cell prefixes. It uses
-the existing auto-sort extension categories so the same heuristics drive both
-filesystem organisation and database persistence.
+The `huey.honeycomb_storage.HoneycombStorage` class exposes a key/value API that
+persists JSON payloads into the `honeycomb_cells` table.【F:huey/honeycomb_storage.py†L16-L101】
+Keys are split on `/` to derive comb and cell components, enabling structured
+queries and efficient indices. Examples:
 
-| Content type | Honeycomb path prefix      | Auto-sort categories |
-| ------------ | -------------------------- | -------------------- |
-| Images       | `media/images/<cell>`      | JPEG, PNG            |
-| Documents    | `knowledge/documents/<cell>` | PDF, MD, TXT, DOC, PPT, XLS |
-| Logs         | `telemetry/logs/<cell>`    | LOG, JSON            |
-| Sensor data  | `telemetry/sensor/<cell>`  | CSV, JSON            |
-| Archives     | `packages/archives/<cell>` | ZIP, GZ              |
-| Code         | `knowledge/code/<cell>`    | PY, SH               |
+| Key example                                | Comb                    | Purpose                              |
+|--------------------------------------------|-------------------------|--------------------------------------|
+| `telemetry/sensor/air_quality/8fa3…`       | `telemetry/sensor`      | Real-time sensor readings            |
+| `knowledge/documents/design/v1`            | `knowledge/documents`   | Indexed project documents            |
+| `media/images/20250201-capture01`          | `media/images`          | Archived camera stills               |
 
-Developers interact with the index through
-`monkey_head.honeycomb_index.HoneycombIndex`, which can classify a path and
-store structured metadata alongside content-specific payloads. Custom content
-mappings can be registered when new categories emerge, and all mappings are
-returned via the API for introspection.
+`HoneycombStorage.store()` automatically timestamps inserts and performs an
+upsert so updates preserve the original creation timestamp while refreshing the
+`updated_at` column.【F:huey/honeycomb_storage.py†L63-L85】 The helper methods
+`load()`, `get_record()`, `list_keys()`, `remove()`, and `count()` make the
+storage behave like a persistent dictionary with optional prefix scoping.【F:huey/honeycomb_storage.py†L87-L153】
 
-## Replication and backups
+## Integration with the sensor manager
 
-`monkey_head.honeycomb_backup.perform_rsync_snapshot` creates timestamped
-snapshots of the memory directory using `rsync`. Snapshots may be sent to local
-or remote (e.g. SSH mounted) destinations. Restoring a snapshot uses the same
-utility via `restore_snapshot`.
+`sensor_manager.SensorManager` captures readings from registered plugins and
+immediately persists them into the honeycomb. Each reading is given a unique
+cell name derived from a UUID, ensuring durable histories for later analysis.
+【F:huey/hardware/manager.py†L59-L111】 The same manager exposes streaming queues
+and history loaders so operators can replay sensor activity or subscribe to live
+feeds without touching the underlying database.
 
-Typical cron entry using a helper script:
+When writing your own sensor plugin, no special code is required to talk to the
+honeycomb. Calling `SensorManager.poll_sensor()` or `poll_all()` records the
+reading and broadcasts it to subscribers.
+
+## Querying and analytics
+
+Several utilities build on top of the storage abstraction:
+
+- `HoneycombIndex` classifies filesystem artefacts into comb paths based on
+  content type mappings shared with the auto-sorter.【F:huey/honeycomb_index.py†L20-L139】
+- `HoneycombMonitor.build_usage_report()` aggregates totals, content-type
+  breakdowns, and growth samples. The FastAPI endpoint `/memory/honeycomb/usage`
+  returns this data in the `HoneycombUsageResponse` schema for dashboards or
+  alerting pipelines.【F:src/huey/api.py†L232-L297】【F:src/huey/api.py†L1084-L1103】
+- `SensorManager.load_history()` retrieves ordered historical records for a
+  sensor, relying on `HoneycombStorage.list_keys()` and `get_record()` to load
+  payloads and timestamps.【F:huey/hardware/manager.py†L113-L148】
+
+## Backups and replication
+
+`huey.honeycomb_backup.perform_rsync_snapshot` creates timestamped snapshots of
+`memory/` using `rsync`. Snapshots may be sent to local or remote destinations,
+and `restore_snapshot` rehydrates the tree when needed. A sample cron entry:
 
 ```
 0 * * * * hueyos /opt/hueyos/.venv/bin/python - <<'PY'
 from pathlib import Path
-from monkey_head.honeycomb_backup import perform_rsync_snapshot
+from huey.honeycomb_backup import perform_rsync_snapshot
 
 perform_rsync_snapshot(destination=Path("/mnt/honeycomb-backups"))
 PY
 ```
 
-Restoration procedure:
+Always verify `rsync` availability during commissioning so operators are alerted
+if the backup toolchain is missing.
 
-1. Mount or attach the external media containing snapshots.
-2. Choose the snapshot directory (e.g. `20240101-000000`).
-3. Run `restore_snapshot(<snapshot>, <target>)` to repopulate the memory tree.
-4. Restart services that rely on the honeycomb database.
+## Monitoring growth
 
-If `rsync` is unavailable the helper raises a `BackupError`, ensuring operators
-are alerted to missing tooling before an incident occurs.
-
-## Monitoring honeycomb growth
-
-`monkey_head.honeycomb_monitor.HoneycombMonitor` calculates per-comb usage,
-content-type breakdowns, and growth trends (daily buckets). The data is
-returned as JSON and feeds the new `/memory/honeycomb/usage` API endpoint.
-Dashboard integrations can visualise the `summary`, `content_types`, and
-`growth` arrays to highlight hot spots or unusually fast growth.
+`HoneycombMonitor` calculates per-comb utilisation, content-type totals, and a
+rolling growth series (daily buckets by default). The resulting payload feeds
+Grafana or similar dashboards so sudden spikes become visible. Combine it with
+`HoneycombIndex` to align storage reporting with the auto-sort file taxonomy.
+【F:huey/honeycomb_monitor.py†L20-L144】
 
 ## Retention and pruning
 
-`monkey_head.honeycomb_retention.RetentionPolicy` deletes stale records while
-respecting critical data. Retention windows can be defined per content type
-(using the index) or directly per comb, with durations specified as symbols
-such as `14d` or `6m`. Applying a policy prunes cells older than the configured
-thresholds and reports how many were removed, allowing automation to log and
-alert on reclaimed capacity.
-
-Combine backups, monitoring, and retention policies to maintain a resilient and
-self-healing storage hive.
+`huey.honeycomb_retention.RetentionPolicy` applies content-aware expiry rules to
+old cells, using duration strings such as `14d` or `6m`. Operators can set
+different windows per content type or comb and record how many rows were
+pruned, closing the loop between ingestion, monitoring, and retention.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,16 @@
 # HueyOS Documentation
 
-- Constitution & Governance
-- Architecture: MacroOS, MicroOS, NanoOS
-- Storage: Bees & Honey
-  - [Honeycomb storage operations](honeycomb-storage.md)
-- Orchestration Node (X9QRI-F+), Nodes (BD795I-SE), Black Box
+HueyOS combines robotics control, knowledge management, and constitutional
+governance primitives. The documents in this directory explain how to extend
+the platform and how to operate core services.
+
+## Quick starts
+
+- [CLI quick reference](#cli-quick-reference)
+- [Sensor plugin development](sensor-plugins.md)
+- [Honeycomb storage operations](honeycomb-storage.md)
+- [API reference](api-reference.md)
+- [Governance & resilience](governance.md)
 
 ## CLI quick reference
 

--- a/docs/sensor-plugins.md
+++ b/docs/sensor-plugins.md
@@ -1,0 +1,86 @@
+# Sensor plugin development
+
+HueyOS acquires telemetry via pluggable sensors. Plugins inherit from
+`huey.hardware.plugins.SensorPlugin`, implement a `read()` method, and rely on
+the `SensorManager` to persist readings into honeycomb storage and broadcast them
+to listeners.
+
+## Lifecycle hooks
+
+All plugins inherit from `BasePlugin`, which provides optional `setup()` and
+`shutdown()` hooks and exposes provenance metadata shared with API clients.
+【F:huey/hardware/plugins.py†L22-L64】 Implement long-running initialisation such
+as opening serial devices inside `setup()` and release resources inside
+`shutdown()`.
+
+Every call to `capture()` wraps the `read()` output with timestamps and
+provenance data, returning a `SensorReading` dataclass.【F:huey/hardware/plugins.py†L32-L55】
+`SensorManager.poll_sensor()` invokes `capture()`, stores the payload in the
+honeycomb, and fan-outs to live subscribers.【F:huey/hardware/manager.py†L71-L112】
+
+## Minimal plugin example
+
+```python
+from huey.hardware.plugins import SensorPlugin
+
+class WorkshopTemperature(SensorPlugin):
+    """Reports ambient temperature from an attached microcontroller."""
+
+    plugin_name = "workshop.temperature"
+
+    def setup(self) -> None:
+        self.serial_port = open("/dev/ttyUSB0", "rb")
+
+    def read(self) -> float:
+        raw = self.serial_port.readline().decode().strip()
+        return float(raw)
+
+    def shutdown(self) -> None:
+        self.serial_port.close()
+```
+
+Register the plugin at runtime using `SensorManager.add_sensor()`:
+
+```python
+from huey.hardware.manager import SensorManager
+
+manager = SensorManager()
+manager.add_sensor("workshop.temperature", name="shop-temp-1", config={"units": "C"})
+```
+
+The manager records each reading under `telemetry/sensor/<name>/<uuid>` inside
+the honeycomb store, making it available through `/sensors/*` endpoints and the
+history loaders.
+
+## Configuration and provenance
+
+Plugin constructors receive a `config` dictionary. The base class stores it and
+exposes it as part of the provenance returned to API consumers.【F:huey/hardware/plugins.py†L24-L47】
+Use this channel for calibration constants, units, or thresholds. Since configs
+are persisted alongside sensor metadata, operators can audit which parameters
+were active when a reading was produced.
+
+## Packaging and entry points
+
+`SensorRegistry` maintains the mapping of symbolic plugin names to classes and
+can lazily load additional plugins from the `monkey_head.sensors` entry point
+group.【F:huey/hardware/plugins.py†L67-L166】 Adding the following to your
+`pyproject.toml` registers the example plugin:
+
+```toml
+[project.entry-points."monkey_head.sensors"]
+"workshop.temperature" = "my_package.sensors:WorkshopTemperature"
+```
+
+When HueyOS starts it enumerates entry points and makes each plugin visible via
+`/sensors/plugins` together with docstrings and sample configuration keys.
+Metadata is sourced from `SensorRegistry.describe()` which instantiates the class
+and inspects its configuration defaults.【F:huey/hardware/plugins.py†L85-L126】
+
+## Testing plugins
+
+To validate a plugin without hardware, provide a stub implementation that returns
+synthetic data—similar to the included `DummyTemperatureSensor`—and register it
+during development or unit tests.【F:huey/hardware/plugins.py†L167-L198】 Use the
+`sensor_manager` streaming helpers to assert that readings propagate to
+subscribers and appear in honeycomb history queries.


### PR DESCRIPTION
## Summary
- expand README installation and usage sections with end-to-end CLI and API boot steps
- add focused guides for sensor plugins, honeycomb storage operations, and governance workflows
- provide a comprehensive FastAPI endpoint reference with request and response examples

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e6ae8bafdc832b974c6fc1bf0e2ddc