### PR TITLE
Expand requirements with packaging and lint dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,9 @@ orjson==3.11.4 ; python_version >= "3.12" and python_version < "3.15"
 psutil==7.1.3 ; python_version >= "3.12" and python_version < "3.15"
 packaging==25.0 ; python_version >= "3.12" and python_version < "3.15"
 typing-extensions==4.15.0 ; python_version >= "3.12" and python_version < "3.15"
+setuptools==75.8.0 ; python_version >= "3.12" and python_version < "3.15"
+wheel==0.45.1 ; python_version >= "3.12" and python_version < "3.15"
+pip==25.0.1 ; python_version >= "3.12" and python_version < "3.15"
 
 # --- ML + SDKs ---
 aiohappyeyeballs==2.6.1 ; python_version >= "3.12" and python_version < "3.15"
@@ -130,6 +133,9 @@ pip-tools==7.5.2 ; python_version >= "3.12" and python_version < "3.15"
 uv==0.9.10 ; python_version >= "3.12" and python_version < "3.15"
 ipython==8.27.0 ; python_version >= "3.12" and python_version < "3.15"
 rich==14.2.0 ; python_version >= "3.12" and python_version < "3.15"
+flake8==7.3.0 ; python_version >= "3.12" and python_version < "3.15"
+flake8-bugbear==24.8.19 ; python_version >= "3.12" and python_version < "3.15"
+bandit==1.7.9 ; python_version >= "3.12" and python_version < "3.15"
 
 # --- Audio IO (optional by marker only) ---
 sounddevice==0.5.3 ; python_version >= "3.12" and python_version < "3.15"


### PR DESCRIPTION
## Summary
- add pip, setuptools, and wheel to the core requirements to pin installation tooling
- include flake8, flake8-bugbear, and bandit in the dev toolchain list for lint/security coverage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a904be1c832ba5517e51d83f3b29)