### PR TITLE
Add CLI scripts to convert AVI->MKV, decompress audio->FLAC, and repackage files

### DIFF
--- a/scripts/convert_avi_to_mkv.py
+++ b/scripts/convert_avi_to_mkv.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Convert AVI files to MKV using ffmpeg."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convert AVI files to MKV using ffmpeg.")
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        type=Path,
+        help="AVI files or directories containing AVI files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Optional output directory. Defaults to input file directory.",
+    )
+    parser.add_argument(
+        "--reencode",
+        action="store_true",
+        help="Re-encode video/audio instead of stream copying.",
+    )
+    return parser
+
+
+def iter_avi_files(paths: list[Path]) -> list[Path]:
+    avi_files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            avi_files.extend(sorted(path.glob("*.avi")))
+        elif path.is_file() and path.suffix.lower() == ".avi":
+            avi_files.append(path)
+    return avi_files
+
+
+def convert_file(input_path: Path, output_dir: Path | None, reencode: bool) -> None:
+    target_dir = output_dir if output_dir is not None else input_path.parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    output_path = target_dir / f"{input_path.stem}.mkv"
+
+    if reencode:
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(input_path),
+            "-c:v",
+            "libx264",
+            "-preset",
+            "medium",
+            "-crf",
+            "23",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            str(output_path),
+        ]
+    else:
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(input_path),
+            "-c",
+            "copy",
+            str(output_path),
+        ]
+
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    avi_files = iter_avi_files(args.inputs)
+    if not avi_files:
+        parser.error("No AVI files found in the provided inputs.")
+
+    for avi_file in avi_files:
+        convert_file(avi_file, args.output_dir, args.reencode)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/decompress_audio_to_flac.py
+++ b/scripts/decompress_audio_to_flac.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Decompress audio files to FLAC using ffmpeg."""
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Decompress audio files to FLAC using ffmpeg."
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        type=Path,
+        help="Audio files or directories containing audio files.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Optional output directory. Defaults to input file directory.",
+    )
+    return parser
+
+
+def iter_audio_files(paths: list[Path]) -> list[Path]:
+    audio_files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            for ext in ("*.mp3", "*.aac", "*.m4a", "*.ogg", "*.wav", "*.wma", "*.flac"):
+                audio_files.extend(sorted(path.glob(ext)))
+        elif path.is_file():
+            audio_files.append(path)
+    return audio_files
+
+
+def decompress_file(input_path: Path, output_dir: Path | None) -> None:
+    target_dir = output_dir if output_dir is not None else input_path.parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    output_path = target_dir / f"{input_path.stem}.flac"
+
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        str(input_path),
+        "-vn",
+        "-c:a",
+        "flac",
+        str(output_path),
+    ]
+
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    audio_files = iter_audio_files(args.inputs)
+    if not audio_files:
+        parser.error("No audio files found in the provided inputs.")
+
+    for audio_file in audio_files:
+        decompress_file(audio_file, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repackage_files.py
+++ b/scripts/repackage_files.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Repackage files or directories into a new archive."""
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Repackage files or directories into an archive."
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        type=Path,
+        help="Files or directories to package.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Output archive path (e.g. output.zip or output.tar.gz).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["zip", "tar", "gztar", "bztar", "xztar"],
+        default=None,
+        help="Archive format. Defaults to inferred from output extension.",
+    )
+    return parser
+
+
+def create_archive(inputs: list[Path], output: Path, archive_format: str | None) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    if archive_format is None:
+        suffixes = "".join(output.suffixes)
+        format_map = {
+            ".zip": "zip",
+            ".tar": "tar",
+            ".tar.gz": "gztar",
+            ".tgz": "gztar",
+            ".tar.bz2": "bztar",
+            ".tar.xz": "xztar",
+        }
+        archive_format = format_map.get(suffixes)
+        if archive_format is None:
+            raise ValueError(
+                "Unable to infer archive format from output extension. "
+                "Specify --format explicitly."
+            )
+
+    staging_dir = output.parent / f"{output.stem}_package"
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir(parents=True)
+
+    for item in inputs:
+        if not item.exists():
+            raise FileNotFoundError(f"Input not found: {item}")
+        destination = staging_dir / item.name
+        if item.is_dir():
+            shutil.copytree(item, destination)
+        else:
+            shutil.copy2(item, destination)
+
+    shutil.make_archive(
+        base_name=str(output.with_suffix("")),
+        format=archive_format,
+        root_dir=staging_dir,
+    )
+
+    shutil.rmtree(staging_dir)
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    create_archive(args.inputs, args.output, args.format)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide simple CLI tools to convert AVI videos to MKV, decompress various audio formats to FLAC, and bundle files/directories into archives.
- Use widely available tooling (`ffmpeg` for media operations and Python `shutil` for packaging) so the scripts are lightweight and portable.
- Make batch processing easy by accepting files or directories and inferring behaviors from inputs and options.

### Description
- Added `scripts/convert_avi_to_mkv.py`, a CLI that finds `.avi` files and either stream-copies them to `.mkv` or re-encodes using `ffmpeg` with configurable options via `--reencode`.
- Added `scripts/decompress_audio_to_flac.py`, a CLI that discovers common audio files and invokes `ffmpeg` to produce lossless `.flac` outputs.
- Added `scripts/repackage_files.py`, a CLI that stages provided inputs into a temporary directory and creates an archive (formats inferred from the `--output` extension or specified via `--format`) using `shutil.make_archive`.
- All three scripts include argument parsing with `argparse`, create output directories as needed, are made executable, and were added to version control.

### Testing
- No automated tests were run on these scripts as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950c6500488832b8923921ca9b19ad9)