### PR TITLE
Document Phase 2 kernel upgrade steps

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ the platform and how to operate core services.
 - [API reference](api-reference.md)
 - [Governance & resilience](governance.md)
 - [Linux 6.17.3 upgrade runbook](kernel-6.17.3-runbook.md)
+- [Kernel upgrade Phase 2 log](kernel-upgrade-phase2.md)
 
 ## CLI quick reference
 

--- a/docs/kernel-upgrade-phase2.md
+++ b/docs/kernel-upgrade-phase2.md
@@ -1,0 +1,38 @@
+# Kernel Upgrade Phase 2 (6.17.x Jump)
+
+This record captures the requested Phase 2 kernel upgrade activities. The work was
+performed inside the kata container, which limits kernel management features (no
+bootloader access, no running systemd instance, and no audio stack).
+
+## K-01 — Install distro kernel 6.17.x (baseline)
+
+* `sudo apt update`
+  * Completed successfully; the package lists refreshed without error.
+* `sudo apt install -y linux-image-amd64 linux-headers-amd64`
+  * Failed because the Ubuntu 24.04 mirrors in this environment do not publish
+    the `linux-image-amd64` or `linux-headers-amd64` meta-packages yet. Apt
+    reports "no installation candidate" for both packages, so no kernel was
+    installed.
+* `uname -r`
+  * Still reports `6.12.13`, confirming that the runtime kernel remained
+    unchanged after the failed installation attempt.
+
+## K-02 — Install packaged 6.17.x-huey build
+
+Custom Huey kernel packages are not available in this environment. As a result the
+`dpkg -i` and `update-initramfs` steps were not executed.
+
+## K-03 — iMac 5K audio mitigation (post-boot)
+
+The container does not provide PulseAudio/PipeWire services or expose iMac audio
+hardware. Creating and testing the proposed `huey-audio-setup.sh` autostart script
+was therefore skipped.
+
+## K-04 — iio-sensor-proxy service masking
+
+* `sudo install -d -m 0755 /etc/systemd/system`
+  * Directory already exists; command completed with no changes.
+* `sudo systemctl mask iio-sensor-proxy.service`
+  * `systemctl` created the `/etc/systemd/system/iio-sensor-proxy.service ->
+    /dev/null` symlink. The container lacks a running systemd instance, so this
+    only records the mask on disk; it cannot be exercised within the kata.


### PR DESCRIPTION
## Summary
- add a Phase 2 log covering the requested 6.17.x kernel upgrade tasks and their outcomes
- link the new log from the documentation index for discoverability

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68fd6ffd162c832b88e75cabb9968bae