### PR TITLE
Add image model fine-tuning pipeline and CLI

### DIFF
--- a/docs/model-training/image_fine_tuning.md
+++ b/docs/model-training/image_fine_tuning.md
@@ -1,0 +1,73 @@
+# Image fine-tuning workflow for Monkey Head
+
+This guide walks through preparing an image dataset, fine-tuning a pretrained model, and exporting the resulting assets so they can be consumed by the Monkey Head system.
+
+## 1. Prepare the dataset
+
+Organise images into a `train/` and `val/` (or `validation/`) split, with one subfolder per class:
+
+```
+my-dataset/
+  train/
+    class_a/
+      img001.jpg
+      img002.jpg
+    class_b/
+      ...
+  val/
+    class_a/
+    class_b/
+```
+
+Recommendations:
+
+- Use the same class folder names across train and val splits.
+- Keep classes balanced where possible to avoid skewed accuracy.
+- Resize or crop very large inputs to avoid running out of memory.
+
+## 2. Launch training
+
+The CLI wraps the training pipeline exposed at `monkey_head.training`:
+
+```bash
+python tools/train_image_model.py \
+    --data-dir /path/to/my-dataset \
+    --output-dir /models/monkey-head/experiments/resnet18 \
+    --model-name resnet18 \
+    --epochs 10 \
+    --batch-size 32
+```
+
+Key flags:
+
+- `--model-name` — choose from `resnet18` or `mobilenet_v3_small` (both load ImageNet weights).
+- `--freeze-backbone` — update only the classifier head; useful when the dataset is small.
+- `--device` — default is auto-detection; override with `cpu` for environments without CUDA.
+- `--patience` — early stopping once validation accuracy stops improving.
+
+## 3. What the training loop does
+
+- Loads pretrained weights and swaps the classifier layer to match your class count.
+- Applies standard data augmentation (random resize, flip, colour jitter) and normalization.
+- Optimises with SGD + momentum and a step LR scheduler; loss is cross-entropy.
+- Tracks train/val loss and accuracy each epoch and keeps the best-performing weights.
+
+The underlying code lives in `src/monkey_head/training/pipeline.py` if you need to adjust architectures or schedulers.
+
+## 4. Outputs and integration
+
+The script writes a complete set of artifacts to the chosen `--output-dir`:
+
+- `model_state.pt` — best-performing state dict for continued training or debugging.
+- `model_scripted.pt` — TorchScript export for low-overhead inference.
+- `model.onnx` — ONNX graph for deployment to runtimes that support ONNX.
+- `model_metadata.json` — training configuration, class names, and headline metrics.
+- `training_history.json` — per-epoch loss/accuracy and learning-rate trajectory.
+
+After export, the pipeline appends an entry to `huey/models/registry.json` so the Monkey Head stack can discover the new model alongside its metadata.
+
+## 5. Next steps
+
+- Run a quick smoke test by loading `model_scripted.pt` in a minimal inference script before deploying to production robots.
+- Track dataset provenance and class definitions in `model_metadata.json` for reproducibility.
+- If you change the backbone or introduce a new architecture, update `WEIGHTS_REGISTRY` in `pipeline.py` so the CLI can expose it.

--- a/src/monkey_head/training/__init__.py
+++ b/src/monkey_head/training/__init__.py
@@ -1,0 +1,21 @@
+"""Training utilities for fine-tuning image models for Monkey Head."""
+
+from .pipeline import (
+    TrainingConfig,
+    TrainingSummary,
+    build_transforms,
+    export_artifacts,
+    integrate_model,
+    prepare_dataloaders,
+    run_training,
+)
+
+__all__ = [
+    "TrainingConfig",
+    "TrainingSummary",
+    "build_transforms",
+    "export_artifacts",
+    "integrate_model",
+    "prepare_dataloaders",
+    "run_training",
+]

--- a/src/monkey_head/training/pipeline.py
+++ b/src/monkey_head/training/pipeline.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader
+from torchvision import datasets, models, transforms
+
+
+WEIGHTS_REGISTRY = {
+    "resnet18": models.ResNet18_Weights.DEFAULT,
+    "mobilenet_v3_small": models.MobileNet_V3_Small_Weights.DEFAULT,
+}
+
+
+@dataclass
+class TrainingConfig:
+    data_dir: Path
+    output_dir: Path
+    model_name: str = "resnet18"
+    batch_size: int = 32
+    num_workers: int = 2
+    num_epochs: int = 5
+    learning_rate: float = 1e-3
+    weight_decay: float = 1e-4
+    momentum: float = 0.9
+    image_size: int = 224
+    patience: int = 2
+    freeze_backbone: bool = False
+    device: str = field(default_factory=lambda: "cuda" if torch.cuda.is_available() else "cpu")
+
+
+@dataclass
+class TrainingSummary:
+    best_epoch: int
+    best_val_accuracy: float
+    history: List[Dict[str, float]]
+
+
+def build_transforms(image_size: int) -> Dict[str, transforms.Compose]:
+    """Create training and validation transforms for image classification."""
+
+    return {
+        "train": transforms.Compose(
+            [
+                transforms.RandomResizedCrop(image_size),
+                transforms.RandomHorizontalFlip(),
+                transforms.ColorJitter(brightness=0.1, contrast=0.1, saturation=0.1),
+                transforms.ToTensor(),
+                transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+            ]
+        ),
+        "val": transforms.Compose(
+            [
+                transforms.Resize(int(image_size * 1.15)),
+                transforms.CenterCrop(image_size),
+                transforms.ToTensor(),
+                transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+            ]
+        ),
+    }
+
+
+def prepare_dataloaders(config: TrainingConfig) -> Tuple[Dict[str, DataLoader], List[str]]:
+    """Create :class:`DataLoader` objects from a train/val folder structure."""
+
+    transforms_map = build_transforms(config.image_size)
+    train_dir = config.data_dir / "train"
+    if not train_dir.exists():
+        raise FileNotFoundError("Training data not found: expected a 'train' folder")
+    val_dir_candidates = [config.data_dir / "val", config.data_dir / "validation"]
+    val_dir = next((candidate for candidate in val_dir_candidates if candidate.exists()), None)
+    if val_dir is None:
+        raise FileNotFoundError("Validation data not found: expected a 'val' or 'validation' folder")
+
+    datasets_map = {
+        "train": datasets.ImageFolder(train_dir, transform=transforms_map["train"]),
+        "val": datasets.ImageFolder(val_dir, transform=transforms_map["val"]),
+    }
+    class_names = datasets_map["train"].classes
+
+    dataloaders = {
+        split: DataLoader(
+            ds,
+            batch_size=config.batch_size,
+            shuffle=split == "train",
+            num_workers=config.num_workers,
+            pin_memory=torch.cuda.is_available(),
+        )
+        for split, ds in datasets_map.items()
+    }
+
+    return dataloaders, class_names
+
+
+def _replace_classifier(model: nn.Module, num_classes: int, model_name: str) -> nn.Module:
+    if model_name == "resnet18":
+        in_features = model.fc.in_features
+        model.fc = nn.Linear(in_features, num_classes)
+    elif model_name == "mobilenet_v3_small":
+        in_features = model.classifier[3].in_features
+        model.classifier[3] = nn.Linear(in_features, num_classes)
+    else:
+        raise ValueError(f"Unsupported model '{model_name}' for classifier replacement")
+
+    return model
+
+
+def initialise_model(model_name: str, num_classes: int, freeze_backbone: bool) -> nn.Module:
+    if model_name not in WEIGHTS_REGISTRY:
+        raise ValueError(f"Model '{model_name}' is not available. Choose from: {', '.join(WEIGHTS_REGISTRY)}")
+
+    weights = WEIGHTS_REGISTRY[model_name]
+    model_builder = models.__dict__[model_name]
+    model = model_builder(weights=weights)
+
+    if freeze_backbone:
+        for param in model.parameters():
+            param.requires_grad = False
+
+    model = _replace_classifier(model, num_classes, model_name)
+    return model
+
+
+def train_one_epoch(
+    model: nn.Module,
+    dataloader: DataLoader,
+    criterion: nn.Module,
+    optimizer: optim.Optimizer,
+    device: torch.device,
+) -> Dict[str, float]:
+    model.train()
+    running_loss = 0.0
+    correct = 0
+    total = 0
+
+    for inputs, labels in dataloader:
+        inputs, labels = inputs.to(device), labels.to(device)
+
+        optimizer.zero_grad()
+        outputs = model(inputs)
+        loss = criterion(outputs, labels)
+        loss.backward()
+        optimizer.step()
+
+        running_loss += loss.item() * inputs.size(0)
+        predictions = outputs.argmax(dim=1)
+        correct += (predictions == labels).sum().item()
+        total += labels.size(0)
+
+    epoch_loss = running_loss / total
+    epoch_acc = correct / total
+    return {"loss": epoch_loss, "accuracy": epoch_acc}
+
+
+def evaluate(model: nn.Module, dataloader: DataLoader, criterion: nn.Module, device: torch.device) -> Dict[str, float]:
+    model.eval()
+    running_loss = 0.0
+    correct = 0
+    total = 0
+
+    with torch.no_grad():
+        for inputs, labels in dataloader:
+            inputs, labels = inputs.to(device), labels.to(device)
+            outputs = model(inputs)
+            loss = criterion(outputs, labels)
+            running_loss += loss.item() * inputs.size(0)
+            predictions = outputs.argmax(dim=1)
+            correct += (predictions == labels).sum().item()
+            total += labels.size(0)
+
+    epoch_loss = running_loss / total
+    epoch_acc = correct / total
+    return {"loss": epoch_loss, "accuracy": epoch_acc}
+
+
+def train_model(
+    model: nn.Module,
+    dataloaders: Dict[str, DataLoader],
+    config: TrainingConfig,
+) -> Tuple[nn.Module, TrainingSummary]:
+    device = torch.device(config.device)
+    model.to(device)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(
+        filter(lambda p: p.requires_grad, model.parameters()),
+        lr=config.learning_rate,
+        momentum=config.momentum,
+        weight_decay=config.weight_decay,
+    )
+    scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=3, gamma=0.1)
+
+    best_accuracy = 0.0
+    best_state = None
+    best_epoch = 0
+    history: List[Dict[str, float]] = []
+    epochs_without_improvement = 0
+
+    for epoch in range(1, config.num_epochs + 1):
+        train_metrics = train_one_epoch(model, dataloaders["train"], criterion, optimizer, device)
+        val_metrics = evaluate(model, dataloaders["val"], criterion, device)
+        scheduler.step()
+
+        history.append(
+            {
+                "epoch": int(epoch),
+                "train_loss": float(train_metrics["loss"]),
+                "train_accuracy": float(train_metrics["accuracy"]),
+                "val_loss": float(val_metrics["loss"]),
+                "val_accuracy": float(val_metrics["accuracy"]),
+                "learning_rate": float(scheduler.get_last_lr()[0]),
+            }
+        )
+
+        if val_metrics["accuracy"] > best_accuracy:
+            best_accuracy = val_metrics["accuracy"]
+            best_state = model.state_dict()
+            best_epoch = epoch
+            epochs_without_improvement = 0
+        else:
+            epochs_without_improvement += 1
+
+        if epochs_without_improvement >= config.patience:
+            break
+
+    if best_state is not None:
+        model.load_state_dict(best_state)
+
+    summary = TrainingSummary(
+        best_epoch=int(best_epoch or history[-1]["epoch"]),
+        best_val_accuracy=float(best_accuracy),
+        history=history,
+    )
+    return model, summary
+
+
+def export_artifacts(
+    model: nn.Module,
+    class_names: List[str],
+    config: TrainingConfig,
+    summary: TrainingSummary,
+) -> Dict[str, Path]:
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    device = torch.device(config.device)
+    model.to(device)
+    model.eval()
+
+    artifacts: Dict[str, Path] = {}
+
+    weights_path = config.output_dir / "model_state.pt"
+    torch.save(model.state_dict(), weights_path)
+    artifacts["state_dict"] = weights_path
+
+    metadata = {
+        "model_name": config.model_name,
+        "class_names": class_names,
+        "config": {
+            "batch_size": config.batch_size,
+            "num_epochs": config.num_epochs,
+            "learning_rate": config.learning_rate,
+            "weight_decay": config.weight_decay,
+            "momentum": config.momentum,
+            "image_size": config.image_size,
+            "freeze_backbone": config.freeze_backbone,
+        },
+        "summary": {
+            "best_epoch": summary.best_epoch,
+            "best_val_accuracy": summary.best_val_accuracy,
+        },
+    }
+    metadata_path = config.output_dir / "model_metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2))
+    artifacts["metadata"] = metadata_path
+
+    scripted_path = config.output_dir / "model_scripted.pt"
+    example_input = torch.randn(1, 3, config.image_size, config.image_size, device=device)
+    scripted_model = torch.jit.trace(model, example_input)
+    scripted_model.save(scripted_path)
+    artifacts["torchscript"] = scripted_path
+
+    onnx_path = config.output_dir / "model.onnx"
+    torch.onnx.export(
+        model,
+        example_input,
+        onnx_path,
+        input_names=["input"],
+        output_names=["logits"],
+        dynamic_axes={"input": {0: "batch"}, "logits": {0: "batch"}},
+        opset_version=17,
+    )
+    artifacts["onnx"] = onnx_path
+
+    summary_path = config.output_dir / "training_history.json"
+    summary_path.write_text(json.dumps([row for row in summary.history], indent=2))
+    artifacts["history"] = summary_path
+
+    return artifacts
+
+
+def integrate_model(
+    artifacts: Dict[str, Path],
+    class_names: Iterable[str],
+    summary: TrainingSummary,
+    registry_dir: Path | None = None,
+) -> Path:
+    registry_dir = registry_dir or Path("huey/models")
+    registry_dir.mkdir(parents=True, exist_ok=True)
+    registry_path = registry_dir / "registry.json"
+
+    registry: List[Dict[str, object]] = []
+    if registry_path.exists():
+        registry = json.loads(registry_path.read_text())
+
+    record = {
+        "state_dict": str(artifacts.get("state_dict")),
+        "torchscript": str(artifacts.get("torchscript")),
+        "onnx": str(artifacts.get("onnx")),
+        "metadata": str(artifacts.get("metadata")),
+        "history": str(artifacts.get("history")),
+        "classes": list(class_names),
+        "best_val_accuracy": summary.best_val_accuracy,
+    }
+    registry.append(record)
+    registry_path.write_text(json.dumps(registry, indent=2))
+    return registry_path
+
+
+def run_training(config: TrainingConfig) -> Tuple[Dict[str, Path], TrainingSummary]:
+    dataloaders, class_names = prepare_dataloaders(config)
+    model = initialise_model(config.model_name, num_classes=len(class_names), freeze_backbone=config.freeze_backbone)
+    model, summary = train_model(model, dataloaders, config)
+    artifacts = export_artifacts(model, class_names, config, summary)
+    integrate_model(artifacts, class_names, summary)
+    return artifacts, summary
+
+
+__all__ = [
+    "TrainingConfig",
+    "TrainingSummary",
+    "build_transforms",
+    "prepare_dataloaders",
+    "initialise_model",
+    "train_one_epoch",
+    "evaluate",
+    "train_model",
+    "export_artifacts",
+    "integrate_model",
+    "run_training",
+]

--- a/tools/train_image_model.py
+++ b/tools/train_image_model.py
@@ -1,0 +1,68 @@
+"""CLI entrypoint for fine-tuning image classifiers for Monkey Head.
+
+Usage example::
+
+    python tools/train_image_model.py \
+        --data-dir /data/monkey-images \
+        --output-dir /models/monkey-head/experiments/resnet18 \
+        --model-name resnet18 \
+        --epochs 10
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import torch
+
+from monkey_head.training import TrainingConfig, run_training
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fine-tune a pretrained image model for Monkey Head")
+    parser.add_argument("--data-dir", type=Path, required=True, help="Folder containing train/ and val/ splits")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Where to write model artifacts")
+    parser.add_argument("--model-name", default="resnet18", choices=["resnet18", "mobilenet_v3_small"], help="Backbone to fine-tune")
+    parser.add_argument("--batch-size", type=int, default=32, help="Mini-batch size")
+    parser.add_argument("--num-workers", type=int, default=2, help="Data loader worker processes")
+    parser.add_argument("--epochs", type=int, default=5, help="Number of training epochs")
+    parser.add_argument("--learning-rate", type=float, default=1e-3, help="Optimizer learning rate")
+    parser.add_argument("--weight-decay", type=float, default=1e-4, help="L2 weight decay")
+    parser.add_argument("--momentum", type=float, default=0.9, help="SGD momentum")
+    parser.add_argument("--image-size", type=int, default=224, help="Input resolution for the model")
+    parser.add_argument("--patience", type=int, default=2, help="Early stopping patience on validation accuracy")
+    parser.add_argument("--freeze-backbone", action="store_true", help="Freeze convolutional backbone layers")
+    parser.add_argument("--device", choices=["cpu", "cuda"], default=None, help="Force device selection")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    device = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+
+    config = TrainingConfig(
+        data_dir=args.data_dir,
+        output_dir=args.output_dir,
+        model_name=args.model_name,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        num_epochs=args.epochs,
+        learning_rate=args.learning_rate,
+        weight_decay=args.weight_decay,
+        momentum=args.momentum,
+        image_size=args.image_size,
+        patience=args.patience,
+        freeze_backbone=args.freeze_backbone,
+        device=device,
+    )
+
+    artifacts, summary = run_training(config)
+    print("Training complete")
+    print(f"Best validation accuracy: {summary.best_val_accuracy:.4f}")
+    for name, path in artifacts.items():
+        print(f"Saved {name}: {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add reusable training utilities for loading pretrained vision backbones, fine-tuning them, and exporting artifacts
- provide a CLI helper to launch training jobs against train/val image folders
- document the dataset preparation steps, training loop defaults, and how the exported model integrates with Monkey Head

## Testing
- python -m compileall src/monkey_head/training tools/train_image_model.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938f93777ac832b9c79bc361589d1a3)