### PR TITLE
Add coverage for huey.run entrypoint

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-python_files = test_cli.py test_task_scheduler.py test_api_routes.py test_honeycomb_storage.py
+python_files = test_cli.py test_task_scheduler.py test_api_routes.py test_honeycomb_storage.py test_run_entrypoint.py
 addopts = -ra
 testpaths = tests

--- a/tests/test_run_entrypoint.py
+++ b/tests/test_run_entrypoint.py
@@ -1,0 +1,55 @@
+"""Tests for the legacy ``huey.run`` entry point wrapper."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+
+def test_run_module_invokes_target():
+    from huey import run as huey_run
+
+    called: dict[str, bool] = {}
+    module = types.ModuleType("_dummy_run_module")
+
+    def main() -> None:
+        called["main"] = True
+
+    def alt() -> None:
+        called["alt"] = True
+
+    module.main = main  # type: ignore[attr-defined]
+    module.alt = alt  # type: ignore[attr-defined]
+    sys.modules[module.__name__] = module
+    try:
+        huey_run.run_module(module.__name__)
+        huey_run.run_module(f"{module.__name__}:alt")
+    finally:
+        sys.modules.pop(module.__name__, None)
+
+    assert called == {"main": True, "alt": True}
+
+
+def test_main_delegates_to_run_module(monkeypatch):
+    from huey import run as huey_run
+
+    invoked: dict[str, str] = {}
+
+    def fake_run_module(target: str) -> None:
+        invoked["target"] = target
+
+    monkeypatch.setattr(huey_run, "run_module", fake_run_module)
+    monkeypatch.setattr(
+        huey_run,
+        "minimal_run",
+        lambda: (_ for _ in ()).throw(AssertionError("unexpected minimal_run")),
+    )
+    monkeypatch.setattr(
+        huey_run,
+        "run_sys_code",
+        lambda cmd: (_ for _ in ()).throw(AssertionError("unexpected run_sys_code")),
+    )
+
+    huey_run.main(["--module", "pkg.module:func"])
+
+    assert invoked["target"] == "pkg.module:func"


### PR DESCRIPTION
## Summary
- add tests ensuring huey.run.run_module executes target callables and huey.run.main delegates to it
- update pytest configuration so the new test module is collected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fd7f972180832ba38253e7364e7d68