### PR TITLE
Add reusable pygpt integration helpers

### DIFF
--- a/src/huey/agents/llm.py
+++ b/src/huey/agents/llm.py
@@ -12,6 +12,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence
 
+from huey.pygpt_integration import prepare_pygpt
+
 
 class LLMProvider(str, Enum):
     """Supported language model providers."""
@@ -96,6 +98,10 @@ class LLMAdapter:
 
     def _register_with_pygpt(self) -> None:
         """Instantiate a pygpt agent wrapper for integration metadata."""
+
+        if not prepare_pygpt():
+            self._pygpt_agent = None
+            return
 
         try:
             if self.provider is LLMProvider.OPENAI:

--- a/src/huey/pygpt_integration.py
+++ b/src/huey/pygpt_integration.py
@@ -1,0 +1,91 @@
+"""Utility helpers for wiring pygpt_net into Monkey Head.
+
+The helpers in this module centralise how we discover and register local copies
+of ``pygpt_net``.  They are intentionally lightweight so they can be imported
+without pulling heavy GUI dependencies during CLI or test runs.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+_PYGPT_PREPARED = False
+
+
+def candidate_src_paths(extra_paths: Iterable[str | os.PathLike[str]] | None = None) -> List[Path]:
+    """Return ordered candidate directories that may house ``pygpt_net`` sources."""
+
+    project_root = Path(__file__).resolve().parents[2]
+    default_paths = [
+        project_root / "pygpt",
+        project_root / "pygpt" / "src",
+        project_root / "src" / "huey" / "memory" / "PY" / "src",
+        project_root / "repo" / "pygpt-MHP" / "src",
+    ]
+
+    env_paths: list[Path] = []
+    env_value = os.environ.get("PYGPT_EXTRA_PATHS")
+    if env_value:
+        for chunk in env_value.split(os.pathsep):
+            if chunk.strip():
+                env_paths.append(Path(chunk).expanduser())
+
+    additional_paths = [Path(path) for path in extra_paths or []]
+
+    seen: set[str] = set()
+    ordered_paths: list[Path] = []
+    for path in (*default_paths, *env_paths, *additional_paths):
+        resolved = str(path)
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        ordered_paths.append(path)
+    return ordered_paths
+
+
+def prepare_pygpt(
+    module_name: str = "pygpt_net",
+    *,
+    search_paths: Iterable[Path] | None = None,
+) -> bool:
+    """Ensure the requested module can be imported.
+
+    When the module is not installed site-wide the function will iteratively add
+    known vendor locations to ``sys.path`` until the import succeeds.
+    """
+
+    global _PYGPT_PREPARED
+    if _PYGPT_PREPARED:
+        return True
+
+    try:
+        importlib.import_module(module_name)
+    except Exception:
+        for candidate in candidate_src_paths(search_paths):
+            if not candidate.exists():
+                continue
+            resolved = str(candidate.resolve())
+            if resolved not in sys.path:
+                sys.path.insert(0, resolved)
+            try:
+                importlib.import_module(module_name)
+            except Exception:
+                continue
+            _PYGPT_PREPARED = True
+            return True
+        return False
+    _PYGPT_PREPARED = True
+    return True
+
+
+def reset_pygpt_state() -> None:
+    """Reset cached preparation state (useful for tests)."""
+
+    global _PYGPT_PREPARED
+    _PYGPT_PREPARED = False
+
+
+__all__ = ["candidate_src_paths", "prepare_pygpt", "reset_pygpt_state"]

--- a/src/huey/run.py
+++ b/src/huey/run.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 from typing import Callable
 
-_PYGPT_PREPARED = False
+from .pygpt_integration import prepare_pygpt
 
 
 def minimal_run() -> None:
@@ -57,46 +57,10 @@ def run_module(target: str) -> None:
         raise ImportError(f"Function {func_name} not found in {module_name}") from exc
     func()
 
-
-def _candidate_src_paths() -> list[Path]:
-    """Return candidate directories that may contain the PyGPT ``src`` tree."""
-
-    project_root = Path(__file__).resolve().parents[2]
-    return [
-        project_root / "pygpt",
-        project_root / "pygpt" / "src",
-        project_root / "src" / "huey" / "memory" / "PY" / "src",
-        project_root / "repo" / "pygpt-MHP" / "src",
-    ]
-
-
 def _prepare_pygpt() -> bool:
     """Ensure :mod:`pygpt_net` is importable either from site-packages or vendors."""
 
-    global _PYGPT_PREPARED
-    if _PYGPT_PREPARED:
-        return True
-
-    try:
-        importlib.import_module("pygpt_net")
-    except Exception:  # pragma: no cover - attempt to load from vendored sources
-        for candidate in _candidate_src_paths():
-            if not candidate.exists():
-                continue
-            resolved = str(candidate.resolve())
-            if resolved not in sys.path:
-                sys.path.insert(0, resolved)
-            try:
-                importlib.import_module("pygpt_net")
-            except Exception:  # pragma: no cover - keep searching
-                continue
-            else:
-                _PYGPT_PREPARED = True
-                return True
-        return False
-    else:
-        _PYGPT_PREPARED = True
-        return True
+    return prepare_pygpt()
 
 
 def _load_cli() -> Callable[..., None]:

--- a/tests/test_pygpt_integration.py
+++ b/tests/test_pygpt_integration.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from huey.pygpt_integration import (
+    candidate_src_paths,
+    prepare_pygpt,
+    reset_pygpt_state,
+)
+
+
+def test_candidate_src_paths_resolves_defaults_and_env(monkeypatch, tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    extra_dir = tmp_path / "custom-src"
+    extra_dir.mkdir()
+    monkeypatch.setenv("PYGPT_EXTRA_PATHS", str(extra_dir))
+
+    paths = candidate_src_paths()
+
+    assert paths[0] == root / "pygpt"
+    assert paths[1] == root / "pygpt" / "src"
+    assert extra_dir in paths
+
+
+def test_prepare_pygpt_uses_extra_paths(monkeypatch, tmp_path):
+    dummy_root = tmp_path / "vendor"
+    package_root = dummy_root / "pygpt_net"
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("__version__ = 'test-vendor'\n")
+
+    monkeypatch.setenv("PYGPT_EXTRA_PATHS", str(dummy_root))
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    monkeypatch.delitem(sys.modules, "pygpt_net", raising=False)
+
+    reset_pygpt_state()
+    assert prepare_pygpt()
+
+    import pygpt_net  # type: ignore
+
+    assert getattr(pygpt_net, "__version__", None) == "test-vendor"
+    reset_pygpt_state()


### PR DESCRIPTION
## Summary
- add a shared helper to centralize pygpt_net discovery and sys.path setup
- update runtime entrypoints and LLM adapter to use the new integration helper
- add tests covering pygpt path discovery and vendor import fallback

## Testing
- pytest tests/test_pygpt_integration.py tests/test_run_minimal.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a70f9210832b9849a9675fd21ad5)