### PR TITLE
Document Ollama runtime checks

### DIFF
--- a/docs/ai_runtimes_gpu_setup.md
+++ b/docs/ai_runtimes_gpu_setup.md
@@ -1,0 +1,16 @@
+# Phase 5 — AI runtimes & GPU selection
+
+## Vulkan fallback for Ollama
+- Exported `OLLAMA_LLM_LIBRARY=vulkan`.
+- Exported `VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/radeon_icd.x86_64.json`.
+- Attempted to run `ollama serve`, but the command is unavailable in the current environment (`bash: command not found: ollama`).
+
+## ROCm verification
+- Exported `OLLAMA_LLM_LIBRARY=rocm`.
+- Attempted to run `ollama serve`, but the command remains unavailable (`bash: command not found: ollama`).
+
+## Model downloads
+- Attempted to pull `mistral:7b-instruct-q4_K_M` and `llama3.1:8b-instruct-q4_K_M` with `ollama pull`.
+- Both commands failed because `ollama` is not installed on this system.
+
+> ℹ️ Install Ollama or provide the binary in the PATH before re-running these steps.


### PR DESCRIPTION
## Summary
- document the attempted Vulkan and ROCm Ollama runtime configuration steps
- record that `ollama serve` and model pulls failed because the command is unavailable

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fd7341e488832bb3c78d05f9be6648