### PR TITLE
Pin setuptools to patched version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -25,6 +25,9 @@ attrs==25.4.0
 certifi==2025.11.12
 cryptography==45.0.4
 
+# Packaging / build tools
+setuptools==78.1.1
+
 # Linux input support (only relevant on Linux)
 evdev==1.9.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ orjson==3.11.4 ; python_version >= "3.12" and python_version < "3.15"
 psutil==7.1.3 ; python_version >= "3.12" and python_version < "3.15"
 packaging==25.0 ; python_version >= "3.12" and python_version < "3.15"
 typing-extensions==4.15.0 ; python_version >= "3.12" and python_version < "3.15"
-setuptools==75.8.0 ; python_version >= "3.12" and python_version < "3.15"
+setuptools>=78.1.1 ; python_version >= "3.12" and python_version < "3.15"
 wheel==0.45.1 ; python_version >= "3.12" and python_version < "3.15"
 pip==25.0.1 ; python_version >= "3.12" and python_version < "3.15"
 


### PR DESCRIPTION
## Summary
- raise setuptools requirement to a non-vulnerable version
- pin setuptools in constraints for deterministic installs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bcc3dde4832b9ed115954c14e316)