### PR TITLE
Add packaging metadata and containerized deployment assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1.7
+
+ARG PYTHON_VERSION=3.11-slim
+FROM python:${PYTHON_VERSION} AS hueyos
+
+ARG HUEY_EXTRAS=""
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    HUEY_API_PORT=1995 \
+    HUEY_CONFIG_DIR=/app/config \
+    HUEY_MEMORY_DIR=/app/memory
+
+WORKDIR /app
+
+# Install build tooling once so the actual dependency install can reuse the cached layer.
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-bootstrap,sharing=locked \
+    pip install --upgrade pip setuptools wheel
+
+COPY README.md pyproject.toml ./
+COPY src ./src
+
+# Install HueyOS with optional extras controlled by the build argument.
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-install,sharing=locked \
+    if [ -n "${HUEY_EXTRAS}" ]; then \
+        pip install --no-cache-dir ".[${HUEY_EXTRAS}]"; \
+    else \
+        pip install --no-cache-dir .; \
+    fi
+
+# Non-root execution user for better container security.
+RUN useradd --create-home --shell /bin/bash huey
+USER huey
+
+# Runtime directories that are usually bind-mounted when running with Compose.
+RUN mkdir -p "${HUEY_CONFIG_DIR}" "${HUEY_MEMORY_DIR}"
+VOLUME ["/app/config", "/app/memory"]
+
+EXPOSE 1995
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=5 \
+    CMD python -c "import socket; s=socket.create_connection(('127.0.0.1', ${HUEY_API_PORT}), 2); s.close()"
+
+ENTRYPOINT ["uvicorn"]
+CMD ["huey.api:app", "--host", "0.0.0.0", "--port", "1995"]

--- a/Makefile
+++ b/Makefile
@@ -1,65 +1,30 @@
 SHELL := /bin/bash
 .ONESHELL:
 .SHELLFLAGS := -eu -o pipefail -c
-.PHONY: setup dev test run fmt lint clean ml data cloud pytest coverage lint-black lint-isort lint-ruff lint-flake8
+.PHONY: setup dev test run fmt lint clean ml data cloud pytest coverage lint-black lint-isort lint-ruff lint-flake8 docker-build docker-up docker-down
 
 PORT ?= 5151
-REQ_DIR := requirements
-REQ_ML_FILE := $(REQ_DIR)/requirements-ml.txt
-REQ_DATA_FILE := $(REQ_DIR)/requirements-data.txt
-REQ_CLOUD_FILE := $(REQ_DIR)/requirements-cloud.txt
-REQ_DEV_FILE := $(REQ_DIR)/requirements-dev.txt
-
-define install_section
-	@if [ -f $(1) ]; then \
-		echo "Installing dependencies from $(1)"; \
-		python3 -m pip install -r $(1); \
-	elif [ -f requirements.txt ]; then \
-		tmp_file="$$\(mktemp\)"; \
-		echo "Extracting $(2) requirements from requirements.txt"; \
-		SECTION="$(2)" TMP_FILE="$$tmp_file" python3 - <<-'PY'; \
-			import os
-			from pathlib import Path
-
-			section = os.environ["SECTION"]
-			tmp_path = Path(os.environ["TMP_FILE"])
-			source = Path("requirements.txt")
-			start_token = f"# ===== {section}.txt ====="
-			capture = False
-			lines = []
-
-			with source.open(encoding="utf-8") as handle:
-				for raw_line in handle:
-					stripped = raw_line.strip()
-					if stripped == start_token:
-						capture = True
-						continue
-					if capture and stripped.startswith("# =====") and stripped != start_token:
-						break
-					if capture and stripped and not stripped.startswith("#"):
-						lines.append(raw_line)
-
-			if not lines:
-				raise SystemExit(f"No requirements found for section '{section}'")
-
-			tmp_path.write_text("".join(lines), encoding="utf-8")
-		PY
-		python3 -m pip install -r "$$tmp_file"; \
-		rm -f "$$tmp_file"; \
-	else \
-		echo "Unable to locate requirements for $(2)" >&2; \
-		exit 1; \
-	fi
-endef
+PYTHON ?= python3
+PIP := $(PYTHON) -m pip
+SETUP_EXTRAS ?=
+DEV_EXTRAS ?= dev
+DEV_OPTIONAL_PROFILES ?=
+ML_EXTRAS ?= ml
+DATA_EXTRAS ?= data
+CLOUD_EXTRAS ?= cloud
 
 setup:
-	python3 -m pip install --upgrade pip
-	python3 -m pip install -r $(REQ_DIR)/requirements-core.txt
+	$(PIP) install --upgrade pip setuptools wheel
+	if [ -n "$(strip $(SETUP_EXTRAS))" ]; then \
+		$(PIP) install -e ".[$(strip $(SETUP_EXTRAS))]"; \
+	else \
+		$(PIP) install -e .; \
+	fi
 
 test: lint pytest
 
 run:
-	python3 -m uvicorn huey.api:app --host 0.0.0.0 --port $(PORT)
+	$(PYTHON) -m uvicorn huey.api:app --host 0.0.0.0 --port $(PORT)
 
 fmt:
 	black . && isort .
@@ -79,10 +44,10 @@ lint-flake8:
 	flake8 .
 
 pytest:
-	python3 -m pytest -q
+	$(PYTHON) -m pytest -q
 
 coverage:
-	python3 -m pytest --cov=huey --cov=monkey_head --cov-report=term-missing
+	$(PYTHON) -m pytest --cov=huey --cov=monkey_head --cov-report=term-missing
 
 clean:
 	rm -rf build dist .pytest_cache **/__pycache__ *.egg-info
@@ -96,13 +61,17 @@ clean:
 	fi
 
 ml:
-	$(call install_section,$(REQ_ML_FILE),requirements-ml)
-	python3 - <<-'PY'
-	from llama_index.core import Document, VectorStoreIndex
-
-	documents = [
-	    Document(text="Huey is a friendly robotics research assistant."),
-	    Document(text="Huey loves banana milkshakes."),
+	if [ -n "$(strip $(ML_EXTRAS))" ]; then \
+		$(PIP) install -e ".[$(strip $(ML_EXTRAS))]"; \
+	else \
+		$(PIP) install -e .; \
+	fi
+	$(PYTHON) - <<-'PY'
+	        from llama_index.core import Document, VectorStoreIndex
+	
+	        documents = [
+	            Document(text="Huey is a friendly robotics research assistant."),
+	            Document(text="Huey loves banana milkshakes."),
 	]
 	index = VectorStoreIndex.from_documents(documents)
 	response = index.as_query_engine().query("What does Huey enjoy?")
@@ -110,13 +79,17 @@ ml:
 	PY
 
 data:
-	$(call install_section,$(REQ_DATA_FILE),requirements-data)
-	python3 - <<-'PY'
-	import chromadb
-
-	client = chromadb.Client()
-	collection = client.get_or_create_collection("makefile_demo")
-	collection.add(
+	if [ -n "$(strip $(DATA_EXTRAS))" ]; then \
+		$(PIP) install -e ".[$(strip $(DATA_EXTRAS))]"; \
+	else \
+		$(PIP) install -e .; \
+	fi
+	$(PYTHON) - <<-'PY'
+	        import chromadb
+	
+	        client = chromadb.Client()
+	        collection = client.get_or_create_collection("makefile_demo")
+	        collection.add(
 	    ids=["1"],
 	    documents=["Huey keeps its research notes in a vector store."],
 	    metadatas=[{"source": "demo"}],
@@ -126,19 +99,23 @@ data:
 	PY
 
 cloud:
-	$(call install_section,$(REQ_CLOUD_FILE),requirements-cloud)
-	python3 - <<-'PY'
-	import urllib.request
-
-	import boto3  # noqa: F401 - ensure AWS SDK is installed
-	from azure.identity import AzureAuthorityHosts  # noqa: F401 - ensure Azure SDK is installed
-
+	if [ -n "$(strip $(CLOUD_EXTRAS))" ]; then \
+		$(PIP) install -e ".[$(strip $(CLOUD_EXTRAS))]"; \
+	else \
+		$(PIP) install -e .; \
+	fi
+	$(PYTHON) - <<-'PY'
+	        import urllib.request
+	
+	        import boto3  # noqa: F401 - ensure AWS SDK is installed
+	        from azure.identity import AzureAuthorityHosts  # noqa: F401 - ensure Azure SDK is installed
+	
 	providers = {
 	    "Azure": "https://management.azure.com/",
 	    "GCP": "https://www.googleapis.com/",
 	    "AWS": "https://sts.amazonaws.com/",
 	}
-
+	
 	for name, url in providers.items():
 	    try:
 	        with urllib.request.urlopen(url, timeout=5) as response:
@@ -149,11 +126,23 @@ cloud:
 	        print(f"{name} connectivity check succeeded (status {status})")
 	PY
 
-dev: setup
-	$(call install_section,$(REQ_DEV_FILE),requirements-dev)
-	python3 -m pip install black isort flake8 ruff
+dev:
+	if [ -n "$(strip $(DEV_OPTIONAL_PROFILES))" ]; then \
+		$(MAKE) setup SETUP_EXTRAS="$(strip $(DEV_EXTRAS)),$(strip $(DEV_OPTIONAL_PROFILES))"; \
+	else \
+		$(MAKE) setup SETUP_EXTRAS="$(strip $(DEV_EXTRAS))"; \
+	fi
 	pre-commit install --install-hooks
 	$(MAKE) fmt
 	$(MAKE) lint
 	pre-commit run --all-files
-	python3 -m pytest -q
+	$(PYTHON) -m pytest -q
+
+docker-build:
+	docker compose build
+
+docker-up:
+	docker compose up -d
+
+docker-down:
+	docker compose down

--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ HueyOS targets **Debian 13 “Trixie”** with a custom low‑latency kernel ser
 | Path                      | Description                                             |
 |---------------------------|---------------------------------------------------------|
 | `.github/`                | CI workflows, CODEOWNERS, issue templates               |
-| `docker/`                 | Compose/build files for HueyOS services                 |
+| `Dockerfile`              | Container image definition for HueyOS services          |
+| `docker-compose.yml`      | Docker Compose stack (API, worker, optional Redis)      |
+| `docker/`                 | Legacy orchestrator assets and experimental builds      |
 | `docs/`                   | Constitution, governance, architecture                  |
 | `huey/`                   | Core runtime and service modules                        |
-| `requirements/`           | Split dependency profiles (core, ml, data, cloud, dev)  |
 | `setup/`                  | Installer scripts, ISO builder, provisioning configs    |
 | `src/`                    | Python package source                                   |
 | `tests/`                  | Unit & integration tests                                |
@@ -170,8 +171,16 @@ uvicorn huey.api:app --reload
 
 ### Docker
 ```bash
+# Build with the default ML, data, and cloud profiles baked into the image
+docker compose build
+# Launch the API and (optionally) enable additional profiles via --profile
 docker compose up -d
 ```
+
+Set `HUEY_BUILD_EXTRAS` (for example, `HUEY_BUILD_EXTRAS=ml`) before running
+`docker compose build` to tailor which optional dependency groups are installed
+into the container image. Runtime-only tweaks can be made with Compose profiles
+(`docker compose --profile worker up`) without rebuilding the image.
 
 ### ISO / Kernel builder
 ```bash
@@ -187,11 +196,13 @@ cd Monkey-Head-Project && make iso
 ## Development Setup
 
 ```bash
-make setup    # Core
-make ml       # ML profile
-make data     # Data profile
-make cloud    # Cloud profile
-make dev      # Dev tools
+make setup                       # Editable install of the core package
+make setup SETUP_EXTRAS=dev      # Install with dev tooling extras
+make ml                          # Install ML profile extras and run a smoke test
+make data                        # Install data profile extras and run a smoke test
+make cloud                       # Install cloud profile extras and run a smoke test
+make dev                         # Install dev extras, format, lint, and test
+make dev DEV_OPTIONAL_PROFILES=ml,data  # Include optional profiles in dev setup
 ```
 
 **Environment:** copy `huey.env.example` to `.env` and configure secrets/ports.  
@@ -211,7 +222,7 @@ make run
 
 **Run in Docker**
 ```bash
-docker compose -f docker/compose.yml up
+docker compose up
 ```
 
 **Run tests**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,81 @@
+name: hueyos
+
+x-service-defaults: &service_defaults
+  restart: unless-stopped
+  tty: true
+  init: true
+  stop_grace_period: 15s
+  logging:
+    driver: json-file
+    options:
+      max-size: "10m"
+      max-file: "3"
+
+services:
+  api:
+    <<: *service_defaults
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        PYTHON_VERSION: ${HUEY_PYTHON_VERSION:-3.11-slim}
+        HUEY_EXTRAS: ${HUEY_BUILD_EXTRAS:-ml,data,cloud}
+    image: ${HUEY_IMAGE:-hueyos:latest}
+    container_name: ${HUEY_API_CONTAINER:-hueyos-api}
+    env_file:
+      - ${HUEY_ENV_FILE:-huey.env.example}
+    environment:
+      HUEY_API_PORT: ${HUEY_API_PORT:-1995}
+      HUEY_CONFIG_DIR: /app/config
+      HUEY_MEMORY_DIR: /app/memory
+    volumes:
+      - ./config:/app/config
+      - ./memory:/app/memory
+    ports:
+      - "${HUEY_API_PORT:-1995}:1995"
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:1995/healthz', timeout=2)"
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  worker:
+    <<: *service_defaults
+    image: ${HUEY_IMAGE:-hueyos:latest}
+    container_name: ${HUEY_WORKER_CONTAINER:-hueyos-worker}
+    command:
+      - huey
+      - run
+      - --cli
+    environment:
+      HUEY_CONFIG_DIR: /app/config
+      HUEY_MEMORY_DIR: /app/memory
+    volumes:
+      - ./config:/app/config
+      - ./memory:/app/memory
+    depends_on:
+      api:
+        condition: service_healthy
+    profiles: ["worker"]
+
+  redis:
+    <<: *service_defaults
+    image: redis:7-alpine
+    container_name: ${HUEY_REDIS_CONTAINER:-hueyos-redis}
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+    profiles: ["extras"]
+
+volumes:
+  redis-data: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "hueyos"
 version = "0.2.0"
 description = "HueyOS: on-robot runtime for the Monkey Head Project (Huey)."
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.11,<3.14"
 readme = "README.md"
 authors = [{ name = "Dylan L. R. Pollock" }]
 license = { text = "GPL-3.0-only" }
@@ -100,6 +100,7 @@ cloud = [
   "s3transfer==0.13.0",
 ]
 dev = [
+  "black==24.10.0",
   "chromedriver-autoinstaller==0.6.4",
   "docker==7.1.0",
   "coloredlogs==15.0.1",
@@ -109,7 +110,10 @@ dev = [
   "pytest-asyncio==1.2.0",
   "pytest-cov==7.0.0",
   "httpx==0.28.1",
+  "isort==5.13.2",
   "pre-commit==4.0.1",
+  "ruff==0.9.10",
+  "flake8==7.1.1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- relax the supported interpreter range and fold formatting/linting tools into the `dev` optional dependency group in `pyproject.toml`
- rework the Makefile targets to install the project and extras directly from `pyproject.toml`
- add a root Dockerfile and docker-compose.yml that build and run the HueyOS API, worker, and optional Redis profile
- refresh the README to document the new deployment workflow and Makefile flags

## Testing
- make setup

------
https://chatgpt.com/codex/tasks/task_e_68e6b10d5400832ba5bea7e88c3ae5f5