### PR TITLE
Potential fix for code scanning alert no. 106: Log Injection

### DIFF
--- a/src/huey/core/resilience.py
+++ b/src/huey/core/resilience.py
@@ -425,9 +425,10 @@ class CrashRecoveryManager:
                 raise KeyError(f"Unknown monitored process: {name}")
             process.auto_restart_enabled = enabled
             process.manual_override_reason = reason if not enabled else None
+            name_sanitized = name.replace('\r', '').replace('\n', '')
             LOGGER.info(
                 "Manual override for %s set to %s (reason=%s)",
-                name,
+                name_sanitized,
                 enabled,
                 reason,
             )


### PR DESCRIPTION
Potential fix for [https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/106](https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/106)

To fix the problem, sanitize the value of `name` before logging it in the `toggle_auto_restart` method in `src/huey/core/resilience.py`. Specifically:
- Remove carriage return (`\r`) and newline (`\n`) characters from `name` before it is used in any logging statements.
- Create a new local variable inside the critical region (after acquiring the lock) that stores the sanitized name.
- Use this sanitized name in the logging call, similar to what is already done in the adjacent `manual_restart` method.
- No import or additional dependency is needed; string `replace` is sufficient and is already used elsewhere in the module.

Only changes to `src/huey/core/resilience.py` are necessary, and specifically to the `toggle_auto_restart` logging call (lines 428-433, focus on line 430).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
