### PR TITLE
Add local py-gpt placeholder module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ dist/
 *.log
 *.sqlite
 *.sqlite3
+src/huey/memory/LOGS/*
+!src/huey/memory/LOGS/.gitkeep
 
 # Editor backups/swaps
 *~

--- a/repo/py-gpt/README.md
+++ b/repo/py-gpt/README.md
@@ -1,0 +1,5 @@
+# Py-GPT vendor placeholder
+
+This directory emulates the upstream [`py-gpt`](https://github.com/szczyglis-dev/py-gpt) submodule used by Monkey Head. It contains a lightweight stub of the `pygpt_net` package so the project can run and test without fetching the full upstream repository.
+
+If you need the full implementation, replace this directory with the real submodule checkout or install `pygpt-net` from PyPI.

--- a/repo/py-gpt/pyproject.toml
+++ b/repo/py-gpt/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools>=67"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pygpt-net"
+version = "0.0.0-local"
+description = "Stub vendor of the py-gpt project for Monkey Head development"
+authors = [{name = "Monkey Head Team"}]
+readme = "README.md"
+requires-python = ">=3.11"

--- a/repo/py-gpt/src/pygpt_net/__init__.py
+++ b/repo/py-gpt/src/pygpt_net/__init__.py
@@ -1,0 +1,63 @@
+"""Minimal stub of the :mod:`pygpt_net` package for local development.
+
+This placeholder mirrors the directory layout of the upstream `py-gpt`
+project without pulling in its heavy dependencies. It focuses on the
+behaviour Monkey Head relies on during tests:
+
+* Expose a ``__version__`` attribute so callers can confirm the vendored
+  package is available.
+* Ensure NLTK data uses a private cache directory to avoid polluting
+  system-level paths or requiring shared writable locations.
+
+If you need the full feature set, replace this stub with the actual
+upstream repository checkout.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+from pathlib import Path
+from typing import Final
+
+__all__ = ["__version__"]
+
+__version__ = "0.0.0-local"
+
+_NLTK_ENV_VAR: Final[str] = "NLTK_DATA"
+_CUSTOM_ENV_VAR: Final[str] = "PYGPT_NLTK_DATA_DIR"
+
+
+def _ensure_private_nltk_data() -> None:
+    """Force NLTK data into a per-user directory to avoid shared caches."""
+
+    if os.environ.get(_NLTK_ENV_VAR):
+        return
+
+    target_dir = Path(
+        os.environ.get(
+            _CUSTOM_ENV_VAR,
+            Path.home() / ".cache" / "pygpt_net" / "nltk_data",
+        )
+    )
+
+    try:
+        target_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    except OSError:
+        # If the directory cannot be created we silently fall back to the
+        # upstream defaults rather than break runtime imports.
+        return
+
+    os.environ[_NLTK_ENV_VAR] = str(target_dir)
+
+    nltk_spec = importlib.util.find_spec("nltk")
+    if nltk_spec is None:
+        return
+
+    nltk = importlib.import_module("nltk")
+    resolved_dir = str(target_dir)
+    if resolved_dir not in nltk.data.path:
+        nltk.data.path.insert(0, resolved_dir)
+
+
+_ensure_private_nltk_data()

--- a/src/huey/pygpt_integration.py
+++ b/src/huey/pygpt_integration.py
@@ -22,6 +22,8 @@ def candidate_src_paths(extra_paths: Iterable[str | os.PathLike[str]] | None = N
     default_paths = [
         project_root / "pygpt",
         project_root / "pygpt" / "src",
+        project_root / "repo" / "py-gpt",
+        project_root / "repo" / "py-gpt" / "src",
         project_root / "src" / "huey" / "memory" / "PY" / "src",
         project_root / "repo" / "pygpt-MHP" / "src",
     ]


### PR DESCRIPTION
## Summary
- add a vendored `py-gpt` placeholder with a minimal `pygpt_net` stub and metadata
- update pygpt discovery paths to search the new vendored location
- document and ignore generated log directories created under `src/huey/memory/LOGS`

## Testing
- pytest -q --disable-warnings --maxfail=1


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bbd62558832bb8b3021b56e1cb6e)