### PR TITLE
Use per-user NLTK cache for llama_index integration

### DIFF
--- a/repo/pygpt-MHP/src/pygpt_net/__init__.py
+++ b/repo/pygpt-MHP/src/pygpt_net/__init__.py
@@ -7,6 +7,50 @@
 
 from __future__ import annotations
 
+import importlib
+import importlib.util
+import os
+from pathlib import Path
+from typing import Final
+
 __all__ = ["__version__"]
 
 __version__ = "0.0.0-dev"
+
+_NLTK_ENV_VAR: Final[str] = "NLTK_DATA"
+_CUSTOM_ENV_VAR: Final[str] = "PYGPT_NLTK_DATA_DIR"
+
+
+def _ensure_private_nltk_data() -> None:
+    """Force NLTK data into a per-user directory to avoid shared caches."""
+
+    if os.environ.get(_NLTK_ENV_VAR):
+        return
+
+    target_dir = Path(
+        os.environ.get(
+            _CUSTOM_ENV_VAR,
+            Path.home() / ".cache" / "pygpt_net" / "nltk_data",
+        )
+    )
+
+    try:
+        target_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError:
+        # If the directory cannot be created we silently fall back to the
+        # upstream defaults rather than break runtime imports.
+        return
+
+    os.environ[_NLTK_ENV_VAR] = str(target_dir)
+
+    nltk_spec = importlib.util.find_spec("nltk")
+    if nltk_spec is None:
+        return
+
+    nltk = importlib.import_module("nltk")
+    resolved_dir = str(target_dir)
+    if resolved_dir not in nltk.data.path:
+        nltk.data.path.insert(0, resolved_dir)
+
+
+_ensure_private_nltk_data()

--- a/tests/test_nltk_data_directory.py
+++ b/tests/test_nltk_data_directory.py
@@ -1,0 +1,27 @@
+"""Tests ensuring NLTK data is stored in a private directory."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+
+def test_nltk_data_directory_is_user_specific(monkeypatch, tmp_path) -> None:
+    """NLTK data should default to a private per-user directory."""
+
+    monkeypatch.delenv("NLTK_DATA", raising=False)
+    custom_dir = tmp_path / "secure-nltk"
+    monkeypatch.setenv("PYGPT_NLTK_DATA_DIR", str(custom_dir))
+
+    module = importlib.import_module("pygpt_net")
+    try:
+        importlib.reload(module)
+    finally:
+        # Ensure future imports see the original module object.
+        sys.modules["pygpt_net"] = module
+
+    assert os.environ.get("NLTK_DATA") == str(custom_dir)
+    assert custom_dir.exists()
+    assert custom_dir.is_dir()
+


### PR DESCRIPTION
## Summary
- force NLTK to use a private, per-user cache directory before llama_index loads
- allow overriding the secure location via `PYGPT_NLTK_DATA_DIR` and fall back to a safe default
- add a regression test that verifies the sandboxed directory is created and selected

## Testing
- pytest tests/test_nltk_data_directory.py

------
https://chatgpt.com/codex/tasks/task_e_68fd819b4ea0832bb3fca292a5a39251