### PR TITLE
Align Python support to 3.13 (update system checks, metadata, and tests)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "hueyos"
 version = "0.2.0"
 description = "HueyOS: on-robot runtime for the Monkey Head Project (Huey)."
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.13,<3.15"
 readme = "README.md"
 authors = [
   { name = "Dylan L. R. Pollock" },
@@ -19,9 +19,8 @@ keywords = [
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: POSIX :: Linux",
 ]
@@ -168,7 +167,7 @@ where = ["src"]
 profile = "black"
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py313"
 
 [tool.ruff.lint]
 ignore = ["E402"]

--- a/src/huey/system_checks.py
+++ b/src/huey/system_checks.py
@@ -119,7 +119,7 @@ def check_os_support() -> None:
 
 
 def check_python_version() -> None:
-    """Warn when running on experimental Python versions."""
+    """Warn when running on unsupported Python versions."""
 
     info = sys.version_info
     if isinstance(info, tuple):  # pragma: no cover - compatibility
@@ -127,9 +127,9 @@ def check_python_version() -> None:
     else:
         major = getattr(info, "major", 0)
         minor = getattr(info, "minor", 0)
-    if major == 3 and minor >= 14:
+    if major == 3 and (minor < 13 or minor >= 15):
         logger.warning(
-            "Python 3.%s detected. This version is experimental and not fully supported.",
+            "Python 3.%s detected. Supported versions are Python 3.13 and 3.14.",
             minor,
         )
 

--- a/src/hueyos/system_checks.py
+++ b/src/hueyos/system_checks.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 SUPPORTED_DISTRO_ID = "debian"
 SUPPORTED_DISTRO_CODENAME = "forky"
 MIN_KERNEL_VERSION = Version("6.18.2")
-MIN_PYTHON_VERSION = (3, 14)
+MIN_PYTHON_VERSION = (3, 13)
 MAX_PYTHON_VERSION = (3, 15)
 REQUIRED_TOOLS: Tuple[str, ...] = ("git", "python3")
 

--- a/tests/test_python_compatibility.py
+++ b/tests/test_python_compatibility.py
@@ -28,16 +28,16 @@ def _marker_allows(line: str, python_version: str) -> bool:
     return req.marker.evaluate({"python_version": python_version})
 
 
-def test_pygpt_marker_allows_python_314() -> None:
+def test_pygpt_marker_allows_python_313() -> None:
     line = _get_requirement_line("pygpt-net")
-    assert _marker_allows(line, "3.14")
+    assert _marker_allows(line, "3.13")
 
 
-def test_audio_bridge_allows_python_314() -> None:
+def test_audio_bridge_allows_python_313() -> None:
     line = _get_requirement_line("audioop-lts")
-    assert _marker_allows(line, "3.14")
+    assert _marker_allows(line, "3.13")
 
 
-def test_aifc_bridge_allows_python_314() -> None:
+def test_aifc_bridge_allows_python_313() -> None:
     line = _get_requirement_line("standard-aifc")
-    assert _marker_allows(line, "3.14")
+    assert _marker_allows(line, "3.13")

--- a/tests/test_python_version.py
+++ b/tests/test_python_version.py
@@ -8,18 +8,18 @@ from unittest.mock import patch
 from hueyos.core.system_checks import check_python_version
 
 
-def test_python_313_warning():
+def test_python_312_warning():
     with (
-        patch("hueyos.core.system_checks.sys.version_info", (3, 13, 0)),
+        patch("hueyos.core.system_checks.sys.version_info", (3, 12, 0)),
         patch("hueyos.core.system_checks.logger") as log,
     ):
         check_python_version()
         log.warning.assert_called_once()
 
 
-def test_python_314_supported_no_warning():
+def test_python_313_supported_no_warning():
     with (
-        patch("hueyos.core.system_checks.sys.version_info", (3, 14, 1)),
+        patch("hueyos.core.system_checks.sys.version_info", (3, 13, 1)),
         patch("hueyos.core.system_checks.logger") as log,
     ):
         check_python_version()

--- a/tests/test_system_checks_module.py
+++ b/tests/test_system_checks_module.py
@@ -59,14 +59,14 @@ def test_check_python_version_warns_on_experimental_release(monkeypatch, caplog)
 def test_check_python_version_accepts_primary_target(monkeypatch, caplog):
     class FakeInfo:
         major = 3
-        minor = 14
+        minor = 13
 
     monkeypatch.setattr(system_checks.sys, "version_info", FakeInfo())
 
     with caplog.at_level(logging.WARNING):
         system_checks.check_python_version()
 
-    assert "Python 3.14" not in caplog.text
+    assert "Python 3.13" not in caplog.text
 
 
 def test_system_check_collects_expected_results(monkeypatch):


### PR DESCRIPTION
### Motivation
- Align project metadata, lint target and runtime checks to Python 3.13 as the supported baseline.
- Ensure compatibility markers and system checks accept 3.13 while warning on unsupported releases.
- Keep unit tests and packaging metadata consistent with the new baseline.

### Description
- Update `pyproject.toml` to `requires-python = ">=3.13,<3.15"`, add the `3.14` classifier, and set Ruff `target-version = "py313"`.
- Change `MIN_PYTHON_VERSION` in `src/hueyos/system_checks.py` from `(3, 14)` to `(3, 13)`.
- Modify `check_python_version()` in `src/huey/system_checks.py` to warn when Python is `<3.13` or `>=3.15` and update the warning message to reference supported versions (`3.13` and `3.14`).
- Update unit tests in `tests/test_python_version.py`, `tests/test_system_checks_module.py`, and `tests/test_python_compatibility.py` to reflect the 3.13 baseline.

### Testing
- No automated tests were executed as part of this change (no local `pytest` or CI run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950cc7e6328832b8a0ed6567112f759)