### PR TITLE
Validate honeycomb storage keys and expand tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-python_files = test_cli.py test_task_scheduler.py test_api_routes.py
+python_files = test_cli.py test_task_scheduler.py test_api_routes.py test_honeycomb_storage.py
 addopts = -ra
 testpaths = tests

--- a/src/monkey_head/honeycomb_storage.py
+++ b/src/monkey_head/honeycomb_storage.py
@@ -106,10 +106,16 @@ class HoneycombStorage:
     # ------------------------------------------------------------------
     @staticmethod
     def _split_key(key: str) -> tuple[str, str]:
+        if not isinstance(key, str):
+            raise TypeError("Honeycomb keys must be strings")
+        if not key or key.strip() == "":
+            raise ValueError("Honeycomb keys must not be empty")
         if "/" in key:
             comb, cell = key.split("/", 1)
         else:
             comb, cell = "default", key
+        if not comb:
+            raise ValueError("Comb portion of key must not be empty")
         return comb, cell
 
     def _record_path(self, key: str) -> Path:

--- a/tests/test_honeycomb_storage.py
+++ b/tests/test_honeycomb_storage.py
@@ -5,6 +5,8 @@
 
 import time
 
+import pytest
+
 from monkey_head.honeycomb_storage import HoneycombStorage
 
 
@@ -62,3 +64,24 @@ def test_conversation_helpers(tmp_path):
 
     results = storage.query("conversation/chat/")
     assert len(results) == 2
+
+
+def test_store_rejects_invalid_keys(tmp_path):
+    storage = HoneycombStorage(base_dir=tmp_path)
+
+    with pytest.raises(TypeError):
+        storage.store(123, {})
+
+    with pytest.raises(ValueError):
+        storage.store("   ", {})
+
+    with pytest.raises(ValueError):
+        storage.store("/leading", {})
+
+
+def test_store_after_close_raises(tmp_path):
+    storage = HoneycombStorage(base_dir=tmp_path)
+    storage.close()
+
+    with pytest.raises(RuntimeError):
+        storage.store("alpha", {})


### PR DESCRIPTION
## Summary
- add explicit validation for honeycomb storage keys to prevent silent misuse
- extend honeycomb storage unit tests to cover invalid keys and closed storage handling
- update pytest configuration so the honeycomb storage tests execute with the default test run

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fd7c2654b4832bb6ce0f15a6ad1974