### PR TITLE
Potential fix for code scanning alert no. 131: Overwriting attribute in super-class or sub-class

### DIFF
--- a/src/huey/pygpt_net/provider/agents/react.py
+++ b/src/huey/pygpt_net/provider/agents/react.py
@@ -25,9 +25,9 @@ from .base import BaseAgent
 
 class ReactAgent(BaseAgent):
     def __init__(self, *args, **kwargs):
-        super(ReactAgent, self).__init__(*args, **kwargs)
+        super(ReactAgent, self).__init__(*args, mode="step", **kwargs)
         self.id = "react"
-        self.mode = "step"  # step|plan
+        # self.mode = "step"  # step|plan
 
     def get_agent(self, window, kwargs: Dict[str, Any]):
         """


### PR DESCRIPTION
Potential fix for [https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/131](https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/131)

The best way to fix this is to modify the initialization of `mode` so it is assigned only in the superclass, and the subclass passes its desired value to the superclass `__init__` as a parameter. Thus, BaseAgent should accept a (possibly defaulted) `mode` parameter in its `__init__` method, and ReactAgent should pass `"step"` when initializing the superclass. Since we only have the snippet from ReactAgent and are not allowed to edit anything outside of it, we assume BaseAgent already supports a `mode` parameter (or at least, our change will be correct once/if BaseAgent is modified accordingly). Remove the assignment of `self.mode` in ReactAgent and pass `mode="step"` as a keyword argument to `super().__init__` (which may be passed in `kwargs` already, but let's be explicit and prevent it being set twice).

Change lines in ReactAgent's `__init__` method:
- Remove `self.mode = "step"`
- Add or ensure `mode="step"` is passed to `super().__init__`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
