### PR TITLE
Fix CLI and API compatibility with legacy modules

### DIFF
--- a/src/huey/__init__.py
+++ b/src/huey/__init__.py
@@ -5,4 +5,30 @@
 
 """Public surface for the HueyOS package."""
 
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from pkgutil import extend_path
+
 __all__ = ["api"]
+
+# Ensure the package exposes modules from the legacy ``huey`` tree that still
+# lives at the repository root.  The CLI relies on helpers such as
+# :mod:`huey.utils`, so we extend ``__path__`` to include that directory when
+# available.  ``extend_path`` keeps compatibility with editable installs where
+# ``src`` already appears on ``sys.path``.
+__path__ = extend_path(__path__, __name__)
+
+_project_root = Path(__file__).resolve().parents[2]
+_legacy_dir = _project_root / "huey"
+if _legacy_dir.exists():
+    legacy_path = str(_legacy_dir)
+    if isinstance(__path__, list):
+        search_path: List[str] = __path__
+    else:  # pragma: no cover - fallback for extend_path returning other types
+        search_path = list(__path__)  # type: ignore[arg-type]
+    if legacy_path not in search_path:
+        search_path.append(legacy_path)
+        __path__ = search_path  # type: ignore[assignment]

--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -26,7 +26,69 @@ from fastapi import FastAPI, HTTPException, Query, status
 from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
-from huey.memory.PY.ai_processor import AIProcessor
+# ``AIProcessor`` pulls in a large number of optional runtime dependencies from
+# the legacy ``huey`` tree. When those modules are unavailable (for example in
+# a trimmed CI environment) we fall back to a lightweight stub that mimics the
+# subset of behaviour exercised by the API endpoints. The stub keeps the
+# service operational for health checks and developer tooling while clearly
+# signalling that the full ML stack is absent.
+try:  # pragma: no cover - exercised indirectly during import
+    from huey.memory.PY.ai_processor import AIProcessor  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim
+    class AIProcessor:  # type: ignore[no-redef]
+        """Minimal stand-in for the legacy :class:`AIProcessor`."""
+
+        _DEFAULT_MODEL = "stub"
+
+        def __init__(
+            self,
+            model: str | None = None,
+            default_instruction: str | None = None,
+            *,
+            telemetry_store: "TelemetryStore" | None = None,
+        ) -> None:
+            self.model = model or self._DEFAULT_MODEL
+            self.default_instruction = default_instruction or (
+                "Rewrite the provided text to improve clarity while preserving meaning."
+            )
+            self.telemetry_store = telemetry_store
+
+        # ------------------------------------------------------------------
+        # Interface compatibility helpers
+        # ------------------------------------------------------------------
+        def get_model_catalog(self, refresh: bool = False) -> Dict[str, Any]:
+            """Return static metadata describing the stub environment."""
+
+            return {
+                "backend": "stub",
+                "active_model": self.model,
+                "recommended_models": [self._DEFAULT_MODEL],
+                "accelerators": [],
+                "total_vram": 0,
+            }
+
+        def process_data(self, text: str) -> str:
+            """Provide a deterministic echo transformation used by the API."""
+
+            return f"Processed: {text.strip()}"
+
+        def compute_mean(self, numbers: Sequence[float]) -> float:
+            """Compute the arithmetic mean of ``numbers`` with basic validation."""
+
+            values = list(numbers)
+            if not values:
+                raise ValueError("numbers must contain at least one value")
+            return sum(values) / len(values)
+
+        def analyze_data(self, text: str) -> Dict[str, Any]:
+            """Return trivial metrics mirroring the real implementation signature."""
+
+            length = len(text)
+            return {
+                "length": length,
+                "words": len(text.split()),
+                "unique_characters": len(set(text)),
+            }
 from monkey_head.core.resilience import (
     CrashRecoveryManager,
     EmergencyGovernanceController,

--- a/src/huey/memory/__init__.py
+++ b/src/huey/memory/__init__.py
@@ -1,0 +1,47 @@
+"""Compatibility namespace for legacy ``huey.memory`` modules."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from pkgutil import extend_path
+from typing import Iterable
+
+__all__: list[str] = ["PY"]
+
+# Start with the standard namespace package path.
+__path__ = extend_path(__path__, __name__)
+
+_project_root = Path(__file__).resolve().parents[2]
+_legacy_root = _project_root / "huey" / "memory"
+if _legacy_root.exists():
+    legacy_path = str(_legacy_root)
+    # ``extend_path`` may return a list or a specialised iterable depending on
+    # the environment. Normalise to a mutable list so we can append our legacy
+    # sources without duplicating entries across interpreter restarts.
+    if isinstance(__path__, list):
+        search_path: list[str] = __path__
+    else:  # pragma: no cover - extremely defensive fallback
+        search_path = list(__path__)  # type: ignore[arg-type]
+    if legacy_path not in search_path:
+        search_path.append(legacy_path)
+        __path__ = search_path  # type: ignore[assignment]
+    if legacy_path not in sys.path:
+        sys.path.insert(0, legacy_path)
+
+
+def __getattr__(name: str):  # pragma: no cover - thin import wrapper
+    """Dynamically resolve submodules from the legacy tree."""
+
+    import importlib
+
+    try:
+        module = importlib.import_module(f"huey.memory.PY.{name}")
+    except ModuleNotFoundError as exc:  # pragma: no cover - error propagation
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+    globals()[name] = module
+    return module
+
+
+def __dir__() -> Iterable[str]:  # pragma: no cover - convenience helper
+    return sorted(set(__all__) | set(globals()))

--- a/src/huey/memory/core/__init__.py
+++ b/src/huey/memory/core/__init__.py
@@ -1,0 +1,24 @@
+"""Compatibility namespace for ``huey.memory.core`` imports."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pkgutil import extend_path
+from typing import Iterable
+
+__all__ = ["system_checks"]
+
+__path__ = extend_path(__path__, __name__)
+
+
+def __getattr__(name: str):  # pragma: no cover - dynamic compatibility shim
+    try:
+        module = import_module(f"huey.core.{name}")
+    except ModuleNotFoundError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+    globals()[name] = module
+    return module
+
+
+def __dir__() -> Iterable[str]:  # pragma: no cover
+    return sorted(set(__all__) | set(globals()))

--- a/src/huey/memory/core/system_checks.py
+++ b/src/huey/memory/core/system_checks.py
@@ -1,0 +1,5 @@
+"""Re-export ``huey.core.system_checks`` for legacy import paths."""
+
+from __future__ import annotations
+
+from huey.core.system_checks import *  # noqa: F401,F403 - compatibility export

--- a/src/huey/memory/utils/__init__.py
+++ b/src/huey/memory/utils/__init__.py
@@ -1,0 +1,40 @@
+"""Expose legacy utility helpers for :mod:`huey.memory` consumers."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+from pkgutil import extend_path
+from typing import Iterable
+
+__all__ = ["commands", "logger"]
+
+__path__ = extend_path(__path__, __name__)
+
+_project_root = Path(__file__).resolve().parents[3]
+_legacy_root = _project_root / "huey" / "memory" / "PY"
+if _legacy_root.exists():
+    legacy_path = str(_legacy_root)
+    if isinstance(__path__, list):
+        search_path: list[str] = __path__
+    else:  # pragma: no cover - defensive fallback
+        search_path = list(__path__)  # type: ignore[arg-type]
+    if legacy_path not in search_path:
+        search_path.append(legacy_path)
+        __path__ = search_path  # type: ignore[assignment]
+    if legacy_path not in sys.path:
+        sys.path.insert(0, legacy_path)
+
+
+def __getattr__(name: str):  # pragma: no cover - dynamic compatibility shim
+    try:
+        module = import_module(f"huey.memory.PY.{name}")
+    except ModuleNotFoundError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+    globals()[name] = module
+    return module
+
+
+def __dir__() -> Iterable[str]:  # pragma: no cover
+    return sorted(set(__all__) | set(globals()))

--- a/src/huey/memory/utils/commands.py
+++ b/src/huey/memory/utils/commands.py
@@ -1,0 +1,15 @@
+"""Compatibility wrapper for :mod:`huey.memory.PY.commands`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+_impl = import_module("huey.memory.PY.commands")
+
+__all__ = getattr(_impl, "__all__", [])
+
+# Re-export public attributes for callers expecting the legacy module layout.
+for name in dir(_impl):
+    if name.startswith("_") and name not in __all__:
+        continue
+    globals()[name] = getattr(_impl, name)

--- a/src/huey/memory/utils/logger.py
+++ b/src/huey/memory/utils/logger.py
@@ -1,0 +1,14 @@
+"""Compatibility wrapper for :mod:`huey.memory.PY.logger`."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+_impl = import_module("huey.memory.PY.logger")
+
+__all__ = getattr(_impl, "__all__", []) or ["get_logger"]
+
+for name in dir(_impl):
+    if name.startswith("_") and name not in __all__:
+        continue
+    globals()[name] = getattr(_impl, name)


### PR DESCRIPTION
## Summary
- extend the src-based `huey` package so the CLI can locate the legacy helpers bundled at the repository root
- add compatibility namespaces for `huey.memory` utilities and core helpers that proxy into the legacy implementation
- provide a lightweight `AIProcessor` stub so the FastAPI application can start even when the full ML stack is absent

## Testing
- huey init --run-checks --verbose
- huey run --ml --cloud
- uvicorn --app-dir src --reload-dir src huey.api:app --host 127.0.0.1 --port 8000 --reload
- curl http://127.0.0.1:8000/healthz
- docker compose pull || true *(fails: command not found)*
- docker compose build *(fails: command not found)*
- docker compose up -d *(fails: command not found)*
- docker compose ps *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fd743c20e8832b869d49859f6644f1