### PR TITLE
Align Python support with changeover targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > HueyOS is a modular robotic AI/OS that blends retro-computing aesthetics with modern Linux, clustered compute, and a constitutional governance model (the **Cloud Pyramid**). It operates offline-first with optional API use. **Governance remains decentralized while memory remains unified.**
 
 ![License](https://img.shields.io/badge/license-GPLv3-blue)
-![Python](https://img.shields.io/badge/python-3.12–3.14-blue)
+![Python](https://img.shields.io/badge/python-3.14.x-blue)
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 Thank you for your interest in contributing. This document explains the workflow, tooling, and quality bars for changes to **HueyOS** and related components.
 
 > TL;DR checklist
-> - Use Python **3.12–3.14** (3.14 support lands after the **2025‑10‑31** certification gate; `audioop-lts`/`standard-aifc` wheels tracked for 3.14).
+> - Use Python **3.14.x** (3.13 remains legacy/pre-changeover; `audioop-lts`/`standard-aifc` wheels tracked for 3.14).
 > - Create an isolated environment and install dependencies.  
 > - Enable `pre-commit` hooks.  
 > - Follow **Conventional Commits** and branch naming.  
@@ -47,8 +47,8 @@ If your change meaningfully alters public behavior or APIs, it **must** include 
 
 ## Prerequisites
 
-- Python **3.12–3.14** installed and available on PATH
-  - If you use `pyenv`: `pyenv install 3.13.5 && pyenv local 3.13.5` today → plan to `pyenv install 3.14.x` once the post‑Oct‑31 builds land
+- Python **3.14.x** installed and available on PATH
+  - If you use `pyenv`: `pyenv install 3.14.0 && pyenv local 3.14.0` (3.13.x is legacy/pre-changeover only)
 - Git ≥ 2.40
 - Make (optional but convenient)
 - Docker (optional) if you run sandboxed plugins or containers during tests

--- a/setup/DebianTrixie/install.sh
+++ b/setup/DebianTrixie/install.sh
@@ -202,26 +202,25 @@ function ensure_python_runtime() {
 
     local version
     version=$("$python_bin" -V 2>&1 | awk '{print $2}')
-    if [[ $version != 3.13.* && $version != 3.14.* ]]; then
+    if [[ $version != 3.14.* ]]; then
         cat <<'PYWARN' >&2
-Python 3.13.x or 3.14.x is required for the Monkey Head Project runtime but was not detected.
-Debian Trixie currently ships Python 3.12. Please build CPython 3.13.5 today and
-schedule the upgrade to Python 3.14.x immediately after the 2025-10-31 certification gate.
-Mirror the Dockerfile build stage when compiling from source:
+Python 3.14.x is required for the Monkey Head Project runtime but was not detected.
+Debian Trixie currently ships Python 3.12. Please build CPython 3.14.x to meet the
+post-changeover target. Mirror the Dockerfile build stage when compiling from source:
 
   apt-get install -y --no-install-recommends \
       build-essential ca-certificates curl wget xz-utils \
       libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
       libffi-dev liblzma-dev tk-dev uuid-dev
-  curl -fsSLO https://www.python.org/ftp/python/${PYTHON_FALLBACK:-3.13.5}/Python-${PYTHON_FALLBACK:-3.13.5}.tgz
-  tar -xzf Python-${PYTHON_FALLBACK:-3.13.5}.tgz
-  cd Python-${PYTHON_FALLBACK:-3.13.5}
+  curl -fsSLO https://www.python.org/ftp/python/${PYTHON_FALLBACK:-3.14.0}/Python-${PYTHON_FALLBACK:-3.14.0}.tgz
+  tar -xzf Python-${PYTHON_FALLBACK:-3.14.0}.tgz
+  cd Python-${PYTHON_FALLBACK:-3.14.0}
   ./configure --prefix=/usr/local --enable-optimizations --with-lto --enable-shared
   make -j"$(nproc)"
   make altinstall
   ldconfig
 
-Re-run this installer after Python 3.13/3.14 is available (python3.14, python3.13 or python3).
+Re-run this installer after Python 3.14 is available (python3.14).
 PYWARN
         exit 1
     fi

--- a/src/hueyos/system_checks.py
+++ b/src/hueyos/system_checks.py
@@ -27,8 +27,8 @@ logger = logging.getLogger(__name__)
 SUPPORTED_DISTRO_ID = "debian"
 SUPPORTED_DISTRO_CODENAME = "forky"
 MIN_KERNEL_VERSION = Version("6.17.0")
-MIN_PYTHON_VERSION = (3, 12)
-MAX_PYTHON_VERSION = (3, 14)
+MIN_PYTHON_VERSION = (3, 14)
+MAX_PYTHON_VERSION = (3, 15)
 REQUIRED_TOOLS: Tuple[str, ...] = ("git", "python3")
 
 __all__ = [

--- a/tests/test_python_version.py
+++ b/tests/test_python_version.py
@@ -17,10 +17,19 @@ def test_python_313_warning():
         log.warning.assert_called_once()
 
 
-def test_python_supported_no_warning():
+def test_python_314_supported_no_warning():
     with (
-        patch("hueyos.core.system_checks.sys.version_info", (3, 12, 0)),
+        patch("hueyos.core.system_checks.sys.version_info", (3, 14, 1)),
         patch("hueyos.core.system_checks.logger") as log,
     ):
         check_python_version()
         log.warning.assert_not_called()
+
+
+def test_python_315_warning():
+    with (
+        patch("hueyos.core.system_checks.sys.version_info", (3, 15, 0)),
+        patch("hueyos.core.system_checks.logger") as log,
+    ):
+        check_python_version()
+        log.warning.assert_called_once()

--- a/tests/test_system_checks_module.py
+++ b/tests/test_system_checks_module.py
@@ -46,6 +46,19 @@ def test_check_os_support_warns_for_non_debian_linux(monkeypatch, caplog):
 def test_check_python_version_warns_on_experimental_release(monkeypatch, caplog):
     class FakeInfo:
         major = 3
+        minor = 15
+
+    monkeypatch.setattr(system_checks.sys, "version_info", FakeInfo())
+
+    with caplog.at_level(logging.WARNING):
+        system_checks.check_python_version()
+
+    assert "Python 3.15 detected" in caplog.text
+
+
+def test_check_python_version_accepts_primary_target(monkeypatch, caplog):
+    class FakeInfo:
+        major = 3
         minor = 14
 
     monkeypatch.setattr(system_checks.sys, "version_info", FakeInfo())
@@ -53,7 +66,7 @@ def test_check_python_version_warns_on_experimental_release(monkeypatch, caplog)
     with caplog.at_level(logging.WARNING):
         system_checks.check_python_version()
 
-    assert "Python 3.14 detected" in caplog.text
+    assert "Python 3.14" not in caplog.text
 
 
 def test_system_check_collects_expected_results(monkeypatch):


### PR DESCRIPTION
## Summary
- Raise the runtime compatibility window to Python 3.14.x in system checks and update tests to treat 3.15 as experimental
- Refresh installer guidance and documentation to emphasize the 3.14 changeover target

## Testing
- pytest tests/test_python_version.py tests/test_system_checks_module.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922aa4e4214832b992312ed3f1dc805)