### PR TITLE
Add standardized project headers across scripts

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Conftest module
+
 """Pytest hooks providing minimal asyncio support for the tests."""
 from __future__ import annotations
 

--- a/docker/orchestrator_utils.py
+++ b/docker/orchestrator_utils.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Orchestrator Utils module (docker)
+
 """Shared helpers for the HostOS/SubOS/NanoOS orchestrators."""
 from __future__ import annotations
 

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for fastapi
+
 """Tiny FastAPI-compatible shim for the unit tests.
 
 The real framework is extensive, however the tests in this kata only exercise a

--- a/fastapi/responses/__init__.py
+++ b/fastapi/responses/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for fastapi/responses
+
 """Minimal subset of ``fastapi.responses`` used in the tests."""
 from __future__ import annotations
 

--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for httpx
+
 """Minimal subset of the ``httpx`` API tailored for the test-suite."""
 from __future__ import annotations
 

--- a/huey/__init__.py
+++ b/huey/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey
+
 """Monkey Head compatibility package."""
 
 from __future__ import annotations

--- a/huey/agents/__init__.py
+++ b/huey/agents/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/agents
+
 """Agent implementations used by HueyOS."""
 
 from .presidential import (

--- a/huey/agents/llm.py
+++ b/huey/agents/llm.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Llm module (huey/agents)
+
 """Abstractions for interacting with LLM providers via the pygpt-MHP stack."""
 
 from __future__ import annotations

--- a/huey/agents/memory.py
+++ b/huey/agents/memory.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Memory module (huey/agents)
+
 """Utilities for persisting agent state within the honeycomb memory."""
 
 from __future__ import annotations

--- a/huey/agents/presidential.py
+++ b/huey/agents/presidential.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Presidential module (huey/agents)
+
 """Bicameral presidential agent structure for HueyOS."""
 
 from __future__ import annotations

--- a/huey/core/__init__.py
+++ b/huey/core/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/core
+
 """Core utilities for the Monkey Head compatibility layer."""
 
 from __future__ import annotations

--- a/huey/core/messaging.py
+++ b/huey/core/messaging.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Messaging module (huey/core)
+
 """Messaging protocol primitives for inter-component communication.
 
 This module defines the internal envelope structure used by HueyOS

--- a/huey/core/resilience.py
+++ b/huey/core/resilience.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Resilience module (huey/core)
+
 """Resilience and emergency management utilities for HueyOS.
 
 This module centralises the logic required to monitor long running

--- a/huey/core/system_checks.py
+++ b/huey/core/system_checks.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: System Checks module (huey/core)
+
 """Compatibility layer for :mod:`monkey_head.system_checks`."""
 
 from __future__ import annotations

--- a/huey/core/task_scheduler.py
+++ b/huey/core/task_scheduler.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Task Scheduler module (huey/core)
+
 """Task scheduling and resource aware assignment for HueyOS agents."""
 
 from __future__ import annotations

--- a/huey/function_registry.py
+++ b/huey/function_registry.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Function Registry module (huey)
+
 """Simple function registry used by high level utilities."""
 
 from __future__ import annotations

--- a/huey/hardware/__init__.py
+++ b/huey/hardware/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/hardware
+
 """Hardware integration layer for HueyOS.
 
 This package provides abstractions around sensors and actuators along with

--- a/huey/hardware/drivers.py
+++ b/huey/hardware/drivers.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Drivers module (huey/hardware)
+
 """Built-in sensor and actuator plugins leveraging common robotics libraries."""
 
 from __future__ import annotations

--- a/huey/hardware/manager.py
+++ b/huey/hardware/manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Manager module (huey/hardware)
+
 """Sensor manager coordinating plugin lifecycle and telemetry logging."""
 
 from __future__ import annotations

--- a/huey/hardware/plugins.py
+++ b/huey/hardware/plugins.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Plugins module (huey/hardware)
+
 """Plugin infrastructure for HueyOS hardware integrations."""
 
 from __future__ import annotations

--- a/huey/honeycomb_backup.py
+++ b/huey/honeycomb_backup.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Honeycomb Backup module (huey)
+
 """Backup and replication helpers for honeycomb memory."""
 
 from __future__ import annotations

--- a/huey/honeycomb_index.py
+++ b/huey/honeycomb_index.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Honeycomb Index module (huey)
+
 """Content aware indexing helpers for :class:`HoneycombStorage`."""
 
 from __future__ import annotations

--- a/huey/honeycomb_monitor.py
+++ b/huey/honeycomb_monitor.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Honeycomb Monitor module (huey)
+
 """Monitoring helpers for analysing honeycomb memory utilisation."""
 
 from __future__ import annotations

--- a/huey/honeycomb_retention.py
+++ b/huey/honeycomb_retention.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Honeycomb Retention module (huey)
+
 """Retention policy helpers for honeycomb storage."""
 
 from __future__ import annotations

--- a/huey/honeycomb_storage.py
+++ b/huey/honeycomb_storage.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Honeycomb Storage module (huey)
+
 """Honeycomb inspired structured storage for HueyOS agents."""
 
 from __future__ import annotations

--- a/huey/legacy/__init__.py
+++ b/huey/legacy/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/legacy
+
 """Legacy hardware integration helpers for HueyOS."""
 
 from .connectors import (

--- a/huey/legacy/connectors.py
+++ b/huey/legacy/connectors.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Connectors module (huey/legacy)
+
 """Legacy system connector abstractions.
 
 The HueyOS codex references Commodore and other retro systems that need to

--- a/huey/logging_setup.py
+++ b/huey/logging_setup.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Logging Setup module (huey)
+
 """Logging helpers for the Monkey Head compatibility layer."""
 
 from __future__ import annotations

--- a/huey/memory/BAT/build.bat
+++ b/huey/memory/BAT/build.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Build batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/build_all.bat
+++ b/huey/memory/BAT/build_all.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Build All batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/build_installer.bat
+++ b/huey/memory/BAT/build_installer.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Build Installer batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/git-install.bat
+++ b/huey/memory/BAT/git-install.bat
@@ -1,1 +1,6 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Git Install batch script (huey/memory/BAT)
+
 winget install --id Git.Git -e --source winget

--- a/huey/memory/BAT/install.bat
+++ b/huey/memory/BAT/install.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Install batch script (huey/memory/BAT)
+
 @echo off
 REM ==================================================
 REM This file is a part of the 'Monkey Head Project'

--- a/huey/memory/BAT/make.bat
+++ b/huey/memory/BAT/make.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Make batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/mkv-mp3.bat
+++ b/huey/memory/BAT/mkv-mp3.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Mkv Mp3 batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/moviepy.bat
+++ b/huey/memory/BAT/moviepy.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Moviepy batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/pygpt-launch-&-update.bat
+++ b/huey/memory/BAT/pygpt-launch-&-update.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Pygpt Launch & Update batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/pygpt-launch.bat
+++ b/huey/memory/BAT/pygpt-launch.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Pygpt Launch batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/pygpt-update.bat
+++ b/huey/memory/BAT/pygpt-update.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Pygpt Update batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/run-tests.bat
+++ b/huey/memory/BAT/run-tests.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Run Tests batch script (huey/memory/BAT)
+
 @echo off
 REM ==================================================
 REM This file is a part of the 'Monkey Head Project'

--- a/huey/memory/BAT/run.bat
+++ b/huey/memory/BAT/run.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Run batch script (huey/memory/BAT)
+
 @echo off
 REM ==================================================
 REM This file is a part of the 'Monkey Head Project'

--- a/huey/memory/BAT/shortcut.bat
+++ b/huey/memory/BAT/shortcut.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Shortcut batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/BAT/uninstall.bat
+++ b/huey/memory/BAT/uninstall.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Uninstall batch script (huey/memory/BAT)
+
 @echo off
 REM ==================================================
 REM This file is a part of the 'Monkey Head Project'

--- a/huey/memory/BAT/winget-update.bat
+++ b/huey/memory/BAT/winget-update.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Winget Update batch script (huey/memory/BAT)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/huey/memory/PY/Huey.py
+++ b/huey/memory/PY/Huey.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Huey module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/__init__.py
+++ b/huey/memory/PY/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/memory/PY
+
 from .container_management import (
     build_docker_image,
     cleanup_images,

--- a/huey/memory/PY/ai_processor.py
+++ b/huey/memory/PY/ai_processor.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Ai Processor module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/ai_tools_gui.py
+++ b/huey/memory/PY/ai_tools_gui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Ai Tools Gui module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/auto-sort.py
+++ b/huey/memory/PY/auto-sort.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Auto Sort module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/backup_restore.py
+++ b/huey/memory/PY/backup_restore.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Backup Restore module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/chapter_splitter.py
+++ b/huey/memory/PY/chapter_splitter.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Chapter Splitter module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/chat_learning.py
+++ b/huey/memory/PY/chat_learning.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Chat Learning module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/check_inter_program_connectivity.py
+++ b/huey/memory/PY/check_inter_program_connectivity.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Check Inter Program Connectivity module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/cli.py
+++ b/huey/memory/PY/cli.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Cli module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/cli_print.py
+++ b/huey/memory/PY/cli_print.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Cli Print module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/cloud_pyramid.py
+++ b/huey/memory/PY/cloud_pyramid.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Cloud Pyramid module (huey/memory/PY)
+
 """Simplified implementation of the Cloud Pyramid governance system."""
 
 from __future__ import annotations

--- a/huey/memory/PY/commands.py
+++ b/huey/memory/PY/commands.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Commands module (huey/memory/PY)
+
 from __future__ import annotations
 
 import subprocess

--- a/huey/memory/PY/config.py
+++ b/huey/memory/PY/config.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Config module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/config_manager.py
+++ b/huey/memory/PY/config_manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Config Manager module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/config_toggle_gui.py
+++ b/huey/memory/PY/config_toggle_gui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Config Toggle Gui module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/container_management.py
+++ b/huey/memory/PY/container_management.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Container Management module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/convert_mkv_to_mp4.py
+++ b/huey/memory/PY/convert_mkv_to_mp4.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Convert Mkv To Mp4 module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/convert_pdf_to_text.py
+++ b/huey/memory/PY/convert_pdf_to_text.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Convert Pdf To Text module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/convert_png_to_jpeg.py
+++ b/huey/memory/PY/convert_png_to_jpeg.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Convert Png To Jpeg module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/convert_video_to_gif.py
+++ b/huey/memory/PY/convert_video_to_gif.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Convert Video To Gif module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/custom_launcher.py
+++ b/huey/memory/PY/custom_launcher.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Custom Launcher module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/dashboard.py
+++ b/huey/memory/PY/dashboard.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Dashboard module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/environment_setup.py
+++ b/huey/memory/PY/environment_setup.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Environment Setup module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/error_handler.py
+++ b/huey/memory/PY/error_handler.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Error Handler module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/example_audio_input.py
+++ b/huey/memory/PY/example_audio_input.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Example Audio Input module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/example_audio_output.py
+++ b/huey/memory/PY/example_audio_output.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Example Audio Output module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/example_data_loader.py
+++ b/huey/memory/PY/example_data_loader.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Example Data Loader module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/example_llm.py
+++ b/huey/memory/PY/example_llm.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Example Llm module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/example_plugin.py
+++ b/huey/memory/PY/example_plugin.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Example Plugin module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/example_tool.py
+++ b/huey/memory/PY/example_tool.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Example Tool module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/example_vector_store.py
+++ b/huey/memory/PY/example_vector_store.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Example Vector Store module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/example_web_search.py
+++ b/huey/memory/PY/example_web_search.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Example Web Search module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/exceptions.py
+++ b/huey/memory/PY/exceptions.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Exceptions module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/file_manager.py
+++ b/huey/memory/PY/file_manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: File Manager module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/formatter.py
+++ b/huey/memory/PY/formatter.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Formatter module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/formatter_temp.py
+++ b/huey/memory/PY/formatter_temp.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Formatter Temp module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/fresh_install.py
+++ b/huey/memory/PY/fresh_install.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Fresh Install module (huey/memory/PY)
+
 """Run a clean reinstall of the Monkey Head Project."""
 from __future__ import annotations
 

--- a/huey/memory/PY/function_registry.py
+++ b/huey/memory/PY/function_registry.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Function Registry module (huey/memory/PY)
+
 from __future__ import annotations
 
 from typing import Callable, Dict, List

--- a/huey/memory/PY/gui_scaling.py
+++ b/huey/memory/PY/gui_scaling.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Gui Scaling module (huey/memory/PY)
+
 """Utilities for scaling Tkinter GUIs on high-DPI displays."""
 
 import os

--- a/huey/memory/PY/hardware_interface.py
+++ b/huey/memory/PY/hardware_interface.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Hardware Interface module (huey/memory/PY)
+
 """Unified hardware command interface across HostOS, SubOS and NanoOS."""
 
 from __future__ import annotations

--- a/huey/memory/PY/home_assistant.py
+++ b/huey/memory/PY/home_assistant.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Home Assistant module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/honeycomb_storage.py
+++ b/huey/memory/PY/honeycomb_storage.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Honeycomb Storage module (huey/memory/PY)
+
 """Honeycomb style storage system with simple clustering and replication."""
 
 from __future__ import annotations

--- a/huey/memory/PY/huey_checks.py
+++ b/huey/memory/PY/huey_checks.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Huey Checks module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/huey_core.py
+++ b/huey/memory/PY/huey_core.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Huey Core module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/huey_core_data.py
+++ b/huey/memory/PY/huey_core_data.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Huey Core Data module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/huey_disk_manager_temp.py
+++ b/huey/memory/PY/huey_disk_manager_temp.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Huey Disk Manager Temp module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/huey_linux.py
+++ b/huey/memory/PY/huey_linux.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Huey Linux module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/huey_remover.py
+++ b/huey/memory/PY/huey_remover.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Huey Remover module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/huey_tkinter.py
+++ b/huey/memory/PY/huey_tkinter.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Huey Tkinter module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/installations.py
+++ b/huey/memory/PY/installations.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Installations module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/installer.py
+++ b/huey/memory/PY/installer.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Installer module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/integrity.py
+++ b/huey/memory/PY/integrity.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Integrity module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/launcher.py
+++ b/huey/memory/PY/launcher.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Launcher module (huey/memory/PY)
+
 """Unified launcher for the Monkey Head Project."""
 
 from __future__ import annotations

--- a/huey/memory/PY/license_cli.py
+++ b/huey/memory/PY/license_cli.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: License Cli module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/license_gui.py
+++ b/huey/memory/PY/license_gui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: License Gui module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/list_by_mtime.py
+++ b/huey/memory/PY/list_by_mtime.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: List By Mtime module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/list_registered_functions.py
+++ b/huey/memory/PY/list_registered_functions.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: List Registered Functions module (huey/memory/PY)
+
 """Print functions registered in ``monkey_head.function_registry``."""
 
 from monkey_head.function_registry import list_functions

--- a/huey/memory/PY/logger.py
+++ b/huey/memory/PY/logger.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Logger module (huey/memory/PY)
+
 """Centralized logging utilities for Monkey Head."""
 
 import logging

--- a/huey/memory/PY/logging_setup.py
+++ b/huey/memory/PY/logging_setup.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Logging Setup module (huey/memory/PY)
+
 import logging
 import logging.handlers
 import os

--- a/huey/memory/PY/main.py
+++ b/huey/memory/PY/main.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Main module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/main_ui.py
+++ b/huey/memory/PY/main_ui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Main Ui module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/media_conversion.py
+++ b/huey/memory/PY/media_conversion.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Media Conversion module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/mini-chat-gui.py
+++ b/huey/memory/PY/mini-chat-gui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Mini Chat Gui module (huey/memory/PY)
+
 import tkinter as tk
 from tkinter import scrolledtext
 

--- a/huey/memory/PY/pdf_chat.py
+++ b/huey/memory/PY/pdf_chat.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Pdf Chat module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/pdf_pre_digestion.py
+++ b/huey/memory/PY/pdf_pre_digestion.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Pdf Pre Digestion module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/pdf_utils.py
+++ b/huey/memory/PY/pdf_utils.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Pdf Utils module (huey/memory/PY)
+
 """Utilities for handling project PDF documents."""
 
 from __future__ import annotations

--- a/huey/memory/PY/preload_data.py
+++ b/huey/memory/PY/preload_data.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Preload Data module (huey/memory/PY)
+
 import csv
 from pathlib import Path
 from typing import Dict, List

--- a/huey/memory/PY/pygpt_custom_cli.py
+++ b/huey/memory/PY/pygpt_custom_cli.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Pygpt Custom Cli module (huey/memory/PY)
+
 from pathlib import Path
 
 

--- a/huey/memory/PY/pygpt_memory.py
+++ b/huey/memory/PY/pygpt_memory.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Pygpt Memory module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/repair.py
+++ b/huey/memory/PY/repair.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Repair module (huey/memory/PY)
+
 """Repair the Monkey Head Project by reinstalling from a fresh clone."""
 from __future__ import annotations
 

--- a/huey/memory/PY/resources.py
+++ b/huey/memory/PY/resources.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Resources module (huey/memory/PY)
+
 import os
 
 

--- a/huey/memory/PY/run.py
+++ b/huey/memory/PY/run.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Run module (huey/memory/PY)
+
 """Entry point wrapper for the legacy :mod:`monkey_head.run` module."""
 
 from __future__ import annotations

--- a/huey/memory/PY/set_api_keys.py
+++ b/huey/memory/PY/set_api_keys.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Set Api Keys module (huey/memory/PY)
+
 import json
 import os
 

--- a/huey/memory/PY/setup.py
+++ b/huey/memory/PY/setup.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Setup module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/simple_chat_gui.py
+++ b/huey/memory/PY/simple_chat_gui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Simple Chat Gui module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/sorting.py
+++ b/huey/memory/PY/sorting.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Sorting module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/startup.py
+++ b/huey/memory/PY/startup.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Startup module (huey/memory/PY)
+
 """Convenient startup entry point for the Monkey Head Project."""
 
 from __future__ import annotations

--- a/huey/memory/PY/storage_management.py
+++ b/huey/memory/PY/storage_management.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Storage Management module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/subos_manager.py
+++ b/huey/memory/PY/subos_manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Subos Manager module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/sync_pygpt_structure.py
+++ b/huey/memory/PY/sync_pygpt_structure.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Sync Pygpt Structure module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/system_checks.py
+++ b/huey/memory/PY/system_checks.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: System Checks module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/tensorflow_feed.py
+++ b/huey/memory/PY/tensorflow_feed.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Tensorflow Feed module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/uninstaller.py
+++ b/huey/memory/PY/uninstaller.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Uninstaller module (huey/memory/PY)
+
 """Cross-platform uninstaller for the Monkey Head Project."""
 import os
 import platform

--- a/huey/memory/PY/update_memory_pdfs.py
+++ b/huey/memory/PY/update_memory_pdfs.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Update Memory Pdfs module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/update_prompts.py
+++ b/huey/memory/PY/update_prompts.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Update Prompts module (huey/memory/PY)
+
 import csv
 import re
 import os

--- a/huey/memory/PY/update_sources_to_trixie.py
+++ b/huey/memory/PY/update_sources_to_trixie.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Update Sources To Trixie module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/updates.py
+++ b/huey/memory/PY/updates.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Updates module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/utils.py
+++ b/huey/memory/PY/utils.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Utils module (huey/memory/PY)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/PY/vic2_demo.py
+++ b/huey/memory/PY/vic2_demo.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Vic2 Demo module (huey/memory/PY)
+
 """Simple VIC-II graphics demo for Raspberry Pi 3/4.
 
 This script opens a 320x200 window using the classic Commodore 64

--- a/huey/memory/SH/Huey.sh
+++ b/huey/memory/SH/Huey.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Huey shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/build-en.sh
+++ b/huey/memory/SH/build-en.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Build En shell script (huey/memory/SH)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/SH/build-pl.sh
+++ b/huey/memory/SH/build-pl.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Build Pl shell script (huey/memory/SH)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/SH/build.sh
+++ b/huey/memory/SH/build.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Build shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/build_huey_iso.sh
+++ b/huey/memory/SH/build_huey_iso.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Build Huey Iso shell script (huey/memory/SH)
+
 set -euo pipefail
 
 # This script builds a UEFI-only amd64 ISO using Debian live-build

--- a/huey/memory/SH/clean.sh
+++ b/huey/memory/SH/clean.sh
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Clean shell script (huey/memory/SH)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/SH/docker_cleanup.sh
+++ b/huey/memory/SH/docker_cleanup.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Docker Cleanup shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/docker_dev_setup.sh
+++ b/huey/memory/SH/docker_dev_setup.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Docker Dev Setup shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/docker_setup.sh
+++ b/huey/memory/SH/docker_setup.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Docker Setup shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/install.sh
+++ b/huey/memory/SH/install.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Install shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/k8s_cleanup.sh
+++ b/huey/memory/SH/k8s_cleanup.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: K8S Cleanup shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/k8s_setup.sh
+++ b/huey/memory/SH/k8s_setup.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: K8S Setup shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/rebuild-lang.sh
+++ b/huey/memory/SH/rebuild-lang.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Rebuild Lang shell script (huey/memory/SH)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/SH/resources.sh
+++ b/huey/memory/SH/resources.sh
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Resources shell script (huey/memory/SH)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/SH/rst_to_md.sh
+++ b/huey/memory/SH/rst_to_md.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Rst To Md shell script (huey/memory/SH)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/SH/run-tests.sh
+++ b/huey/memory/SH/run-tests.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Run Tests shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/run.sh
+++ b/huey/memory/SH/run.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Run shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/shortcut.sh
+++ b/huey/memory/SH/shortcut.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Shortcut shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/snaprun.sh
+++ b/huey/memory/SH/snaprun.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Snaprun shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/sort_locale.sh
+++ b/huey/memory/SH/sort_locale.sh
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Sort Locale shell script (huey/memory/SH)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/memory/SH/uninstall.sh
+++ b/huey/memory/SH/uninstall.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Uninstall shell script (huey/memory/SH)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/huey/memory/SH/update.sh
+++ b/huey/memory/SH/update.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Update shell script (huey/memory/SH)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/huey/network/__init__.py
+++ b/huey/network/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/network
+
 """Network management utilities with wired-first preference."""
 
 from .manager import NetworkManager, NetworkStatus

--- a/huey/network/manager.py
+++ b/huey/network/manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Manager module (huey/network)
+
 """Network manager that prefers wired connections with Wi-Fi failover."""
 
 from __future__ import annotations

--- a/huey/pdf_utils.py
+++ b/huey/pdf_utils.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Pdf Utils module (huey)
+
 """Utilities for handling project PDF documents."""
 
 from __future__ import annotations

--- a/huey/power/__init__.py
+++ b/huey/power/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/power
+
 """Power management utilities for HueyOS."""
 
 from .management import BatteryMonitor, PowerEvent

--- a/huey/power/management.py
+++ b/huey/power/management.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Management module (huey/power)
+
 """Battery monitoring and safe shutdown routines."""
 
 from __future__ import annotations

--- a/huey/pygpt_custom_cli.py
+++ b/huey/pygpt_custom_cli.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Pygpt Custom Cli module (huey)
+
 """Lightweight CLI integration mimicking the legacy PyGPT launcher."""
 
 from __future__ import annotations

--- a/huey/pygpt_memory.py
+++ b/huey/pygpt_memory.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Pygpt Memory module (huey)
+
 """Simplified conversation memory helpers for Monkey Head's PyGPT integration."""
 
 from __future__ import annotations

--- a/huey/pygpt_net/__init__.py
+++ b/huey/pygpt_net/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net
+
 """Minimal stub of the :mod:`pygpt_net` package for integration tests."""
 
 from __future__ import annotations

--- a/huey/pygpt_net/app.py
+++ b/huey/pygpt_net/app.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: App module (huey/pygpt_net)
+
 """Stub application runner compatible with Monkey Head integration tests."""
 
 from __future__ import annotations

--- a/huey/pygpt_net/controller/__init__.py
+++ b/huey/pygpt_net/controller/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/controller
+
 """Controller shims for mirrored PyGPT configuration modules."""
 
 __all__ = []

--- a/huey/pygpt_net/controller/agent/__init__.py
+++ b/huey/pygpt_net/controller/agent/__init__.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/controller/agent
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/controller/agent/common.py
+++ b/huey/pygpt_net/controller/agent/common.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Common module (huey/pygpt_net/controller/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/controller/agent/experts.py
+++ b/huey/pygpt_net/controller/agent/experts.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Experts module (huey/pygpt_net/controller/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/controller/agent/legacy.py
+++ b/huey/pygpt_net/controller/agent/legacy.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Legacy module (huey/pygpt_net/controller/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/controller/agent/llama.py
+++ b/huey/pygpt_net/controller/agent/llama.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Llama module (huey/pygpt_net/controller/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/controller/config/__init__.py
+++ b/huey/pygpt_net/controller/config/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/controller/config
+
 """Configuration helpers for the mirrored PyGPT controller."""
 
 __all__ = ["placeholder"]

--- a/huey/pygpt_net/controller/config/placeholder.py
+++ b/huey/pygpt_net/controller/config/placeholder.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Placeholder module (huey/pygpt_net/controller/config)
+
 """Placeholder utilities mirrored from the PyGPT configuration tree."""
 
 from __future__ import annotations

--- a/huey/pygpt_net/core/agents/__init__.py
+++ b/huey/pygpt_net/core/agents/__init__.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/core/agents
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/core/agents/legacy.py
+++ b/huey/pygpt_net/core/agents/legacy.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Legacy module (huey/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/core/agents/memory.py
+++ b/huey/pygpt_net/core/agents/memory.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Memory module (huey/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/core/agents/observer/__init__.py
+++ b/huey/pygpt_net/core/agents/observer/__init__.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/core/agents/observer
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/core/agents/observer/evaluation.py
+++ b/huey/pygpt_net/core/agents/observer/evaluation.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Evaluation module (huey/pygpt_net/core/agents/observer)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/core/agents/provider.py
+++ b/huey/pygpt_net/core/agents/provider.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Provider module (huey/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/core/agents/runner.py
+++ b/huey/pygpt_net/core/agents/runner.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Runner module (huey/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/core/agents/tools.py
+++ b/huey/pygpt_net/core/agents/tools.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Tools module (huey/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/item/__init__.py
+++ b/huey/pygpt_net/item/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/item
+
 """Expose simple data structures used by Monkey Head tests."""
 
 from __future__ import annotations

--- a/huey/pygpt_net/item/preset.py
+++ b/huey/pygpt_net/item/preset.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Preset module (huey/pygpt_net/item)
+
 """Simplified preset data model used for testing integrations."""
 
 from __future__ import annotations

--- a/huey/pygpt_net/plugin/agent/__init__.py
+++ b/huey/pygpt_net/plugin/agent/__init__.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/plugin/agent
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/plugin/agent/config.py
+++ b/huey/pygpt_net/plugin/agent/config.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Config module (huey/pygpt_net/plugin/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/provider/agents/__init__.py
+++ b/huey/pygpt_net/provider/agents/__init__.py
@@ -1,0 +1,5 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/provider/agents
+

--- a/huey/pygpt_net/provider/agents/base.py
+++ b/huey/pygpt_net/provider/agents/base.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Base module (huey/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/provider/agents/openai.py
+++ b/huey/pygpt_net/provider/agents/openai.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Openai module (huey/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/provider/agents/openai_assistant.py
+++ b/huey/pygpt_net/provider/agents/openai_assistant.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Openai Assistant module (huey/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/provider/agents/planner.py
+++ b/huey/pygpt_net/provider/agents/planner.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Planner module (huey/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/provider/agents/react.py
+++ b/huey/pygpt_net/provider/agents/react.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: React module (huey/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/tools/__init__.py
+++ b/huey/pygpt_net/tools/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/tools
+
 """Tool shims that integrate Monkey Head with the PyGPT stub."""
 
 from __future__ import annotations

--- a/huey/pygpt_net/tools/manager.py
+++ b/huey/pygpt_net/tools/manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Manager module (huey/pygpt_net/tools)
+
 """Minimal Monkey Head manager tool for the PyGPT stub environment."""
 
 from __future__ import annotations

--- a/huey/pygpt_net/tools/manager/__init__.py
+++ b/huey/pygpt_net/tools/manager/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/pygpt_net/tools/manager
+
 from __future__ import annotations
 import platform
 import subprocess

--- a/huey/pygpt_net/ui/layout/toolbox/agent.py
+++ b/huey/pygpt_net/ui/layout/toolbox/agent.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Agent module (huey/pygpt_net/ui/layout/toolbox)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/pygpt_net/ui/layout/toolbox/agent_llama.py
+++ b/huey/pygpt_net/ui/layout/toolbox/agent_llama.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Agent Llama module (huey/pygpt_net/ui/layout/toolbox)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/huey/run.py
+++ b/huey/run.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Run module (huey)
+
 """Runtime entry points integrating the PyGPT stack with Monkey Head."""
 
 from __future__ import annotations

--- a/huey/scripts/__init__.py
+++ b/huey/scripts/__init__.py
@@ -1,1 +1,6 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/scripts
+
 """Command line entry points for Monkey Head utilities."""

--- a/huey/scripts/auto_sort.py
+++ b/huey/scripts/auto_sort.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Auto Sort module (huey/scripts)
+
 """CLI for the :func:`monkey_head.utils.auto_sort.auto_sort_memory` helper."""
 
 from __future__ import annotations

--- a/huey/scripts/failover.py
+++ b/huey/scripts/failover.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Failover module (huey/scripts)
+
 """Dual-motherboard failover orchestration utilities.
 
 The HueyOS hardware topology includes redundant motherboards. This module

--- a/huey/services/__init__.py
+++ b/huey/services/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/services
+
 """Service layer utilities for Monkey Head."""
 
 from __future__ import annotations

--- a/huey/services/container_management.py
+++ b/huey/services/container_management.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Container Management module (huey/services)
+
 """Utility helpers for orchestrating external container and cluster tooling."""
 
 from __future__ import annotations

--- a/huey/system_checks.py
+++ b/huey/system_checks.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: System Checks module (huey)
+
 """System environment checks for the Monkey Head compatibility layer."""
 
 from __future__ import annotations

--- a/huey/utils/__init__.py
+++ b/huey/utils/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey/utils
+
 """Utility helpers for the Monkey Head compatibility layer."""
 
 from .paths import get_memory_path, get_logs_dir, ensure_subdirectory

--- a/huey/utils/auto_sort.py
+++ b/huey/utils/auto_sort.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Auto Sort module (huey/utils)
+
 """Utilities for organising files stored in the shared memory directory."""
 
 from __future__ import annotations

--- a/huey/utils/paths.py
+++ b/huey/utils/paths.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Paths module (huey/utils)
+
 """Filesystem helpers for managing shared project directories."""
 
 from __future__ import annotations

--- a/install/gtk/install.bat
+++ b/install/gtk/install.bat
@@ -1,1 +1,6 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Install batch script (install/gtk)
+
 \tools\loadlin.exe \install\vmlinuz initrd=initrd.gz vga=788

--- a/install/install.bat
+++ b/install/install.bat
@@ -1,1 +1,6 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Install batch script (install)
+
 \tools\loadlin.exe vmlinuz initrd=initrd.gz

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for pydantic
+
 """Lightweight stand-in for the ``pydantic`` package used in the tests.
 
 The real dependency is not available in the execution environment, but the

--- a/repo/pygpt-MHP/src/pygpt_net/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net
+
 """Minimal stub of the :mod:`pygpt_net` package for integration tests."""
 
 from __future__ import annotations

--- a/repo/pygpt-MHP/src/pygpt_net/app.py
+++ b/repo/pygpt-MHP/src/pygpt_net/app.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: App module (repo/pygpt-MHP/src/pygpt_net)
+
 """Stub application runner compatible with Monkey Head integration tests."""
 
 from __future__ import annotations

--- a/repo/pygpt-MHP/src/pygpt_net/controller/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/controller
+
 """Controller shims for mirrored PyGPT configuration modules."""
 
 __all__ = []

--- a/repo/pygpt-MHP/src/pygpt_net/controller/agent/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/agent/__init__.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/controller/agent
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/controller/agent/common.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/agent/common.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Common module (repo/pygpt-MHP/src/pygpt_net/controller/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/controller/agent/experts.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/agent/experts.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Experts module (repo/pygpt-MHP/src/pygpt_net/controller/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/controller/agent/legacy.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/agent/legacy.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Legacy module (repo/pygpt-MHP/src/pygpt_net/controller/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/controller/agent/llama.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/agent/llama.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Llama module (repo/pygpt-MHP/src/pygpt_net/controller/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/controller/config/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/config/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/controller/config
+
 """Configuration helpers for the mirrored PyGPT controller."""
 
 __all__ = ["placeholder"]

--- a/repo/pygpt-MHP/src/pygpt_net/controller/config/placeholder.py
+++ b/repo/pygpt-MHP/src/pygpt_net/controller/config/placeholder.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Placeholder module (repo/pygpt-MHP/src/pygpt_net/controller/config)
+
 """Placeholder utilities mirrored from the PyGPT configuration tree."""
 
 from __future__ import annotations

--- a/repo/pygpt-MHP/src/pygpt_net/core/agents/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/agents/__init__.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/core/agents
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/core/agents/legacy.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/agents/legacy.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Legacy module (repo/pygpt-MHP/src/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/core/agents/memory.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/agents/memory.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Memory module (repo/pygpt-MHP/src/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/core/agents/observer/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/agents/observer/__init__.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/core/agents/observer
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/core/agents/observer/evaluation.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/agents/observer/evaluation.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Evaluation module (repo/pygpt-MHP/src/pygpt_net/core/agents/observer)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/core/agents/provider.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/agents/provider.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Provider module (repo/pygpt-MHP/src/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/core/agents/runner.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/agents/runner.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Runner module (repo/pygpt-MHP/src/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/core/agents/tools.py
+++ b/repo/pygpt-MHP/src/pygpt_net/core/agents/tools.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Tools module (repo/pygpt-MHP/src/pygpt_net/core/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/item/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/item/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/item
+
 """Expose simple data structures used by Monkey Head tests."""
 
 from __future__ import annotations

--- a/repo/pygpt-MHP/src/pygpt_net/item/preset.py
+++ b/repo/pygpt-MHP/src/pygpt_net/item/preset.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Preset module (repo/pygpt-MHP/src/pygpt_net/item)
+
 """Simplified preset data model used for testing integrations."""
 
 from __future__ import annotations

--- a/repo/pygpt-MHP/src/pygpt_net/plugin/agent/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/plugin/agent/__init__.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/plugin/agent
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/plugin/agent/config.py
+++ b/repo/pygpt-MHP/src/pygpt_net/plugin/agent/config.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Config module (repo/pygpt-MHP/src/pygpt_net/plugin/agent)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/provider/agents/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/provider/agents/__init__.py
@@ -1,0 +1,5 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/provider/agents
+

--- a/repo/pygpt-MHP/src/pygpt_net/provider/agents/base.py
+++ b/repo/pygpt-MHP/src/pygpt_net/provider/agents/base.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Base module (repo/pygpt-MHP/src/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/provider/agents/openai.py
+++ b/repo/pygpt-MHP/src/pygpt_net/provider/agents/openai.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Openai module (repo/pygpt-MHP/src/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/provider/agents/openai_assistant.py
+++ b/repo/pygpt-MHP/src/pygpt_net/provider/agents/openai_assistant.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Openai Assistant module (repo/pygpt-MHP/src/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/provider/agents/planner.py
+++ b/repo/pygpt-MHP/src/pygpt_net/provider/agents/planner.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Planner module (repo/pygpt-MHP/src/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/provider/agents/react.py
+++ b/repo/pygpt-MHP/src/pygpt_net/provider/agents/react.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: React module (repo/pygpt-MHP/src/pygpt_net/provider/agents)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/tools/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/tools/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/tools
+
 """Tool shims that integrate Monkey Head with the PyGPT stub."""
 
 from __future__ import annotations

--- a/repo/pygpt-MHP/src/pygpt_net/tools/manager.py
+++ b/repo/pygpt-MHP/src/pygpt_net/tools/manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Manager module (repo/pygpt-MHP/src/pygpt_net/tools)
+
 """Minimal Monkey Head manager tool for the PyGPT stub environment."""
 
 from __future__ import annotations

--- a/repo/pygpt-MHP/src/pygpt_net/tools/manager/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/tools/manager/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for repo/pygpt-MHP/src/pygpt_net/tools/manager
+
 from __future__ import annotations
 import platform
 import subprocess

--- a/repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox/agent.py
+++ b/repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox/agent.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Agent module (repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox/agent_llama.py
+++ b/repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox/agent_llama.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Agent Llama module (repo/pygpt-MHP/src/pygpt_net/ui/layout/toolbox)
+
 # ================================================== #
 # This file is a part of PYGPT package               #
 # Website: https://pygpt.net                         #

--- a/run.py
+++ b/run.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Run module
+
 """Convenience proxy to expose the Huey runtime entry points at the project root."""
 
 from __future__ import annotations

--- a/setup/DebianTrixie/install.sh
+++ b/setup/DebianTrixie/install.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Install shell script (setup/DebianTrixie)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/setup/DebianTrixie/uninstall.sh
+++ b/setup/DebianTrixie/uninstall.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Uninstall shell script (setup/DebianTrixie)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/setup/DebianTrixie/update.sh
+++ b/setup/DebianTrixie/update.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Update shell script (setup/DebianTrixie)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/setup/Windows10/windows-remove-tool.bat
+++ b/setup/Windows10/windows-remove-tool.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Windows Remove Tool batch script (setup/Windows10)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/00-WIN11.bat
+++ b/setup/Windows11/00-WIN11.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 00 Win11 batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/01-FULL.bat
+++ b/setup/Windows11/01-FULL.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 01 Full batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/02-MINI.bat
+++ b/setup/Windows11/02-MINI.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 02 Mini batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/03-CLEANUP.bat
+++ b/setup/Windows11/03-CLEANUP.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 03 Cleanup batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/04-TERMINAL.bat
+++ b/setup/Windows11/04-TERMINAL.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 04 Terminal batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/05-UPDATE.bat
+++ b/setup/Windows11/05-UPDATE.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 05 Update batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/06-BUILD.bat
+++ b/setup/Windows11/06-BUILD.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 06 Build batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/07-CONTAINER.bat
+++ b/setup/Windows11/07-CONTAINER.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 07 Container batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/08-VOLUME.bat
+++ b/setup/Windows11/08-VOLUME.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 08 Volume batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/09-KUBERNETES.bat
+++ b/setup/Windows11/09-KUBERNETES.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 09 Kubernetes batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/10-START.bat
+++ b/setup/Windows11/10-START.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 10 Start batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/11-HOSTOS.bat
+++ b/setup/Windows11/11-HOSTOS.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 11 Hostos batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/12-SUBOS.bat
+++ b/setup/Windows11/12-SUBOS.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 12 Subos batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/13-NANOOS.bat
+++ b/setup/Windows11/13-NANOOS.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: 13 Nanoos batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/Windows11/EXIT.bat
+++ b/setup/Windows11/EXIT.bat
@@ -1,3 +1,8 @@
+REM Monkey Head Project
+REM By: Dylan L.R. Pollock
+REM www.dlrp.ca
+REM HueyOS: Exit batch script (setup/Windows11)
+
 # ==================================================  #
 # This file is a part of the 'Monkey Head Project'                                       #
 # Website:   https://dlrp.ca                                                                            #

--- a/setup/macOS/install.sh
+++ b/setup/macOS/install.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Install shell script (setup/macOS)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/setup/macOS/uninstall.sh
+++ b/setup/macOS/uninstall.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Uninstall shell script (setup/macOS)
+
 set -euo pipefail
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/src/huey/__init__.py
+++ b/src/huey/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for src/huey
+
 """Public surface for the HueyOS package."""
 
 __all__ = ["api"]

--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Api module (src/huey)
+
 """FastAPI application exposing the HueyOS control surface."""
 
 from __future__ import annotations

--- a/src/huey/cli.py
+++ b/src/huey/cli.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Cli module (src/huey)
+
 """Top-level command line interface for HueyOS."""
 
 from __future__ import annotations

--- a/src/monkey_head/__init__.py
+++ b/src/monkey_head/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for src/monkey_head
+
 """Compatibility package mapping the legacy :mod:`monkey_head` namespace."""
 
 from __future__ import annotations

--- a/src/monkey_head/core/__init__.py
+++ b/src/monkey_head/core/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for src/monkey_head/core
+
 """Core orchestration primitives for the Monkey Head compatibility layer."""
 
 from __future__ import annotations

--- a/src/monkey_head/core/resilience.py
+++ b/src/monkey_head/core/resilience.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Resilience module (src/monkey_head/core)
+
 """Compatibility wrapper for :mod:`huey.core.resilience`."""
 
 from __future__ import annotations

--- a/src/monkey_head/core/system_checks.py
+++ b/src/monkey_head/core/system_checks.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: System Checks module (src/monkey_head/core)
+
 """Compatibility wrapper for :mod:`huey.system_checks`."""
 
 from __future__ import annotations

--- a/src/monkey_head/core/task_scheduler.py
+++ b/src/monkey_head/core/task_scheduler.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Task Scheduler module (src/monkey_head/core)
+
 """Task scheduling and resource aware assignment for HueyOS agents."""
 
 from __future__ import annotations

--- a/src/monkey_head/hardware/__init__.py
+++ b/src/monkey_head/hardware/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for src/monkey_head/hardware
+
 """Compatibility package for hardware integrations."""
 
 from __future__ import annotations

--- a/src/monkey_head/hardware/manager.py
+++ b/src/monkey_head/hardware/manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Manager module (src/monkey_head/hardware)
+
 """Compatibility wrapper for :mod:`huey.hardware.manager`."""
 
 from __future__ import annotations

--- a/src/monkey_head/hardware/plugins.py
+++ b/src/monkey_head/hardware/plugins.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Plugins module (src/monkey_head/hardware)
+
 """Compatibility wrapper for :mod:`huey.hardware.plugins`."""
 
 from __future__ import annotations

--- a/src/monkey_head/honeycomb_index.py
+++ b/src/monkey_head/honeycomb_index.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Honeycomb Index module (src/monkey_head)
+
 """Content-aware indexing helpers for :class:`HoneycombStorage`."""
 
 from __future__ import annotations

--- a/src/monkey_head/honeycomb_monitor.py
+++ b/src/monkey_head/honeycomb_monitor.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Honeycomb Monitor module (src/monkey_head)
+
 """Monitoring helpers for analysing honeycomb memory utilisation."""
 
 from __future__ import annotations

--- a/src/monkey_head/honeycomb_storage.py
+++ b/src/monkey_head/honeycomb_storage.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Honeycomb Storage module (src/monkey_head)
+
 """File-backed honeycomb storage for structured agent memory."""
 
 from __future__ import annotations

--- a/src/monkey_head/network.py
+++ b/src/monkey_head/network.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Network module (src/monkey_head)
+
 """Network management helpers bridging to :mod:`huey.network.manager`."""
 
 from __future__ import annotations

--- a/src/monkey_head/pdf_utils.py
+++ b/src/monkey_head/pdf_utils.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Pdf Utils module (src/monkey_head)
+
 """PDF helper functions used by the HueyOS API."""
 
 from __future__ import annotations

--- a/src/monkey_head/power.py
+++ b/src/monkey_head/power.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Power module (src/monkey_head)
+
 """Power management helpers bridging to :mod:`huey.power.management`."""
 
 from __future__ import annotations

--- a/src/monkey_head/scripts/__init__.py
+++ b/src/monkey_head/scripts/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for src/monkey_head/scripts
+
 """Compatibility helpers for legacy management scripts."""
 
 from __future__ import annotations

--- a/src/monkey_head/scripts/preload_data.py
+++ b/src/monkey_head/scripts/preload_data.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Preload Data module (src/monkey_head/scripts)
+
 """Utility helpers for preloading reference data used by the tests."""
 
 from __future__ import annotations

--- a/src/monkey_head/services/__init__.py
+++ b/src/monkey_head/services/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for src/monkey_head/services
+
 """Compatibility layer for service management helpers."""
 
 from __future__ import annotations

--- a/src/monkey_head/services/environment_setup.py
+++ b/src/monkey_head/services/environment_setup.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Environment Setup module (src/monkey_head/services)
+
 """Minimal project environment management helpers used in tests."""
 
 from __future__ import annotations

--- a/src/monkey_head/services/home_assistant.py
+++ b/src/monkey_head/services/home_assistant.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Home Assistant module (src/monkey_head/services)
+
 """Minimal Home Assistant API helpers used by the test-suite."""
 
 from __future__ import annotations

--- a/src/monkey_head/system_checks.py
+++ b/src/monkey_head/system_checks.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: System Checks module (src/monkey_head)
+
 """System environment checks for the Monkey Head runtime."""
 
 from __future__ import annotations

--- a/src/monkey_head/utils/__init__.py
+++ b/src/monkey_head/utils/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for src/monkey_head/utils
+
 """Expose utility helpers while bridging legacy Monkey Head modules."""
 
 from __future__ import annotations

--- a/src/monkey_head/utils/auto_sort.py
+++ b/src/monkey_head/utils/auto_sort.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Auto Sort module (src/monkey_head/utils)
+
 """Compatibility wrapper around :mod:`huey.utils.auto_sort`."""
 
 from __future__ import annotations

--- a/src/monkey_head/utils/gpu.py
+++ b/src/monkey_head/utils/gpu.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Gpu module (src/monkey_head/utils)
+
 """Hardware accelerator detection utilities for HueyOS and Monkey Head."""
 
 from __future__ import annotations

--- a/src/monkey_head/utils/paths.py
+++ b/src/monkey_head/utils/paths.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Paths module (src/monkey_head/utils)
+
 """Compatibility wrapper around :mod:`huey.utils.paths`."""
 
 from __future__ import annotations

--- a/src/monkey_head/utils/persistence.py
+++ b/src/monkey_head/utils/persistence.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Persistence module (src/monkey_head/utils)
+
 """Persistent telemetry storage utilities."""
 
 from __future__ import annotations

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for tests
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/dummy_module.py
+++ b/tests/dummy_module.py
@@ -1,2 +1,7 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Dummy Module module (tests)
+
 def main():
     print("dummy module executed")

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Api Routes module (tests)
+
 """Tests for FastAPI application routes."""
 
 from __future__ import annotations

--- a/tests/test_auto_sort.py
+++ b/tests/test_auto_sort.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Auto Sort module (tests)
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_battery_hooks.py
+++ b/tests/test_battery_hooks.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Battery Hooks module (tests)
+
 from huey.power.management import BatteryMonitor
 
 

--- a/tests/test_chat_learning.py
+++ b/tests/test_chat_learning.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Chat Learning module (tests)
+
 import pytest
 
 tf = pytest.importorskip("tensorflow")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Cli module (tests)
+
 """Tests for the top-level huey CLI."""
 
 from __future__ import annotations

--- a/tests/test_cli_print.py
+++ b/tests/test_cli_print.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Cli Print module (tests)
+
 from monkey_head.cli_print import print_message
 import pytest
 

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Cli Run module (tests)
+
 from monkey_head.cli import CLI
 
 

--- a/tests/test_cloud_pyramid.py
+++ b/tests/test_cloud_pyramid.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Cloud Pyramid module (tests)
+
 from monkey_head.cloud_pyramid import CloudPyramid
 
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Config Manager module (tests)
+
 from monkey_head.config_manager import ConfigManager
 
 

--- a/tests/test_config_toggle_gui.py
+++ b/tests/test_config_toggle_gui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Config Toggle Gui module (tests)
+
 import json
 from monkey_head.config_toggle_gui import update_toggle_settings
 

--- a/tests/test_container_management_new.py
+++ b/tests/test_container_management_new.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Container Management New module (tests)
+
 from unittest.mock import patch
 import pytest
 

--- a/tests/test_convert_mkv_to_mp4.py
+++ b/tests/test_convert_mkv_to_mp4.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Convert Mkv To Mp4 module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_convert_pdf_to_text.py
+++ b/tests/test_convert_pdf_to_text.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Convert Pdf To Text module (tests)
+
 import importlib.util
 from pathlib import Path
 import shutil

--- a/tests/test_convert_png_to_jpeg.py
+++ b/tests/test_convert_png_to_jpeg.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Convert Png To Jpeg module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_convert_video_to_gif.py
+++ b/tests/test_convert_video_to_gif.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Convert Video To Gif module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_custom_pygpt_cli.py
+++ b/tests/test_custom_pygpt_cli.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Custom Pygpt Cli module (tests)
+
 from monkey_head.pygpt_custom_cli import CustomPyGPT
 
 

--- a/tests/test_environment_setup_git.py
+++ b/tests/test_environment_setup_git.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Environment Setup Git module (tests)
+
 from monkey_head.services.environment_setup import (
     clone_repository,
     checkout_branch,

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Error Handler module (tests)
+
 import importlib.util
 import logging
 import sys

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Failover module (tests)
+
 from pathlib import Path
 
 from monkey_head.scripts.failover import (

--- a/tests/test_file_sorter.py
+++ b/tests/test_file_sorter.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test File Sorter module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Formatter module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_fresh_install.py
+++ b/tests/test_fresh_install.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Fresh Install module (tests)
+
 from unittest.mock import patch
 import fresh_install
 

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Function Registry module (tests)
+
 """Tests for the lightweight function registry utilities."""
 
 from __future__ import annotations

--- a/tests/test_gpu_utils.py
+++ b/tests/test_gpu_utils.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Gpu Utils module (tests)
+
 import math
 
 from monkey_head.utils.gpu import detect_accelerators, recommend_models_for_vram

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Gui module (tests)
+
 from unittest.mock import patch
 from types import SimpleNamespace
 from gui.main_ui import MainUI

--- a/tests/test_home_assistant.py
+++ b/tests/test_home_assistant.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Home Assistant module (tests)
+
 from unittest.mock import patch
 import pytest
 

--- a/tests/test_honeycomb_index.py
+++ b/tests/test_honeycomb_index.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Honeycomb Index module (tests)
+
 import time
 
 from monkey_head.honeycomb_index import HoneycombIndex

--- a/tests/test_honeycomb_management.py
+++ b/tests/test_honeycomb_management.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Honeycomb Management module (tests)
+
 import subprocess
 from pathlib import Path
 

--- a/tests/test_honeycomb_storage.py
+++ b/tests/test_honeycomb_storage.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Honeycomb Storage module (tests)
+
 import time
 
 from monkey_head.honeycomb_storage import HoneycombStorage

--- a/tests/test_hostos_module.py
+++ b/tests/test_hostos_module.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Hostos Module module (tests)
+
 import importlib.util
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_huey.py
+++ b/tests/test_huey.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Huey module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_huey_cli_config.py
+++ b/tests/test_huey_cli_config.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Huey Cli Config module (tests)
+
 import sys
 from unittest.mock import patch
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Integrity module (tests)
+
 import hashlib
 from monkey_head.utils.integrity import sha256_digest, verify_checksums
 

--- a/tests/test_inter_program_connectivity.py
+++ b/tests/test_inter_program_connectivity.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Inter Program Connectivity module (tests)
+
 from scripts.check_inter_program_connectivity import (
     check_inter_program_connectivity,
 )

--- a/tests/test_legacy_connectors.py
+++ b/tests/test_legacy_connectors.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Legacy Connectors module (tests)
+
 import asyncio
 
 import pytest

--- a/tests/test_license_cli.py
+++ b/tests/test_license_cli.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test License Cli module (tests)
+
 import json
 from unittest.mock import patch
 

--- a/tests/test_license_gui.py
+++ b/tests/test_license_gui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test License Gui module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_list_available_pdfs.py
+++ b/tests/test_list_available_pdfs.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test List Available Pdfs module (tests)
+
 from monkey_head.pdf_utils import list_available_pdfs
 
 

--- a/tests/test_load_cli.py
+++ b/tests/test_load_cli.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Load Cli module (tests)
+
 import builtins
 import run
 

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Logging Setup module (tests)
+
 import logging
 
 import pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Main module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_main_script.py
+++ b/tests/test_main_script.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Main Script module (tests)
+
 import sys
 import pytest
 

--- a/tests/test_media_conversion.py
+++ b/tests/test_media_conversion.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Media Conversion module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Memory module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_memory_paths.py
+++ b/tests/test_memory_paths.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Memory Paths module (tests)
+
 from pathlib import Path
 
 from monkey_head.utils.paths import ensure_subdirectory, get_memory_path, memory_candidates

--- a/tests/test_misc_modules.py
+++ b/tests/test_misc_modules.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Misc Modules module (tests)
+
 from unittest.mock import patch
 from pathlib import Path
 import pytest

--- a/tests/test_os_check.py
+++ b/tests/test_os_check.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Os Check module (tests)
+
 from unittest.mock import patch
 import pytest
 

--- a/tests/test_os_check_fallback.py
+++ b/tests/test_os_check_fallback.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Os Check Fallback module (tests)
+
 from unittest.mock import patch
 
 from monkey_head.core.system_checks import check_os_support

--- a/tests/test_pdf_chat.py
+++ b/tests/test_pdf_chat.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Pdf Chat module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_pdf_pre_digestion.py
+++ b/tests/test_pdf_pre_digestion.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Pdf Pre Digestion module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Placeholder module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_preloader.py
+++ b/tests/test_preloader.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Preloader module (tests)
+
 from monkey_head.scripts.preload_data import preload_all
 
 

--- a/tests/test_python_version.py
+++ b/tests/test_python_version.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Python Version module (tests)
+
 from unittest.mock import patch
 
 from monkey_head.core.system_checks import check_python_version

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Repair module (tests)
+
 from unittest.mock import patch
 import sys
 import subprocess

--- a/tests/test_resilience_core.py
+++ b/tests/test_resilience_core.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Resilience Core module (tests)
+
 import pytest
 
 from monkey_head.core.resilience import (

--- a/tests/test_run_config_path.py
+++ b/tests/test_run_config_path.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Run Config Path module (tests)
+
 from run import main
 import os
 

--- a/tests/test_run_container_opts.py
+++ b/tests/test_run_container_opts.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Run Container Opts module (tests)
+
 from run import main
 
 

--- a/tests/test_run_manager_ui.py
+++ b/tests/test_run_manager_ui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Run Manager Ui module (tests)
+
 from run import main
 
 

--- a/tests/test_run_minimal.py
+++ b/tests/test_run_minimal.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Run Minimal module (tests)
+
 import os
 from run import minimal_run
 from monkey_head.pygpt_custom_cli import CustomPyGPT

--- a/tests/test_run_module_option.py
+++ b/tests/test_run_module_option.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Run Module Option module (tests)
+
 import sys
 from run import main
 

--- a/tests/test_run_sys_code.py
+++ b/tests/test_run_sys_code.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Run Sys Code module (tests)
+
 from run import main
 import sys
 

--- a/tests/test_run_system_check.py
+++ b/tests/test_run_system_check.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Run System Check module (tests)
+
 from run import main
 
 

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Scaling module (tests)
+
 from monkey_head.gui_scaling import apply_scaling
 
 

--- a/tests/test_simple_chat_gui.py
+++ b/tests/test_simple_chat_gui.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Simple Chat Gui module (tests)
+
 from types import SimpleNamespace
 
 from monkey_head.simple_chat_gui import get_answer, run_simple_chat

--- a/tests/test_storage_management.py
+++ b/tests/test_storage_management.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Storage Management module (tests)
+
 import os
 import time
 from monkey_head.storage_management import StorageManager

--- a/tests/test_subos_manager.py
+++ b/tests/test_subos_manager.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Subos Manager module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tests/test_system_checks_module.py
+++ b/tests/test_system_checks_module.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test System Checks Module module (tests)
+
 """Unit tests for :mod:`monkey_head.system_checks`."""
 
 from __future__ import annotations

--- a/tests/test_task_scheduler.py
+++ b/tests/test_task_scheduler.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Task Scheduler module (tests)
+
 """Tests for the :mod:`monkey_head.core.task_scheduler` module."""
 
 from __future__ import annotations

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Telemetry Store module (tests)
+
 import sys
 from dataclasses import dataclass
 from pathlib import Path

--- a/tests/test_tensorflow_feed.py
+++ b/tests/test_tensorflow_feed.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Tensorflow Feed module (tests)
+
 import pytest
 
 tf = pytest.importorskip("tensorflow")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,8 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Test Utils module (tests)
+
 # ==================================================
 # This file is a part of the 'Monkey Head Project'
 # Website:   https://dlrp.ca

--- a/tools/add_project_headers.py
+++ b/tools/add_project_headers.py
@@ -1,0 +1,172 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Automated header injection utility
+
+"""Utility to add standardized Monkey Head Project headers to source files.
+
+This script walks the repository and ensures that Python, shell, and batch
+scripts include the project header block requested by the project authors.
+It preserves shebang and encoding lines and avoids duplicating an existing
+header if it is already present.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import re
+from pathlib import Path
+from typing import Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+HEADER_LINES_COMMON = (
+    "Monkey Head Project",
+    "By: Dylan L.R. Pollock",
+    "www.dlrp.ca",
+)
+
+PYTHON_EXTENSIONS = {".py"}
+SHELL_EXTENSIONS = {".sh"}
+BATCH_EXTENSIONS = {".bat"}
+TARGET_EXTENSIONS = PYTHON_EXTENSIONS | SHELL_EXTENSIONS | BATCH_EXTENSIONS
+
+
+def humanize_path(path: Path) -> str:
+    """Return a human friendly description for a file."""
+
+    relative = path.relative_to(REPO_ROOT)
+    parent = relative.parent.as_posix()
+    stem = relative.stem
+
+    if path.name == "__init__.py":
+        if parent == ".":
+            return "Root package initializer"
+        return f"Package initializer for {parent}"
+
+    if path.name == "__main__.py":
+        if parent == ".":
+            return "Package entry point"
+        return f"Module entry point for {parent}"
+
+    stem_text = re.sub(r"[-_]+", " ", stem).strip()
+    stem_text = re.sub(r"\s+", " ", stem_text)
+    stem_text = stem_text.title() if stem_text else relative.name
+
+    if path.suffix in PYTHON_EXTENSIONS:
+        description = f"{stem_text} module"
+    elif path.suffix in SHELL_EXTENSIONS:
+        description = f"{stem_text} shell script"
+    elif path.suffix in BATCH_EXTENSIONS:
+        description = f"{stem_text} batch script"
+    else:
+        description = stem_text
+
+    if parent != ".":
+        description = f"{description} ({parent})"
+
+    return description
+
+
+def build_header(path: Path) -> Sequence[str]:
+    description = humanize_path(path)
+
+    if path.suffix in BATCH_EXTENSIONS:
+        prefix = "REM"
+    else:
+        prefix = "#"
+
+    header = [f"{prefix} {line}" for line in HEADER_LINES_COMMON]
+    header.append(f"{prefix} HueyOS: {description}")
+    return header
+
+
+def read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def write_lines(path: Path, lines: Iterable[str]) -> None:
+    text = "\n".join(lines) + "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def has_header(lines: Sequence[str]) -> bool:
+    prefixes = ("# Monkey Head Project", "REM Monkey Head Project")
+    for line in itertools.islice(lines, 0, 10):
+        stripped = line.strip()
+        if any(stripped.startswith(prefix) for prefix in prefixes):
+            return True
+    return False
+
+
+def insertion_index(path: Path, lines: Sequence[str]) -> int:
+    idx = 0
+    if lines and lines[0].startswith("#!"):
+        idx += 1
+    if path.suffix in PYTHON_EXTENSIONS and idx < len(lines):
+        if re.match(r"#.*coding[:=]", lines[idx]):
+            idx += 1
+    return idx
+
+
+def ensure_header(path: Path, dry_run: bool = False) -> bool:
+    original_lines = read_lines(path)
+    if has_header(original_lines):
+        return False
+
+    header_lines = build_header(path)
+    idx = insertion_index(path, original_lines)
+
+    updated_lines = list(original_lines)
+    updated_lines[idx:idx] = header_lines + [""]
+
+    if not dry_run:
+        write_lines(path, updated_lines)
+    return True
+
+
+def find_targets(root: Path) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        if path.is_file() and path.suffix.lower() in TARGET_EXTENSIONS:
+            yield path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Only report files missing headers")
+    parser.add_argument("paths", nargs="*", type=Path, default=[REPO_ROOT], help="Paths to scan")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    modified_any = False
+    missing: list[Path] = []
+
+    for input_path in args.paths:
+        root = (REPO_ROOT / input_path).resolve() if not input_path.is_absolute() else input_path
+        if root.is_file():
+            targets = [root]
+        else:
+            targets = list(find_targets(root))
+        for path in targets:
+            if args.check:
+                if not has_header(read_lines(path)):
+                    missing.append(path.relative_to(REPO_ROOT))
+            else:
+                if ensure_header(path):
+                    modified_any = True
+
+    if args.check:
+        if missing:
+            for path in missing:
+                print(path)
+            return 1
+        return 0
+
+    return 0 if modified_any else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add the required Monkey Head Project header block to Python, shell, and batch scripts with per-file descriptions
- add an automation utility to insert and verify the standardized headers across the repository

## Testing
- python tools/add_project_headers.py --check

------
https://chatgpt.com/codex/tasks/task_e_68f017e7d92c832ba144053089ca1c6c