### PR TITLE
Document Python 3.14 installation failure

### DIFF
--- a/docs/python314-upgrade-notes.md
+++ b/docs/python314-upgrade-notes.md
@@ -1,0 +1,30 @@
+# Python 3.14 Upgrade Attempt
+
+The Phase 4 task to install Python 3.14 and rebuild the HueyOS virtual environment could not be completed because the Ubuntu package repositories in this environment do not provide the requested packages.
+
+## Commands Attempted
+
+```bash
+sudo apt update
+sudo apt install -y python3.14 python3.14-venv python3.14-dev
+```
+
+The installation command failed with:
+
+```
+E: Unable to locate package python3.14
+E: Couldn't find any package by glob 'python3.14'
+E: Unable to locate package python3.14-venv
+E: Couldn't find any package by glob 'python3.14-venv'
+E: Unable to locate package python3.14-dev
+E: Couldn't find any package by glob 'python3.14-dev'
+```
+
+Without the Python 3.14 runtime the subsequent virtual environment creation step also fails:
+
+```bash
+python3.14 -m venv .venv
+# bash: command not found: python3.14
+```
+
+As soon as Ubuntu packages for Python 3.14 are published, rerunning the commands above should allow the environment rebuild to proceed.


### PR DESCRIPTION
## Summary
- note that the Ubuntu repositories in this environment do not currently ship Python 3.14 packages
- record the commands attempted and the resulting errors for visibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd722d865c832b8ac47c1527d0790a