### PR TITLE
Potential fix for code scanning alert no. 109: Log Injection

### DIFF
--- a/src/huey/core/resilience.py
+++ b/src/huey/core/resilience.py
@@ -448,7 +448,8 @@ class CrashRecoveryManager:
             if process is None:
                 raise KeyError(f"Unknown monitored process: {name}")
             process.restart()
-            LOGGER.info("Manual restart executed for process %s", name)
+            name_sanitized = name.replace('\r', '').replace('\n', '')
+            LOGGER.info("Manual restart executed for process %s", name_sanitized)
 
     def statuses(self) -> List[Dict[str, Any]]:
         """Return serialisable status information for each process."""


### PR DESCRIPTION
Potential fix for [https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/109](https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/109)

The best way to fix this issue is to sanitize the `name` variable before logging. Specifically, you should remove or replace any newline or carriage return characters from `name` before it is logged, ensuring users cannot inject new lines into log files. This can be done by adding a line such as `name_sanitized = name.replace('\r', '').replace('\n', '')` before the log call, and then using `name_sanitized` in place of `name` in the log statement. You should make this change inside the `manual_restart` method in `src/huey/core/resilience.py`, right before the log entry on line 451.

Since you can only edit shown code, this must be a local sanitization within the relevant function. No new function definitions are necessary. The change is also limited to the immediate scope of the log entry.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
