### PR TITLE
Update setuptools requirement for security

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,8 @@ orjson==3.11.4 ; python_version >= "3.12" and python_version < "3.15"
 psutil==7.1.3 ; python_version >= "3.12" and python_version < "3.15"
 packaging==25.0 ; python_version >= "3.12" and python_version < "3.15"
 typing-extensions==4.15.0 ; python_version >= "3.12" and python_version < "3.15"
-setuptools==75.8.0 ; python_version >= "3.12" and python_version < "3.15"
+# Security: fix setuptools path traversal (arbitrary file write)
+setuptools>=78.1.1 ; python_version >= "3.12" and python_version < "3.15"
 wheel==0.45.1 ; python_version >= "3.12" and python_version < "3.15"
 pip==25.0.1 ; python_version >= "3.12" and python_version < "3.15"
 


### PR DESCRIPTION
## Summary
- bump setuptools dependency to >=78.1.1 to address path traversal vulnerability
- note security fix comment in requirements file

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bcbddf4c832b85d320fa2f079613)