### PR TITLE
Document migration toward Debian Forky and kernel 6.17.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > **HueyOS** is a prototype robotic AI/OS that marries retro computing legacies with modern, modular hardware and a living constitutional framework. Huey is transparent by design, modular by necessity, and governed—not merely programmed—by the **Cloud Pyramid**.
 
-(UEFI-only - amd64 - Kernel 6.16.12 - Debian 13.0.0 Trixie)
+(UEFI-only - amd64 - Kernel 6.16.12 · Forky/6.17.x migration underway - Debian 13.0.0 Trixie)
 
 ![License](https://img.shields.io/badge/license-GPLv3-blue)
 ![Python](https://img.shields.io/badge/python-3.12–3.13-blue)
@@ -33,18 +33,18 @@
 
 ## Overview
 
-HueyOS targets **Debian 13 “Trixie”** with a custom low‑latency kernel series **6.16.12‑huey**. It unifies modern AI agents, a codified constitutional framework, and retro hardware support in a single modular platform. Headless and GUI modes are supported.
+HueyOS targets **Debian 13 “Trixie”** with a custom low‑latency kernel series **6.16.12‑huey** while the next milestone actively migrates the stack to **Debian “Forky”** with kernel **6.17.x**. It unifies modern AI agents, a codified constitutional framework, and retro hardware support in a single modular platform. Headless and GUI modes are supported.
 
 **Highlights (as of 2025‑10‑05):**
 
-- **OS baseline:** Debian 13.0.0 (Trixie), custom kernel **6.16.12‑huey**
+- **OS baseline:** Debian 13.0.0 (Trixie), custom kernel **6.16.12‑huey** → transitioning to **Debian 14 “Forky”** with kernel **6.17.x-huey**
 - **Python:** initial pin **3.13.5** (user‑upgradable post‑install)
 - **Desktop:** **MATE** + **LightDM**; preferred lightweight browser: **qutebrowser**; full browser: **Edge Dev**
 - **AI runtime:** **PyGPT‑net** (desktop orchestrator), **Ollama** (local LLMs), ROCm/AMDGPU where available
 - **Memory:** unified long‑term store via JSON logs + SQLite; reproducible telemetry; VNC via TigerVNC tunneled over SSH
 - **Networking:** prefer bonded Ethernet; Wi‑Fi only as fallback
 
-> **Lifecycle notice (2025‑10‑05):** Upstream kernel **6.16.x** has entered end‑of‑life. HueyOS stays pinned to **6.16.12** for production compliance while we begin validation on **kernel 6.17.x** and **Debian “Forky”** starting **2025‑10‑31**.
+> **Lifecycle notice (2025‑11‑15):** Upstream kernel **6.16.x** has entered end‑of‑life. HueyOS is actively switching its baseline to **kernel 6.17.x** on **Debian “Forky”**, keeping **6.16.12/Trixie** builds online only until migration certification completes.
 
 **Core Principles**
 

--- a/huey/memory/MD/HARDWARE.md
+++ b/huey/memory/MD/HARDWARE.md
@@ -1,4 +1,4 @@
-# Hardware Enablement Guide — Huey OS (Debian Trixie · Kernel 6.16.12)
+# Hardware Enablement Guide — Huey OS (Debian Trixie · Kernel 6.16.12 → Forky · Kernel 6.17.x migration)
 
 **System Platform**: Supermicro X9QRI-F+  
 **Chipset**: Intel C602  
@@ -8,10 +8,10 @@
 **Storage**: 2 × Kingston SSD 240 GB (RAID)  
 **Bluetooth**: ASUS USB-BT500  
 **Wi-Fi**: USB 2.4GHz adapter
-**OS Base**: Debian “Trixie” (testing)
-**Kernel**: Custom 6.16.12 RT with modular driver flags
+**OS Base**: Debian “Trixie” (testing) → migrating to Debian “Forky” (testing/next)
+**Kernel**: Custom 6.16.12 RT with modular driver flags → migrating to 6.17.x RT tree
 
-> **Lifecycle update:** Kernel **6.16.x** has reached upstream EOL. Production images remain on **6.16.12** while validation of **6.17.x** and **Debian “Forky”** begins on **2025-10-31**.
+> **Lifecycle update:** Kernel **6.16.x** has reached upstream EOL. Production images remain on **6.16.12** while the migration to **6.17.x** on **Debian “Forky”** is now underway (validation window kicked off **2025-10-31**).
 
 ---
 
@@ -81,6 +81,7 @@
    ```
 
 3. **Build Custom Kernel 6.16.12**
+   - _Transition note:_ 6.17.x RT configs are staged in `huey/memory/SH/` for the Forky switchover; keep both trees buildable until the final cutover.
    Minimum `.config` flags:
    - `CONFIG_AHCI`
    - `CONFIG_XHCI_HCD`

--- a/huey/memory/SH/build_huey_iso.sh
+++ b/huey/memory/SH/build_huey_iso.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 # This script builds a UEFI-only amd64 ISO using Debian live-build
 # and a custom Linux kernel version 6.16.12. It is adapted from the
-# user‑provided instructions. Because this container environment
+# user‑provided instructions while being prepped for the Debian “Forky” /
+# kernel 6.17.x migration (comments note the pending switch while 6.16.x
+# remains the production floor). Because this container environment
 # doesn't provide a Windows filesystem under /mnt/c, the output
 # directory (OUTWIN) is pointed at the shared folder so that the ISO
 # and its extracted contents can be accessed from outside the


### PR DESCRIPTION
## Summary
- highlight the active migration from Debian Trixie/6.16.x to Debian Forky/6.17.x in the main README overview and lifecycle notice
- update the hardware enablement guide with transition notes covering the new Debian Forky and kernel 6.17.x targets
- annotate the ISO build script comments to flag the forthcoming Forky/6.17.x switch while 6.16.x remains production

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f015c57868832bb33ec8c7901f5909