### PR TITLE
Potential fix for code scanning alert no. 3: Unnecessary lambda

### DIFF
--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -558,7 +558,7 @@ class ServiceStatus(BaseModel):
     name: str = Field(..., description="Human readable service identifier")
     status: str = Field(..., description="Current state such as 'running' or 'stopped'")
     last_changed: float = Field(
-        default_factory=lambda: time.time(),
+        default_factory=time.time,
         description="Unix timestamp when the status last changed",
     )
 


### PR DESCRIPTION
Potential fix for [https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/3](https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/3)

To fix the problem, simply replace the lambda wrapping (`default_factory=lambda: time.time()`) with the direct function object (`default_factory=time.time`). This change should be made on line 561 of `src/huey/api.py` within the definition of the `ServiceStatus` class. There are no additional imports or definitions required, as `time` is already imported. The rest of the code is unaffected, and functionality is maintained.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
