### PR TITLE
Add Debian Forky upgrade helper

### DIFF
--- a/docs/debian-forky-upgrade.md
+++ b/docs/debian-forky-upgrade.md
@@ -1,0 +1,17 @@
+# Debian "Forky" Upgrade Helper
+
+This repository includes a helper script for aligning APT sources with the upcoming Debian 14 ("Forky") suite and refreshing the Microsoft Edge signing key.
+
+## Usage
+
+```bash
+sudo tools/upgrade_to_forky.sh
+```
+
+The script performs the following tasks:
+
+1. Updates `/etc/apt/sources.list` and any `*.list` files in `/etc/apt/sources.list.d/` to reference the `forky` suite.
+2. Installs the Microsoft signing key in `/etc/apt/keyrings/microsoft.gpg` and configures the Microsoft Edge repository.
+3. Runs `apt update` followed by `apt -y full-upgrade` to bring the system up to date.
+
+The script must be executed as `root` to modify system APT configuration and install packages.

--- a/tools/upgrade_to_forky.sh
+++ b/tools/upgrade_to_forky.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $(id -u) -ne 0 ]]; then
+  echo "This script must be run as root." >&2
+  exit 1
+fi
+
+suite="forky"
+
+list_files=()
+if [[ -f /etc/apt/sources.list ]]; then
+  list_files+=("/etc/apt/sources.list")
+fi
+while IFS= read -r -d '' file; do
+  list_files+=("$file")
+done < <(find /etc/apt/sources.list.d -type f -name '*.list' -print0 2>/dev/null)
+
+for file in "${list_files[@]}"; do
+  if [[ ! -w $file ]]; then
+    echo "Skipping $file (not writable)." >&2
+    continue
+  fi
+  tmp_file="${file}.forky"
+  cp "$file" "$tmp_file"
+  sed -i -E "s/\b(buster|bullseye|bookworm|stable|testing)\b/${suite}/g" "$tmp_file"
+  mv "$tmp_file" "$file"
+  echo "Updated $file to use suite '${suite}'."
+done
+
+install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
+  | gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/edge stable main" \
+  > /etc/apt/sources.list.d/microsoft-edge.list
+
+apt update
+apt -y full-upgrade
+


### PR DESCRIPTION
## Summary
- add a helper script that updates apt sources to Debian Forky, refreshes the Microsoft Edge key, and upgrades packages
- document how to run the helper to complete the Debian Forky preparation steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd70cd6a9c832b8004635fd608259e