### PR TITLE
Potential fix for code scanning alert no. 85: Potentially uninitialized local variable

### DIFF
--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -1533,14 +1533,14 @@ def override_monitored_process(
     """Enable or disable automatic crash recovery for the given process."""
 
     try:
-        status = CRASH_MANAGER.toggle_auto_restart(
+        process_status = CRASH_MANAGER.toggle_auto_restart(
             name, request.auto_restart, reason=request.reason
         )
     except KeyError as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
         ) from exc
-    return MonitoredProcessStatusModel(**status)
+    return MonitoredProcessStatusModel(**process_status)
 
 
 @app.post(


### PR DESCRIPTION
Potential fix for [https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/85](https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/85)

The ideal fix is to avoid shadowing the imported `status` from FastAPI with a local variable, and to make explicit that the local variable is always assigned before its use. The most straightforward way to address this is to rename the local variable (e.g., from `status` to `result` or `process_status`) so it cannot be confused with the imported `status`. This removes the potential for referring to an uninitialized local variable and clarifies the code. 

The specific changes needed are:
- In `override_monitored_process`, change the local variable `status` assignment (used to hold the result of `CRASH_MANAGER.toggle_auto_restart`) to a different name, e.g., `process_status`.
- Update the instantiation of the response model to use the new variable name.
- No other parts of the code need to be changed.
No new imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
