### PR TITLE
Ensure pytest can import project modules

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,10 +7,18 @@
 from __future__ import annotations
 
 import asyncio
-
 import inspect
+import sys
+from pathlib import Path
 
 import pytest
+
+
+# Ensure the ``src`` directory is importable without requiring installation.
+_PROJECT_ROOT = Path(__file__).resolve().parent
+_SRC_PATH = _PROJECT_ROOT / "src"
+if str(_SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(_SRC_PATH))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add the repository's src directory to sys.path during pytest configuration so imports succeed without installation

## Testing
- pytest tests/test_system_checks_module.py -k kernel -q
- pytest tests/test_os_check.py -q

------
https://chatgpt.com/codex/tasks/task_e_68f060787594832b86f70c63869610e4