### PR TITLE
Update Windows batch scripts to use repo root paths

### DIFF
--- a/src/huey/memory/BAT/install.bat
+++ b/src/huey/memory/BAT/install.bat
@@ -15,9 +15,10 @@ REM ==================================================
 
 setlocal
 set "SCRIPT_DIR=%~dp0"
-set "INSTALL_SCRIPT=%SCRIPT_DIR%setup\Windows11\01-FULL.bat"
+for %%I in ("%SCRIPT_DIR%..\..\..\..") do set "ROOT_DIR=%%~fI"
+set "INSTALL_SCRIPT=%ROOT_DIR%\setup\Windows11\01-FULL.bat"
 
-pushd "%SCRIPT_DIR%"
+pushd "%ROOT_DIR%"
 if not exist "%INSTALL_SCRIPT%" (
     echo Installation script not found: %INSTALL_SCRIPT%
     popd

--- a/src/huey/memory/BAT/run-tests.bat
+++ b/src/huey/memory/BAT/run-tests.bat
@@ -15,9 +15,11 @@ REM ==================================================
 REM This script runs the project's tests using the virtual environment
 setlocal
 set "SCRIPT_DIR=%~dp0"
-set "ACTIVATE=%SCRIPT_DIR%venv\Scripts\activate.bat"
+for %%I in ("%SCRIPT_DIR%..\..\..\..") do set "ROOT_DIR=%%~fI"
+set "ACTIVATE=%ROOT_DIR%\venv\Scripts\activate.bat"
+set "LOG_DIR=%ROOT_DIR%\src\huey\memory\LOGS"
 
-pushd "%SCRIPT_DIR%"
+pushd "%ROOT_DIR%"
 if not exist "%ACTIVATE%" (
     echo Virtual environment not found. Please run install.bat first.
     popd
@@ -25,10 +27,9 @@ if not exist "%ACTIVATE%" (
     exit /b 1
 )
 call "%ACTIVATE%"
-if not exist memory\LOGS mkdir memory\LOGS
-set "LOG_FILE=memory\LOGS\test_results.log"
+if not exist "%LOG_DIR%" mkdir "%LOG_DIR%"
+set "LOG_FILE=%LOG_DIR%\test_results.log"
 echo Test run started at %DATE% %TIME% > "%LOG_FILE%"
-pytest -vv --cov=hueyos --cov-report=term >> "%LOG_FILE%" 2>&1
+pytest -vv --cov=huey --cov-report=term >> "%LOG_FILE%" 2>&1
 popd
 endlocal
-

--- a/src/huey/memory/BAT/run.bat
+++ b/src/huey/memory/BAT/run.bat
@@ -15,7 +15,8 @@ REM ==================================================
 REM This script launches the app using the virtual environment
 setlocal
 set "SCRIPT_DIR=%~dp0"
-set "ACTIVATE=%SCRIPT_DIR%venv\Scripts\activate.bat"
+for %%I in ("%SCRIPT_DIR%..\..\..\..") do set "ROOT_DIR=%%~fI"
+set "ACTIVATE=%ROOT_DIR%\venv\Scripts\activate.bat"
 
 if /I "%~1"=="help"       goto :help
 if /I "%~1"=="--help"     goto :help
@@ -24,7 +25,7 @@ if /I "%~1"=="tests"      goto :tests
 if /I "%~1"=="--tests"    goto :tests
 
 :run
-pushd "%SCRIPT_DIR%"
+pushd "%ROOT_DIR%"
 if not exist "%ACTIVATE%" (
     echo Virtual environment not found. Please run install.bat first.
     popd
@@ -32,13 +33,13 @@ if not exist "%ACTIVATE%" (
     exit /b 1
 )
 call "%ACTIVATE%"
-python run.py %*
+python "%ROOT_DIR%\run.py" %*
 popd
 endlocal
 goto :eof
 
 :tests
-pushd "%SCRIPT_DIR%"
+pushd "%ROOT_DIR%"
 if not exist "%ACTIVATE%" (
     echo Virtual environment not found. Please run install.bat first.
     popd


### PR DESCRIPTION
### Motivation

- Ensure Windows helper scripts resolve paths relative to the repository root instead of the BAT folder so the virtualenv, installer, and test logs are found reliably.
- Make test logging and coverage target consistent with the Python package layout used by the project.

### Description

- Updated `src/huey/memory/BAT/install.bat` to compute a `ROOT_DIR` from `SCRIPT_DIR` and use it to locate the `setup\Windows11\01-FULL.bat` installer.
- Updated `src/huey/memory/BAT/run.bat` to compute `ROOT_DIR`, resolve the virtualenv activation script from the repo root, and invoke `run.py` via the repo-root path.
- Updated `src/huey/memory/BAT/run-tests.bat` to compute `ROOT_DIR`, create test logs under `src\huey\memory\LOGS`, and run `pytest` with `--cov=huey` (previously `hueyos`).

### Testing

- No automated tests were executed as part of this change.
- The changes are limited to Windows BAT helpers and update file paths and the coverage target; further CI or local test runs are recommended to validate runtime behavior on Windows environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950ca77ae0c832b92fa9454290c593b)