### PR TITLE
Add file-audit reports for duplicate files and placeholder keywords

### DIFF
--- a/reports/file-audit/duplicate-files.md
+++ b/reports/file-audit/duplicate-files.md
@@ -1,0 +1,205 @@
+# Duplicate Files (by SHA-256 content)
+
+## Duplicate Group (4 files)
+- SHA-256: `6403203dd5a0867eb14d104ee8a73730bd72dd9ad92e78d996a6dba0a5dcfc01`
+  - `.disk/base_components`
+  - `firmware/dep11/firmware-ath9k-htc.component`
+  - `firmware/dep11/firmware-carl9170.component`
+  - `firmware/dep11/firmware-linux-free.component`
+
+## Duplicate Group (4 files)
+- SHA-256: `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+  - `.disk/base_installable`
+  - `boot/grub/x86_64-efi/fdt.lst`
+  - `shared-host/.gitkeep`
+  - `src/huey/memory/LOGS/.gitkeep`
+
+## Duplicate Group (3 files)
+- SHA-256: `a77695b538801d92913d40aaf0ab3b9b39deab2f1d9b2770600752607b2da142`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/settings_section.json`
+  - `src/huey/memory/JSON/settings_section.json`
+  - `src/huey/pygpt_net/data/config/settings_section.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `5ac33a87c43d39a4f018ca60aeea4ffc8e77f87371cce2b9e5a3ad3893a23e1a`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/settings.json`
+  - `src/huey/memory/JSON/settings.json`
+  - `src/huey/pygpt_net/data/config/settings.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `66f69a46aa1874ed6d8dea12c437aab92a3eb4d46d579f91957ce2fedc676720`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/models.json`
+  - `src/huey/memory/JSON/models.json`
+  - `src/huey/pygpt_net/data/config/models.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `355486cbb8a68e1bff44e8ec054a8c79035ac8c107e7ecede1e57cac03cc85bf`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/modes.json`
+  - `src/huey/memory/JSON/modes.json`
+  - `src/huey/pygpt_net/data/config/modes.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `2ccfcd7c626e8e140ff4699e995f2e008bba21a8f5dca8a54470ed846adcb331`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.research.json`
+  - `src/huey/memory/JSON/current.research.json`
+  - `src/huey/pygpt_net/data/config/presets/current.research.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `04beab224bab9c257ccd2d307ee52773f8078e6b3ff3b033de8edb47cfe6be08`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/joke_expert.json`
+  - `src/huey/memory/JSON/joke_expert.json`
+  - `src/huey/pygpt_net/data/config/presets/joke_expert.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `9b9db8174ce70ca7df0a718d0a99c396e368e65bca9c0086d94ac3eadee48fbe`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.agent_llama.json`
+  - `src/huey/memory/JSON/current.agent_llama.json`
+  - `src/huey/pygpt_net/data/config/presets/current.agent_llama.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `1bbed05b6e40c72c0202970265917b581d0124afeb9313d396602a698dc0c1b6`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.img.json`
+  - `src/huey/memory/JSON/current.img.json`
+  - `src/huey/pygpt_net/data/config/presets/current.img.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `cb2efb663bc88caeeb7f387e21d2d2c511e3754f47f97c66c8adb7887f9e5de0`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.assistant.json`
+  - `src/huey/memory/JSON/current.assistant.json`
+  - `src/huey/pygpt_net/data/config/presets/current.assistant.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `b2611d341d90fd9897345aa00b5ec77410b364c4d6ea3d46e1a6bf2930492db9`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.chat.json`
+  - `src/huey/memory/JSON/current.chat.json`
+  - `src/huey/pygpt_net/data/config/presets/current.chat.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `5bd8c08e3f9b3bf66ad6e2c2c587d2f66f2f2a20075e6c1600f11abf7d672bed`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/agent_react.json`
+  - `src/huey/memory/JSON/agent_react.json`
+  - `src/huey/pygpt_net/data/config/presets/agent_react.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `321c9d26b72a4b3ebc0001b6247dde8f0e83800b4df8a38a3ff22d1dd391ef9e`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/batman_and_joker.json`
+  - `src/huey/memory/JSON/batman_and_joker.json`
+  - `src/huey/pygpt_net/data/config/presets/batman_and_joker.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `2f7300d1a0b0b2ba90950fd0af6a75316f64ce38f55a38d71a09704478d63415`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/dalle_white_cat.json`
+  - `src/huey/memory/JSON/dalle_white_cat.json`
+  - `src/huey/pygpt_net/data/config/presets/dalle_white_cat.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `db0ca1d6ecadfffe5872edb01b1a4cba97386b16271df4eb2b66c8825e657a52`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/agent_planner.json`
+  - `src/huey/memory/JSON/agent_planner.json`
+  - `src/huey/pygpt_net/data/config/presets/agent_planner.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `712c3ad56ea820bc98a12ffd2cbe9f04efc9401ae4885788dbbb57a16da2c3cc`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.completion.json`
+  - `src/huey/memory/JSON/current.completion.json`
+  - `src/huey/pygpt_net/data/config/presets/current.completion.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `0dadb245066c9391ff9e2429737da605ebe80e008ab77d601adde4fa83d73c24`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.llama_index.json`
+  - `src/huey/memory/JSON/current.llama_index.json`
+  - `src/huey/pygpt_net/data/config/presets/current.llama_index.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `e2970e37c2500111737d0ed28dd275f445535a14a18488bb7f8e4e5c60d63d54`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.vision.json`
+  - `src/huey/memory/JSON/current.vision.json`
+  - `src/huey/pygpt_net/data/config/presets/current.vision.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `3bd025afb2d356e889ab98afc0674ed45084b2c657fc2f424dfb85291a930953`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.audio.json`
+  - `src/huey/memory/JSON/current.audio.json`
+  - `src/huey/pygpt_net/data/config/presets/current.audio.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `82d9aac25601428f3016a4dd82f4251e658ef726158d34f955936b1a994de51c`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.expert.json`
+  - `src/huey/memory/JSON/current.expert.json`
+  - `src/huey/pygpt_net/data/config/presets/current.expert.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `481c3dba70393d09a39dad34d4a061ade577f71d0a9a79a5399b0ba1c986e1cc`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/joke_agent.json`
+  - `src/huey/memory/JSON/joke_agent.json`
+  - `src/huey/pygpt_net/data/config/presets/joke_agent.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `32111652529e085d3a5130e055fbedb1b2a3a73a0fde9a7d9a4a7aacb924b4eb`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.agent.json`
+  - `src/huey/memory/JSON/current.agent.json`
+  - `src/huey/pygpt_net/data/config/presets/current.agent.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `d49dc6c7cecb49db9f95a82e2cc78f6b52851e0370a6149726634019e8a33753`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/agent_openai_assistant.json`
+  - `src/huey/memory/JSON/agent_openai_assistant.json`
+  - `src/huey/pygpt_net/data/config/presets/agent_openai_assistant.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `0717754fa6d510959d2cf7e25d651823a2f1bcdf659f7e7c8413ee9233d41692`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/current.langchain.json`
+  - `src/huey/memory/JSON/current.langchain.json`
+  - `src/huey/pygpt_net/data/config/presets/current.langchain.json`
+
+## Duplicate Group (3 files)
+- SHA-256: `bb4c090c85724df574ae364b6bcc8124132c4163d7cd82ec5b00d692e1e01c24`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/agent_openai.json`
+  - `src/huey/memory/JSON/agent_openai.json`
+  - `src/huey/pygpt_net/data/config/presets/agent_openai.json`
+
+## Duplicate Group (2 files)
+- SHA-256: `2982ea2fa3a9d635ee056cec8a3754d9f65d64f3f7c29654708089e3636df783`
+  - `repo/pygpt-MHP/src/pygpt_net/data/prompts.csv`
+  - `src/huey/pygpt_net/data/prompts.csv`
+
+## Duplicate Group (2 files)
+- SHA-256: `c0edc61366cd3992f20a8138ba1a67583ad45e842977a7c7f903e3409a9ef921`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/config.json`
+  - `src/huey/pygpt_net/data/config/config.json`
+
+## Duplicate Group (2 files)
+- SHA-256: `bf2b0d54607142c90fa527e06240082132e1144e3ac997b33a314eb00aefdded`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/pirate_captain.json`
+  - `src/huey/pygpt_net/data/config/presets/pirate_captain.json`
+
+## Duplicate Group (2 files)
+- SHA-256: `fc2ee568ca857bb13562786bdd5d270cc7326ed3bfb455b4a0748cc77592cb94`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/wild_west_cowboy.json`
+  - `src/huey/pygpt_net/data/config/presets/wild_west_cowboy.json`
+
+## Duplicate Group (2 files)
+- SHA-256: `719125ec27c6731dd45d1f1e4b2a0d2c32771dc2f17af4fb2d06f55e533602fe`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/mad_scientist.json`
+  - `src/huey/pygpt_net/data/config/presets/mad_scientist.json`
+
+## Duplicate Group (2 files)
+- SHA-256: `70c720d0e87f7f2dce987ddff4a87b01ed20ce3277f31725584752097c484425`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/noir_detective.json`
+  - `src/huey/pygpt_net/data/config/presets/noir_detective.json`
+
+## Duplicate Group (2 files)
+- SHA-256: `6b991d48731366bbc51a5ff90cc82a56e135fb05a7da6ddbe8a0bd1197bedecf`
+  - `repo/pygpt-MHP/src/pygpt_net/data/config/presets/fantasy_bard.json`
+  - `src/huey/pygpt_net/data/config/presets/fantasy_bard.json`
+
+## Duplicate Group (2 files)
+- SHA-256: `05c3a45f9a5c13034012b7ab799b57bdf1f8f2c292cc88f27dd70eb081cf040e`
+  - `install/gtk/vmlinuz`
+  - `install/vmlinuz`
+
+## Duplicate Group (2 files)
+- SHA-256: `ae86f58c72333ec4c6ed2260ba4a55adfc0335ddaa954add7e5dbbe4272f7103`
+  - `src/huey/prompts/PAGES/Monkey_Head_Project_Page29_Storage.pdf`
+  - `src/huey/prompts/PAGES/Monkey_Head_Project_Page30_Logistics.pdf`
+

--- a/reports/file-audit/placeholder-occurrences.md
+++ b/reports/file-audit/placeholder-occurrences.md
@@ -1,0 +1,45 @@
+# Placeholder Occurrences
+
+- `README.md`:347 - `- Status: being stripped, inspected, reinforced, and repainted (dark tractor red base, silver overlays TBD).`
+- `constraints.txt`:42 - `# Examples (commented placeholders):`
+- `docs/CONTRIBUTING.md`:181 - `7. **Review-ready.** No commented-out code, no stray prints, no TODOs without issue links.`
+- `master_plan_v15.json`:40 - `"Robot shell exists physically and is being stripped, reinforced, and repainted (dark tractor red base, silver overlays TBD).",`
+- `master_plan_v15.json`:562 - `"tts": "Configurable TTS stack (exact engine TBD per node).",`
+- `repo/py-gpt/README.md`:1 - `# Py-GPT vendor placeholder`
+- `repo/py-gpt/src/pygpt_net/__init__.py`:3 - `This placeholder mirrors the directory layout of the upstream `py-gpt``
+- `repo/pygpt-MHP/src/pygpt_net/controller/config/__init__.py`:8 - `__all__ = ["placeholder"]`
+- `repo/pygpt-MHP/src/pygpt_net/data/prompts.csv`:132 - `"Web Browser","I want you to act as a text based web browser browsing an imaginary internet. You should only reply with the contents of the page, nothing else. I will enter a url and you will return the contents of this webpage on the imaginary internet. Don't write explanations. Links on the pages should have numbers next to them written between []. When I want to follow a link, I will reply with the number of the link. Inputs on the pages should have numbers next to them written between []. Input placeholder should be written between (). When I want to enter text to an input I will do it with the same format for example [1] (example input value). This inserts 'example input value' into the input numbered 1. When I want to go back i will write (b). When I want to go forward I will write (f). My first prompt is google.com",TRUE`
+- `src/huey/memory/CSV/pygpt_prompts.csv`:133 - `Web Browser,"You are a Web Browser. You should only reply with the contents of the page, nothing else. I will enter a url and you will return the contents of this webpage on the imaginary internet. Don't write explanations. Links on the pages should have numbers next to them written between []. When I want to follow a link, I will reply with the number of the link. Inputs on the pages should have numbers next to them written between []. Input placeholder should be written between (). When I want to enter text to an input I will do it with the same format for example [1] (example input value). This inserts 'example input value' into the input numbered 1. When I want to go back i will write (b). When I want to go forward I will write (f). My first prompt is google.com",TRUE`
+- `src/huey/memory/HTML/dlrp.ca_files/favicon.ico`:1 - `PLACEHOLDER – Replace with actual favicon file`
+- `src/huey/memory/HTML/dlrp.ca_files/index.html`:43 - `<div class="placeholder-image">[ Huey Image Placeholder ]<br /><small>The physical shell of Huey</small></div>`
+- `src/huey/memory/HTML/dlrp.ca_files/index.html`:68 - `<div class="placeholder-image">[ Dirty Leroy ]</div>`
+- `src/huey/memory/HTML/dlrp.ca_files/index.html`:69 - `<div class="placeholder-image">[ The Executive ]</div>`
+- `src/huey/memory/HTML/dlrp.ca_files/index.html`:89 - `<div class="placeholder-image">[ Dirty Leroy Image ]<br /><small>Prototype Unit</small></div>`
+- `src/huey/memory/HTML/dlrp.ca_files/index.html`:90 - `<div class="placeholder-image">[ The Executive Image ]<br /><small>Refined Cabinet</small></div>`
+- `src/huey/memory/HTML/dlrp.ca_files/style.css`:74 - `.placeholder-image {`
+- `src/huey/memory/HTML/dlrp.ca_files/style.css`:129 - `.project-image-dual .placeholder-image {`
+- `src/huey/memory/HTML/dlrp.ca_files/style.css`:142 - `.split-image .placeholder-image {`
+- `src/huey/memory/PY/ai_processor.py`:375 - `"""Fetch a sample TODO item and return its title."""`
+- `src/huey/memory/PY/ai_processor.py`:377 - `url = f"https://jsonplaceholder.typicode.com/todos/{todo_id}"`
+- `src/huey/memory/PY/sync_pygpt_structure.py`:31 - `"""Return True if ``dst`` does not exist or contains a placeholder header."""`
+- `src/huey/memory/PY/sync_pygpt_structure.py`:50 - `"""Copy file or directory from src to dst if missing or placeholder."""`
+- `src/huey/prompts/master-plan-v3.json`:166 - `"term_length": "Four cycles (exact definition of cycle TBD).",`
+- `src/huey/prompts/master-plan-v5.json`:190 - `"term_length": "Four cycles (exact definition of cycle TBD).",`
+- `src/huey/pygpt_net/controller/config/__init__.py`:8 - `__all__ = ["placeholder"]`
+- `src/huey/pygpt_net/data/prompts.csv`:132 - `"Web Browser","I want you to act as a text based web browser browsing an imaginary internet. You should only reply with the contents of the page, nothing else. I will enter a url and you will return the contents of this webpage on the imaginary internet. Don't write explanations. Links on the pages should have numbers next to them written between []. When I want to follow a link, I will reply with the number of the link. Inputs on the pages should have numbers next to them written between []. Input placeholder should be written between (). When I want to enter text to an input I will do it with the same format for example [1] (example input value). This inserts 'example input value' into the input numbered 1. When I want to go back i will write (b). When I want to go forward I will write (f). My first prompt is google.com",TRUE`
+- `tests/test_placeholder.py`:1 - `"""Tests for the lightweight placeholder helpers."""`
+- `tests/test_placeholder.py`:3 - `from huey.pygpt_net.controller.config.placeholder import Placeholder`
+- `tests/test_placeholder.py`:35 - `placeholder = Placeholder(DummyWindow(DummyPresets({preset.filename: preset})))`
+- `tests/test_placeholder.py`:37 - `result = placeholder.get_presets()`
+- `tests/test_placeholder.py`:44 - `placeholder = Placeholder(DummyWindow(with_core=False))`
+- `tests/test_placeholder.py`:46 - `assert placeholder.get_presets() == [{"_": "---"}]`
+- `tests/test_placeholder.py`:51 - `placeholder = Placeholder(DummyWindow(DummyPresets(presets)))`
+- `tests/test_placeholder.py`:53 - `assert placeholder.get_presets()[1:] == [{"first.json": "First"}]`
+- `tests/test_placeholder.py`:58 - `placeholder = Placeholder(DummyWindow(DummyPresets(presets)))`
+- `tests/test_placeholder.py`:60 - `assert placeholder.get_presets()[1:] == [{"alt.json": "Alternate"}]`
+- `tests/test_placeholder.py`:67 - `placeholder_list = Placeholder(DummyWindow(DummyPresets([NoFilename()])))`
+- `tests/test_placeholder.py`:68 - `placeholder_error = Placeholder(DummyWindow(DummyPresets(ValueError("bad"))))`
+- `tests/test_placeholder.py`:69 - `placeholder_string = Placeholder(DummyWindow(DummyPresets("not iterable")))`
+- `tests/test_placeholder.py`:71 - `assert placeholder_list.get_presets() == [{"_": "---"}]`
+- `tests/test_placeholder.py`:72 - `assert placeholder_error.get_presets() == [{"_": "---"}]`
+- `tests/test_placeholder.py`:73 - `assert placeholder_string.get_presets() == [{"_": "---"}]`


### PR DESCRIPTION
### Motivation

- Provide a quick automated audit of repository content to surface duplicated files by content and occurrences of placeholder keywords.
- Make it easier to identify temporary placeholders like `TBD`, `TODO`, and `PLACEHOLDER` that need follow-up work.

### Description

- Add a new `reports/file-audit/` folder containing `duplicate-files.md` and `placeholder-occurrences.md` generated from a content scan.
- Duplicate detection uses SHA-256 of file contents and groups files with identical digests into duplicate groups in `duplicate-files.md`.
- Placeholder scanning searches for keywords (`placeholder`, `PLACEHOLDER`, `TODO`, `TBD`, `FIXME`) and records matches with file paths and line numbers in `placeholder-occurrences.md`.
- The reports were generated by a Python audit script and committed to the repository.

### Testing

- Executed the audit script which wrote `reports/file-audit/duplicate-files.md` and `reports/file-audit/placeholder-occurrences.md` successfully.
- The repository changes were committed and include the two new report files.
- No unit or integration test suites were run as part of this change (report generation only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950c5b2ca64832b9e81b1950f9eeef3)