### PR TITLE
Skip hidden files during auto sort and update master plan docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ At a conceptual level:
 
 The **Master Plan JSON** is the canonical, machine-readable blueprint for Huey’s hardware, governance, memory model, and history. The current canonical version is:
 
-- **`master-plan-v14.5`** — *“Master Plan V14.5: structurally expanded successor to V14.0.”*  
-  It preserves all constitutional, hardware, and history content from V14.0 and adds explicit meta/lineage blocks, process skeletons, and templates for nodes, districts, citizens, and governance workflows.
+- **`master-plan-v13.json`** — *“Master Plan V13: canonical blueprint for V13.x releases.”*
+  It captures the governance, hardware, and historical context referenced throughout this README and is consumed by Huey at boot time.
 
 Key points:
 
-- **Schema** — Version 11 (frozen for V14.x); all new content must conform to this schema.
-- **Lineage** — V14.5 compiles and refines V0.1, V2-final, V3, V4, V5, V7, V8, V10, V11 (and 11.5), V12 (and 12.5), and the entire V13 family, then locks those decisions for training and reference.
+- **Schema** — Version 11 (frozen for the V13 family); all new content must conform to this schema.
+- **Lineage** — V13 compiles and refines V0.1, V2-final, V3, V4, V5, V7, V8, V10, V11 (and 11.5), and V12 (and 12.5), then locks those decisions for training and reference.
 - **Role in the repo**  
   - This README is the **human-facing narrative**.  
   - The Master Plan JSON is the **AI-facing canonical spec**, consumed by Huey at boot and by tooling during orchestration and training.
@@ -110,7 +110,7 @@ If you change the governance model, hardware assumptions, or key policies, updat
 | `docs/`                   | Constitution, governance, architecture, API, plugins  |
 | `docs/api-reference.md`   | FastAPI reference and `curl` recipes                  |
 | `docs/sensor-plugins.md`  | Sensor plugin development guide                       |
-| `docs/master-plan/`       | Master Plan JSONs (V14.x is canonical)               |
+| `master-plan-v13.json`    | Canonical Master Plan JSON consumed at runtime       |
 | `huey/`                   | Core runtime and service modules                      |
 | `huey/api/`               | FastAPI surface                                       |
 | `setup/`                  | Installer scripts, ISO builder, provisioning configs  |

--- a/src/huey/utils/auto_sort.py
+++ b/src/huey/utils/auto_sort.py
@@ -100,6 +100,12 @@ def auto_sort_memory(
     -------
     dict
         A summary containing the moved and skipped files.
+
+    Notes
+    -----
+    Hidden files (those beginning with a period) are left untouched and are
+    included in the ``skipped`` list to avoid copying OS metadata into the
+    organised memory tree.
     """
 
     source_path = _normalise_source(source_dir)
@@ -113,6 +119,9 @@ def auto_sort_memory(
 
     for item in sorted(source_path.iterdir()):
         if not item.is_file():
+            continue
+        if item.name.startswith("."):
+            skipped.append(item.name)
             continue
         target_dir_name = _determine_target_dir(item)
         target_dir = destination_path / target_dir_name

--- a/tests/test_auto_sort.py
+++ b/tests/test_auto_sort.py
@@ -45,3 +45,16 @@ def test_auto_sort_missing_source(monkeypatch, tmp_path):
     monkeypatch.setenv("MEMORY_PATH", str(memory_root))
     with pytest.raises(FileNotFoundError):
         auto_sort_memory(source_dir=memory_root / "does-not-exist")
+
+
+def test_auto_sort_skips_hidden_files(monkeypatch, tmp_path):
+    memory_root = tmp_path / "memory"
+    monkeypatch.setenv("MEMORY_PATH", str(memory_root))
+    raw = _prepare_raw(memory_root)
+    hidden_file = raw / ".DS_Store"
+    hidden_file.write_text("metadata")
+
+    summary = auto_sort_memory()
+
+    assert hidden_file.exists()
+    assert ".DS_Store" in summary["skipped"]


### PR DESCRIPTION
## Summary
- skip hidden files during memory auto-sorting and document the behavior
- add coverage ensuring hidden files remain untouched
- clarify README references to the canonical master plan JSON location

## Testing
- pytest tests/test_auto_sort.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ace82a70832ba461ab27d412d2c2)