### PR TITLE
Switch system checks to Debian Forky baseline

### DIFF
--- a/huey/memory/PY/system_checks.py
+++ b/huey/memory/PY/system_checks.py
@@ -85,9 +85,9 @@ def check_os_support() -> None:
                     release_info = {}
             dist_id = release_info.get("ID", "").lower()
             codename = release_info.get("VERSION_CODENAME", "").lower()
-        if dist_id != "debian" or codename not in {"trixie", "testing"}:
+        if dist_id != "debian" or codename not in {"forky", "testing"}:
             logger.warning(
-                "Unsupported Linux distribution detected (%s %s). Debian Trixie/testing is required.",
+                "Unsupported Linux distribution detected (%s %s). Debian Forky/testing is required.",
                 dist_id,
                 codename,
             )
@@ -115,9 +115,9 @@ def system_check():
     with open("/etc/os-release") as f:
         content = f.read().lower()
         if "debian" not in content or not any(
-            x in content for x in ("trixie", "testing")
+            x in content for x in ("forky", "testing")
         ):
-            error_message = "Debian Trixie/Testing Check failed"
+            error_message = "Debian Forky/Testing Check failed"
             log_error(error_message)
             raise RuntimeError(error_message)
 

--- a/huey/system_checks.py
+++ b/huey/system_checks.py
@@ -32,7 +32,7 @@ __all__ = [
     "system_check",
 ]
 
-_SUPPORTED_LINUX_CODENAMES = {"trixie", "testing"}
+_SUPPORTED_LINUX_CODENAMES = {"forky", "testing"}
 
 
 def ensure_admin() -> None:
@@ -110,7 +110,7 @@ def check_os_support() -> None:
             codename = str(release_info.get("VERSION_CODENAME", "")).lower()
         if dist_id != "debian" or codename not in _SUPPORTED_LINUX_CODENAMES:
             logger.warning(
-                "Unsupported Linux distribution detected (%s %s). Debian Trixie/testing is required.",
+                "Unsupported Linux distribution detected (%s %s). Debian Forky/testing is required.",
                 dist_id,
                 codename,
             )

--- a/src/monkey_head/system_checks.py
+++ b/src/monkey_head/system_checks.py
@@ -25,8 +25,8 @@ except Exception:  # pragma: no cover - handled gracefully in tests
 logger = logging.getLogger(__name__)
 
 SUPPORTED_DISTRO_ID = "debian"
-SUPPORTED_DISTRO_CODENAME = "trixie"
-MIN_KERNEL_VERSION = Version("6.16.12")
+SUPPORTED_DISTRO_CODENAME = "forky"
+MIN_KERNEL_VERSION = Version("6.17.0")
 MIN_PYTHON_VERSION = (3, 12)
 MAX_PYTHON_VERSION = (3, 14)
 REQUIRED_TOOLS: Tuple[str, ...] = ("git", "python3")
@@ -111,7 +111,7 @@ def check_os_support() -> bool:
 
     if not supported:
         logger.warning(
-            "Unsupported Linux distribution detected (%s %s). Debian Trixie is required.",
+            "Unsupported Linux distribution detected (%s %s). Debian Forky is required.",
             dist_id or "unknown",
             codename or "unknown",
         )

--- a/tests/test_os_check.py
+++ b/tests/test_os_check.py
@@ -22,7 +22,7 @@ def test_windows_warning():
 def test_linux_supported_no_warning():
     with patch("platform.system", return_value="Linux"), patch(
         "distro.id", return_value="debian"
-    ), patch("distro.codename", return_value="trixie"), patch(
+    ), patch("distro.codename", return_value="forky"), patch(
         "monkey_head.core.system_checks.logger"
     ) as log:
         check_os_support()

--- a/tests/test_os_check_fallback.py
+++ b/tests/test_os_check_fallback.py
@@ -13,7 +13,7 @@ def test_linux_fallback_no_warning():
         "monkey_head.core.system_checks.distro", None
     ), patch(
         "platform.freedesktop_os_release",
-        return_value={"ID": "debian", "VERSION_CODENAME": "trixie"},
+        return_value={"ID": "debian", "VERSION_CODENAME": "forky"},
     ), patch("monkey_head.core.system_checks.logger") as log:
         check_os_support()
         log.warning.assert_not_called()


### PR DESCRIPTION
## Summary
- require Debian Forky and kernel 6.17.0 in the primary system check logic
- align Huey compatibility layers with Forky/testing messaging
- update unit tests to expect the new codename detection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f061ab8b40832b9c8ec839db1e72b0