### PR TITLE
Organize hueyos bridges and failover utilities

### DIFF
--- a/src/huey/core/system_checks.py
+++ b/src/huey/core/system_checks.py
@@ -17,6 +17,8 @@ __all__ = getattr(
 )
 if "check_python_version" not in __all__:
     __all__.append("check_python_version")
+if "check_error" not in __all__:
+    __all__.append("check_error")
 
 for _name in __all__:
     if _name != "check_python_version":
@@ -55,3 +57,13 @@ def check_python_version() -> None:
             "Python 3.%s detected. This version is experimental and not fully supported.",
             minor,
         )
+
+
+def check_error(command: Any, description: str) -> None:
+    """Raise a runtime error when a subprocess command fails."""
+
+    returncode = getattr(command, "returncode", 0)
+    if returncode != 0:
+        message = f"Error: {description} failed with error code {returncode}."
+        logger.error(message)
+        raise RuntimeError(message)

--- a/src/huey/memory/PY/logger.py
+++ b/src/huey/memory/PY/logger.py
@@ -7,7 +7,7 @@
 
 import logging
 
-from ..logging_setup import configure_logging
+from .logging_setup import configure_logging
 
 
 def get_logger(name: str | None = None, level: str | None = None) -> logging.Logger:

--- a/src/hueyos/ai_processor.py
+++ b/src/hueyos/ai_processor.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.ai_processor")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/chapter_splitter.py
+++ b/src/hueyos/chapter_splitter.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.chapter_splitter")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/cli.py
+++ b/src/hueyos/cli.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.cli")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/cli_print.py
+++ b/src/hueyos/cli_print.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.cli_print")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/cloud_pyramid.py
+++ b/src/hueyos/cloud_pyramid.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.cloud_pyramid")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/config_toggle_gui.py
+++ b/src/hueyos/config_toggle_gui.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.config_toggle_gui")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/convert_png_to_jpeg.py
+++ b/src/hueyos/convert_png_to_jpeg.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.convert_png_to_jpeg")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/error_handler.py
+++ b/src/hueyos/error_handler.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.error_handler")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/file_manager.py
+++ b/src/hueyos/file_manager.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.file_manager")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/formatter.py
+++ b/src/hueyos/formatter.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.formatter")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/gui_scaling.py
+++ b/src/hueyos/gui_scaling.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.gui_scaling")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/huey_checks.py
+++ b/src/hueyos/huey_checks.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.huey_checks")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/huey_core.py
+++ b/src/hueyos/huey_core.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.huey_core")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/huey_core_data.py
+++ b/src/hueyos/huey_core_data.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.huey_core_data")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/huey_disk_manager_temp.py
+++ b/src/hueyos/huey_disk_manager_temp.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.huey_disk_manager_temp")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/huey_linux.py
+++ b/src/hueyos/huey_linux.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.huey_linux")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/huey_remover.py
+++ b/src/hueyos/huey_remover.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.huey_remover")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/huey_tkinter.py
+++ b/src/hueyos/huey_tkinter.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.huey_tkinter")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/legacy/__init__.py
+++ b/src/hueyos/legacy/__init__.py
@@ -1,0 +1,8 @@
+"""Legacy connector bridges for HueyOS.
+
+This package proxies calls into the legacy ``huey.legacy`` namespace while
+keeping imports stable for callers that depend on the newer ``hueyos`` path.
+"""
+from __future__ import annotations
+
+__all__ = ["connectors"]

--- a/src/hueyos/legacy/connectors.py
+++ b/src/hueyos/legacy/connectors.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.legacy.connectors")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/license_cli.py
+++ b/src/hueyos/license_cli.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.license_cli")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/license_gui.py
+++ b/src/hueyos/license_gui.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.license_gui")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/log.py
+++ b/src/hueyos/log.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.logger")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/logging_setup.py
+++ b/src/hueyos/logging_setup.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.logging_setup")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/pdf_chat.py
+++ b/src/hueyos/pdf_chat.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.pdf_chat")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/pdf_pre_digestion.py
+++ b/src/hueyos/pdf_pre_digestion.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.pdf_pre_digestion")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/pygpt_custom_cli.py
+++ b/src/hueyos/pygpt_custom_cli.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.pygpt_custom_cli")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/pygpt_memory.py
+++ b/src/hueyos/pygpt_memory.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.pygpt_memory")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/scripts/failover.py
+++ b/src/hueyos/scripts/failover.py
@@ -1,0 +1,89 @@
+"""Simple failover planning helpers.
+
+The utilities here provide minimal structures for building and executing
+synchronisation plans between a primary and secondary filesystem. They are
+lightweight by design and focused on the unit-test scenarios in this kata.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterable, List
+import time
+
+
+@dataclass
+class Task:
+    """Represents a single shell command to execute."""
+
+    command: List[str]
+
+
+@dataclass
+class FailoverPlan:
+    """Collection of tasks to mirror volumes to a secondary target."""
+
+    source: Path
+    target: Path
+    volumes: list[str]
+    excludes: list[str]
+    dry_run: bool = False
+    tasks: List[Task] = field(default_factory=list)
+
+    def commands(self) -> List[List[str]]:
+        """Return a list of commands for execution."""
+
+        return [task.command for task in self.tasks]
+
+
+def _build_rsync_command(source: Path, target: Path, volume: str, excludes: Iterable[str], dry_run: bool) -> List[str]:
+    command = ["rsync", "-a", "--delete"]
+    if dry_run:
+        command.append("--dry-run")
+    command.extend([f"--exclude={pattern}" for pattern in excludes])
+    command.append(f"{source / volume}/")
+    command.append(str(target / volume))
+    return command
+
+
+def build_failover_plan(source: Path, target: Path, *, volumes: list[str], excludes: list[str], dry_run: bool = False) -> FailoverPlan:
+    """Create a failover plan containing rsync commands for each volume."""
+
+    plan = FailoverPlan(source=source, target=target, volumes=list(volumes), excludes=list(excludes), dry_run=dry_run)
+    plan.tasks = [
+        Task(command=_build_rsync_command(source, target, volume, excludes, dry_run))
+        for volume in plan.volumes
+    ]
+    return plan
+
+
+def execute_plan(plan: FailoverPlan, *, runner: Callable[[List[str]], None] | None = None) -> None:
+    """Execute each command in the plan using the provided runner."""
+
+    if runner is None:
+        import subprocess
+
+        def runner(cmd: List[str]) -> None:  # type: ignore[redefinition]
+            subprocess.run(cmd, check=False)
+
+    for command in plan.commands():
+        runner(command)
+
+
+def simulate_hot_swap(plan: FailoverPlan, *, runner: Callable[[List[str]], None] | None = None) -> None:
+    """Simulate a hot-swap by executing tasks then verifying synchronisation."""
+
+    execute_plan(plan, runner=runner)
+    time.sleep(1)
+    if runner is not None:
+        for command in plan.commands():
+            runner(command)
+
+
+__all__ = [
+    "Task",
+    "FailoverPlan",
+    "build_failover_plan",
+    "execute_plan",
+    "simulate_hot_swap",
+]

--- a/src/hueyos/services/container_management.py
+++ b/src/hueyos/services/container_management.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.container_management")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/simple_chat_gui.py
+++ b/src/hueyos/simple_chat_gui.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.simple_chat_gui")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/storage_management.py
+++ b/src/hueyos/storage_management.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.storage_management")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/system_checks.py
+++ b/src/hueyos/system_checks.py
@@ -34,6 +34,8 @@ REQUIRED_TOOLS: Tuple[str, ...] = ("git", "python3")
 __all__ = [
     "logger",
     "ensure_admin",
+    "log_error",
+    "check_error",
     "check_os_support",
     "check_python_version",
     "system_check",
@@ -67,6 +69,22 @@ def ensure_admin() -> None:
                 "Unable to determine administrator privileges on Windows.",
                 exc_info=True,
             )
+
+
+def log_error(description: str) -> None:
+    """Log an error message through the module logger."""
+
+    logger.error(description)
+
+
+def check_error(command: object, description: str) -> None:
+    """Raise a :class:`RuntimeError` when a command returns a non-zero code."""
+
+    returncode = getattr(command, "returncode", 0)
+    if returncode != 0:
+        message = f"Error: {description} failed with error code {returncode}."
+        log_error(message)
+        raise RuntimeError(message)
 
 
 def _detect_linux_distribution() -> Tuple[str, str]:

--- a/src/hueyos/tensorflow_feed.py
+++ b/src/hueyos/tensorflow_feed.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.tensorflow_feed")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/utils/integrity.py
+++ b/src/hueyos/utils/integrity.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.integrity")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')

--- a/src/hueyos/utils/sorting.py
+++ b/src/hueyos/utils/sorting.py
@@ -1,0 +1,17 @@
+# Auto-generated bridge to legacy module
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+_impl = import_module("huey.memory.PY.sorting")
+__all__ = getattr(_impl, "__all__", [name for name in dir(_impl) if not name.startswith('_')])
+for name in __all__:
+    globals()[name] = getattr(_impl, name)
+
+
+def __getattr__(name: str) -> Any:
+    return getattr(_impl, name)
+
+
+__doc__ = getattr(_impl, '__doc__')


### PR DESCRIPTION
## Summary
- add hueyos namespace bridge modules to expose legacy functionality from the existing huey.memory implementation
- implement failover planning utilities for rsync-based synchronization and simulations
- tighten system check and logging helpers with missing error handling and imports

## Testing
- pytest tests/test_failover.py tests/test_logging_setup.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a1fc4f94832b8254a63d5262cec0)