### PR TITLE
Potential fix for code scanning alert no. 145: Empty except

### DIFF
--- a/src/huey/memory/PY/tensorflow_feed.py
+++ b/src/huey/memory/PY/tensorflow_feed.py
@@ -19,7 +19,7 @@ import csv
 import json
 from pathlib import Path
 from typing import List
-
+import logging
 from .chat_learning import train_from_chat_and_pdfs
 
 
@@ -66,8 +66,8 @@ def load_memory_texts(memory_dir: str | Path) -> List[str]:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
             texts.append(json.dumps(data))
-        except Exception:
-            pass
+        except Exception as e:
+            logging.warning(f"Failed to load JSON from '{path}': {e}")
     return texts
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/145](https://github.com/DylanLRPollock/Monkey-Head-Project/security/code-scanning/145)

The best way to fix this problem is to handle the exception appropriately rather than silently passing. At the very least, the exception should be logged, so that if files are being skipped, the user or developer will be aware of which files and why. This can be done using the standard library's `logging` module, which doesn't require external dependencies. Only the relevant except block(s) should be modified: replace `pass` with a logging statement including the filename and the error encountered. If the logging module is not already imported, add the import at the top of the file.

You should only edit what you've been shown; therefore, only update the except block in `load_memory_texts` and add `import logging` near the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
