### PR TITLE
Add least privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
 
+# Limit default token permissions for the workflow
+permissions:
+  contents: read
+
 # Prevent overlapping runs on the same ref
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- set the CI workflow's token permissions to read-only for repository contents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd825e47cc832ba4d07129dbe785da