### PR TITLE
Handle invalid sensor timestamps in TelemetryStore

### DIFF
--- a/src/monkey_head/utils/persistence.py
+++ b/src/monkey_head/utils/persistence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import sqlite3
 import threading
 import time
@@ -71,9 +72,10 @@ class TelemetryStore:
 
     # ------------------------------------------------------------------
     def log_sensor_reading(self, reading: SensorReading) -> None:
+        timestamp = self._normalise_timestamp(getattr(reading, "timestamp", None))
         payload = {
             "name": getattr(reading, "name", None),
-            "timestamp": float(getattr(reading, "timestamp", time.time())),
+            "timestamp": timestamp,
             "value": getattr(reading, "value", None),
             "provenance": getattr(reading, "provenance", {}),
         }
@@ -273,6 +275,24 @@ class TelemetryStore:
         if len(value) <= limit:
             return value
         return value[: limit - 3] + "..."
+
+    @staticmethod
+    def _normalise_timestamp(value: Any) -> float:
+        """Convert *value* to a float timestamp, falling back to ``time.time``."""
+
+        if value is None:
+            return time.time()
+        if isinstance(value, (int, float)):
+            if math.isfinite(value):
+                return float(value)
+            return time.time()
+        try:
+            converted = float(value)
+        except (TypeError, ValueError):
+            return time.time()
+        if math.isfinite(converted):
+            return converted
+        return time.time()
 
 
 def _stringify(value: Any) -> Any:

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -1,4 +1,28 @@
-from huey.hardware.plugins import SensorReading
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+REPO_STR = str(REPO_ROOT)
+SRC_STR = str(SRC_ROOT)
+if REPO_STR not in sys.path:
+    sys.path.insert(0, REPO_STR)
+if SRC_STR not in sys.path:
+    # Insert after the repository root so our vendored ``huey`` package wins
+    sys.path.insert(1 if sys.path else 0, SRC_STR)
+
+try:  # pragma: no cover - exercised indirectly when the package is available
+    from huey.hardware.plugins import SensorReading
+except ModuleNotFoundError:  # pragma: no cover - fallback for isolated test runs
+    @dataclass
+    class SensorReading:  # type: ignore[override]
+        name: str
+        value: Any
+        timestamp: Optional[float] = None
+        provenance: Optional[Dict[str, Any]] = None
+
 from monkey_head.utils.persistence import TelemetryStore
 
 
@@ -32,3 +56,17 @@ def test_telemetry_store_sensor_and_ai(tmp_path):
 
     events = store.fetch_recent_events()
     assert events == []
+
+
+def test_telemetry_store_handles_invalid_sensor_timestamp(tmp_path):
+    class DummyReading:
+        name = "temperature"
+        value = 21.0
+        timestamp = "invalid"
+
+    store = TelemetryStore(tmp_path / "telemetry.db")
+    store.log_sensor_reading(DummyReading())
+
+    readings = store.fetch_recent_sensor_readings()
+    assert readings
+    assert isinstance(readings[0].timestamp, float)


### PR DESCRIPTION
## Summary
- normalise sensor timestamps before persisting telemetry so non-numeric values fall back to the current time
- add regression coverage for invalid sensor timestamps and make the telemetry store test runnable in isolation

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e6c3358cdc832b90f7bed86d3a58e0