### PR TITLE
Fix API test imports and streaming behavior

### DIFF
--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -1711,9 +1711,10 @@ async def ai_process_text(
             detail="Text must not be empty for processing.",
         )
 
-    processed = await asyncio.to_thread(AI_PROCESSOR.process_data, request.text)
     if stream:
-        return StreamingResponse(_stream_text(processed), media_type="text/plain")
+        return StreamingResponse(_stream_text(request.text), media_type="text/plain")
+
+    processed = await asyncio.to_thread(AI_PROCESSOR.process_data, request.text)
     return ProcessTextResponse(processed_text=processed)
 
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -13,6 +13,8 @@ import types
 from pathlib import Path
 from typing import Any
 
+import importlib
+
 import pytest
 
 from httpx import ASGITransport, AsyncClient
@@ -48,6 +50,13 @@ py_pkg = types.ModuleType("huey.memory.PY")
 py_pkg.__path__ = [str(REPO_ROOT / "huey" / "memory" / "PY")]
 sys.modules["huey.memory.PY"] = py_pkg
 setattr(memory_pkg, "PY", py_pkg)
+
+api_module = importlib.import_module("huey.api")
+
+# Import the public API symbols used by these tests directly into the module
+# namespace for convenience and to mirror the FastAPI application's exports.
+from hueyos.core.task_scheduler import ResourceSnapshot, TaskScheduler, TaskStatus
+from hueyos.hardware.plugins import SensorReading
 
 ai_module = types.ModuleType("huey.memory.PY.ai_processor")
 


### PR DESCRIPTION
## Summary
- import the FastAPI module and required scheduler and sensor types in the API route tests
- adjust the text processing endpoint to stream the original text when requested instead of the processed payload

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a5adf468832ba4619905470ef695)