### PR TITLE
Document phase 8 validation results

### DIFF
--- a/docs/phase-8-validation.md
+++ b/docs/phase-8-validation.md
@@ -1,0 +1,12 @@
+# Phase 8 Validation & Burn-In Report
+
+## [V-01] System Validation
+- `huey system-check --verbose` *(failed)*: `huey` command not found in the environment.
+- `huey agent-status --json | jq .` *(failed)*: `huey` command not found in the environment.
+
+## [V-02] 10-hour Burn-in (Light)
+- Not executed. The provided container environment does not permit long-running (10 hour) burn-in loops.
+
+## [V-03] Log Collection
+- `journalctl -b --no-pager | gzip > ~/huey-logs-$(hostname)-$(date +%F).gz`
+  - Result: Command reported "No journal files were found." A gzipped log artifact was created but contains no journal data in this environment.


### PR DESCRIPTION
## Summary
- add a Phase 8 validation and burn-in report capturing the status of required checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd7a7181c0832b84868a14f7693373