### PR TITLE
Update minimum kernel requirement to 6.16.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@
 
 ## Overview
 
-HueyOS targets **Debian 13 “Trixie”** with a custom low‑latency kernel series **6.16.0‑huey**. It unifies modern AI agents, a codified constitutional framework, and retro hardware support in a single modular platform. Headless and GUI modes are supported.
+HueyOS targets **Debian 13 “Trixie”** with a custom low‑latency kernel series **6.16.4‑huey**. It unifies modern AI agents, a codified constitutional framework, and retro hardware support in a single modular platform. Headless and GUI modes are supported.
 
 **Highlights (as of 2025‑10‑05):**
 
-- **OS baseline:** Debian 13.0.0 (Trixie), custom kernel **6.16.0‑huey**
+- **OS baseline:** Debian 13.0.0 (Trixie), custom kernel **6.16.4‑huey**
 - **Python:** initial pin **3.13.5** (user‑upgradable post‑install)
 - **Desktop:** **MATE** + **LightDM**; preferred lightweight browser: **qutebrowser**; full browser: **Edge Dev**
 - **AI runtime:** **PyGPT‑net** (desktop orchestrator), **Ollama** (local LLMs), ROCm/AMDGPU where available

--- a/src/monkey_head/system_checks.py
+++ b/src/monkey_head/system_checks.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_DISTRO_ID = "debian"
 SUPPORTED_DISTRO_CODENAME = "trixie"
-MIN_KERNEL_VERSION = Version("6.16.0")
+MIN_KERNEL_VERSION = Version("6.16.4")
 MIN_PYTHON_VERSION = (3, 12)
 MAX_PYTHON_VERSION = (3, 14)
 REQUIRED_TOOLS: Tuple[str, ...] = ("git", "python3")


### PR DESCRIPTION
## Summary
- update the minimum kernel version check to require Linux 6.16.4
- refresh the documentation to advertise the 6.16.4-huey kernel baseline

## Testing
- PYTHONPATH=src pytest tests/test_system_checks_module.py

------
https://chatgpt.com/codex/tasks/task_e_68e7314eb5b8832b8e78312acc4a5c95