### PR TITLE
Set Microsoft Edge Beta as the official browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ On **2025‑10‑31**, HueyOS migrates to **Debian 14 “Forky,” kernel 6.17.x
 
 ## Quick Recipes — Oct 31 Changeover
 
-- **Forky apt switch:** `sudo tools/upgrade_to_forky.sh` — applies the staged APT source flip and refreshes the Microsoft Edge signing key (see [docs/debian-forky-upgrade.md](docs/debian-forky-upgrade.md)).
+- **Forky apt switch:** `sudo tools/upgrade_to_forky.sh` — applies the staged APT source flip and refreshes the Microsoft Edge Beta signing key (see [docs/debian-forky-upgrade.md](docs/debian-forky-upgrade.md)).
 - **Kernel 6.17.x-huey build:** follow [docs/kernel-6.17.3-runbook.md](docs/kernel-6.17.3-runbook.md) to rebuild and install the DKMS-free kernel, then record results in the release stub.
 - **Python 3.14 virtualenv:** once packages land, rerun the commands in [docs/python314-upgrade-notes.md](docs/python314-upgrade-notes.md) to create the 3.14 environment and capture any blockers.
 - **Release log:** summarize successful steps and deltas in [`docs/releases/2025-10-31-changeover.md`](docs/releases/2025-10-31-changeover.md) for final publication.
@@ -62,7 +62,8 @@ HueyOS targets **Debian 13 “Trixie”** today with a low‑latency **6.16.x‑
 - **OS baseline:** Debian 13.0.0 (Trixie) → changeover to **Debian 14 “Forky”** begins **2025‑10‑31**.  
 - **Kernel:** 6.16.x‑huey → **6.17.x‑huey** (low‑latency, targeted drivers).  
 - **Python:** 3.13.x now; **3.14.x** becomes baseline post‑changeover.  
-- **Runtime:** **PyGPT‑net** (orchestrator) + **Ollama** (local LLMs); ROCm/Vulkan where available.  
+- **Runtime:** **PyGPT‑net** (orchestrator) + **Ollama** (local LLMs); ROCm/Vulkan where available.
+- **Official browser:** Microsoft Edge Beta across Linux and Windows deployments.
 - **Memory:** unified long‑term store via JSON logs + SQLite with reproducible telemetry.  
 - **Networking:** bonded Ethernet preferred; Wi‑Fi fallback; **TigerVNC** bound to localhost via SSH.
 
@@ -310,9 +311,10 @@ wget -qO- https://packages.microsoft.com/keys/microsoft.asc | \
 
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] \
 https://packages.microsoft.com/repos/edge stable main" | \
-  sudo tee /etc/apt/sources.list.d/microsoft-edge.list >/dev/null
+  sudo tee /etc/apt/sources.list.d/microsoft-edge-beta.list >/dev/null
 
 sudo apt update
+sudo apt install -y microsoft-edge-beta
 ```
 
 ### RAID Superblock Cleanup (when reverting experiments)

--- a/docs/debian-forky-upgrade.md
+++ b/docs/debian-forky-upgrade.md
@@ -11,7 +11,7 @@ sudo tools/upgrade_to_forky.sh
 The script performs the following tasks:
 
 1. Updates `/etc/apt/sources.list` and any `*.list` files in `/etc/apt/sources.list.d/` to reference the `forky` suite.
-2. Installs the Microsoft signing key in `/etc/apt/keyrings/microsoft.gpg` and configures the Microsoft Edge repository.
+2. Installs the Microsoft signing key in `/etc/apt/keyrings/microsoft.gpg` and configures the Microsoft Edge Beta repository (`/etc/apt/sources.list.d/microsoft-edge-beta.list`).
 3. Runs `apt update` followed by `apt -y full-upgrade` to bring the system up to date.
 
 The script must be executed as `root` to modify system APT configuration and install packages.

--- a/setup/DebianTrixie/install.sh
+++ b/setup/DebianTrixie/install.sh
@@ -174,15 +174,19 @@ function install_packages() {
 }
 
 function install_edge() {
-    echo "Installing Microsoft Edge Dev ..."
+    echo "Installing Microsoft Edge Beta ..."
     apt-get purge -y firefox || true
     apt-get autoremove -y || true
     install -d -m 755 /usr/share/keyrings
     curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft.gpg
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/edge stable main" \
-        > /etc/apt/sources.list.d/microsoft-edge-dev.list
+        > /etc/apt/sources.list.d/microsoft-edge-beta.list
     apt-get update -y
-    apt-get install -y microsoft-edge-dev
+    apt-get install -y microsoft-edge-beta
+    if command -v update-alternatives >/dev/null 2>&1 && [[ -x /usr/bin/microsoft-edge-beta ]]; then
+        update-alternatives --set x-www-browser /usr/bin/microsoft-edge-beta || true
+        update-alternatives --set gnome-www-browser /usr/bin/microsoft-edge-beta || true
+    fi
 }
 
 function ensure_python_runtime() {

--- a/setup/Windows11/10-START.bat
+++ b/setup/Windows11/10-START.bat
@@ -160,9 +160,16 @@ goto :eof
 :: Function to open application in browser (optional)
 :openBrowser
 echo Opening application in web browser...
-REM Add command to open application in default web browser
-REM For example:
-start http://localhost
+set "EDGE_BETA_EXE=%ProgramFiles(x86)%\Microsoft\Edge Beta\Application\msedge.exe"
+if not exist "%EDGE_BETA_EXE%" (
+    set "EDGE_BETA_EXE=%ProgramFiles%\Microsoft\Edge Beta\Application\msedge.exe"
+)
+if exist "%EDGE_BETA_EXE%" (
+    start "" "%EDGE_BETA_EXE%" http://localhost
+) else (
+    echo Microsoft Edge Beta not found. Launching with default browser instead.
+    start http://localhost
+)
 goto :eof
 
 :: Function to log startup steps

--- a/tools/upgrade_to_forky.sh
+++ b/tools/upgrade_to_forky.sh
@@ -32,8 +32,11 @@ install -d -m 0755 /etc/apt/keyrings
 curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
   | gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
 
+rm -f /etc/apt/sources.list.d/microsoft-edge.list \
+  /etc/apt/sources.list.d/microsoft-edge-dev.list
+
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/edge stable main" \
-  > /etc/apt/sources.list.d/microsoft-edge.list
+  > /etc/apt/sources.list.d/microsoft-edge-beta.list
 
 apt update
 apt -y full-upgrade


### PR DESCRIPTION
## Summary
- switch Debian installer scripts to install Microsoft Edge Beta, set it as the default browser, and drop legacy Dev channel references
- refresh documentation and upgrade helper scripts to point to the Edge Beta repository and package
- update the Windows startup helper to open the app in Microsoft Edge Beta when available

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68feb4908b18832ba0e962e16cb74923