### PR TITLE
Fix Huey compatibility imports and lazy-load optional deps

### DIFF
--- a/src/huey/__init__.py
+++ b/src/huey/__init__.py
@@ -1,0 +1,10 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey (src)
+
+"""Compatibility package exposing the legacy Huey modules under ``src``."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/src/huey/api.py
+++ b/src/huey/api.py
@@ -1,0 +1,14 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: API compatibility wrapper (src)
+
+"""Expose the FastAPI application under :mod:`huey.api`."""
+
+from __future__ import annotations
+
+import sys
+
+from .memory.PY import api as _api
+
+sys.modules[__name__] = _api

--- a/src/huey/cli.py
+++ b/src/huey/cli.py
@@ -1,0 +1,49 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: CLI compatibility wrapper (src)
+
+"""Expose the HueyOS CLI interfaces under :mod:`huey.cli`."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, Optional
+
+from .memory.PY import cli as _cli
+
+main = _cli.main
+
+__all__ = ["main", "parse_arguments", "run_cli", "huey_main"]
+
+
+def parse_arguments(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    """Parse CLI arguments for the legacy Huey entry point."""
+
+    parser = argparse.ArgumentParser(description="Huey CLI wrapper")
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to configuration file",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging output",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def huey_main(config_file: str = "config.yaml") -> None:
+    """Compatibility shim for legacy CLI entry points."""
+
+    raise NotImplementedError(
+        "The legacy CLI entry point is not available in this environment."
+    )
+
+
+def run_cli(argv: Optional[Iterable[str]] = None) -> None:
+    """Invoke the legacy CLI with parsed arguments."""
+
+    args = parse_arguments(argv)
+    huey_main(config_file=args.config)

--- a/src/huey/config.py
+++ b/src/huey/config.py
@@ -1,0 +1,12 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Config compatibility wrapper (src)
+
+"""Expose configuration helpers under :mod:`huey.config`."""
+
+from __future__ import annotations
+
+from .memory.PY.config import load_config
+
+__all__ = ["load_config"]

--- a/src/huey/exceptions.py
+++ b/src/huey/exceptions.py
@@ -1,0 +1,20 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Exceptions compatibility wrapper (src)
+
+"""Expose shared exception types under :mod:`huey.exceptions`."""
+
+from __future__ import annotations
+
+from .memory.PY.exceptions import (  # noqa: F401
+    DataNotFoundError,
+    HueyError,
+    InvalidInputError,
+)
+
+__all__ = [
+    "HueyError",
+    "DataNotFoundError",
+    "InvalidInputError",
+]

--- a/src/huey/function_registry.py
+++ b/src/huey/function_registry.py
@@ -1,0 +1,14 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Function registry compatibility wrapper (src)
+
+"""Expose the shared function registry under :mod:`huey.function_registry`."""
+
+from __future__ import annotations
+
+import sys
+
+from .memory.PY import function_registry as _function_registry
+
+sys.modules[__name__] = _function_registry

--- a/src/huey/memory/PY/logging_setup.py
+++ b/src/huey/memory/PY/logging_setup.py
@@ -18,7 +18,7 @@ from hueyos.config_manager import ConfigManager
 
 __all__ = ["CriticalErrorHandler", "configure_logging"]
 
-from .utils.paths import get_logs_dir, get_memory_path
+from huey.utils.paths import get_logs_dir, get_memory_path
 
 
 class CriticalErrorHandler(logging.Handler):

--- a/src/huey/memory/PY/pdf_utils.py
+++ b/src/huey/memory/PY/pdf_utils.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from .function_registry import register_function
-from .utils.paths import memory_candidates
+from huey.utils.paths import memory_candidates
 
 BASE_DIR = Path(__file__).resolve().parents[1]
 

--- a/src/huey/memory/PY/utils.py
+++ b/src/huey/memory/PY/utils.py
@@ -17,8 +17,6 @@ import logging
 from pathlib import Path
 from typing import Iterable, Optional
 
-from PIL import Image
-
 from .exceptions import InvalidInputError
 
 # Supported image formats for conversion
@@ -30,6 +28,12 @@ SUPPORTED_FORMATS: Iterable[str] = (
     "TIFF",
     "WEBP",
 )
+
+
+def _load_image_module():
+    from PIL import Image
+
+    return Image
 
 
 def setup_logging(config):
@@ -85,6 +89,7 @@ def convert_jpeg_to_png(jpeg_path: str, png_path: Optional[str] | None = None) -
     else:
         png_file = Path(png_path)
 
+    Image = _load_image_module()
     with Image.open(jpeg_file) as img:
         img.save(png_file, format="PNG")
 
@@ -130,6 +135,7 @@ def convert_image(
     else:
         out_file = Path(output_path)
 
+    Image = _load_image_module()
     with Image.open(img_file) as img:
         save_kwargs = {}
         if fmt == "JPEG" or fmt == "WEBP":

--- a/src/huey/memory/__init__.py
+++ b/src/huey/memory/__init__.py
@@ -1,0 +1,10 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Package initializer for huey.memory (src)
+
+"""Legacy memory package wrapper for HueyOS."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/src/huey/pdf_utils.py
+++ b/src/huey/pdf_utils.py
@@ -1,0 +1,14 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: PDF utils compatibility wrapper (src)
+
+"""Expose PDF helpers under :mod:`huey.pdf_utils`."""
+
+from __future__ import annotations
+
+import sys
+
+from .memory.PY import pdf_utils as _pdf_utils
+
+sys.modules[__name__] = _pdf_utils

--- a/src/huey/pygpt_integration.py
+++ b/src/huey/pygpt_integration.py
@@ -1,0 +1,14 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: PyGPT integration compatibility wrapper (src)
+
+"""Expose PyGPT integration utilities under :mod:`huey.pygpt_integration`."""
+
+from __future__ import annotations
+
+from .memory.PY import pygpt_integration as _pygpt_integration
+
+__all__ = list(getattr(_pygpt_integration, "__all__", ()))
+
+globals().update({name: getattr(_pygpt_integration, name) for name in __all__})

--- a/src/huey/run.py
+++ b/src/huey/run.py
@@ -1,0 +1,14 @@
+# Monkey Head Project
+# By: Dylan L.R. Pollock
+# www.dlrp.ca
+# HueyOS: Run compatibility wrapper (src)
+
+"""Expose legacy runtime entry points under :mod:`huey.run`."""
+
+from __future__ import annotations
+
+import sys
+
+from .memory.PY import run as _run
+
+sys.modules[__name__] = _run

--- a/src/huey/utils/__init__.py
+++ b/src/huey/utils/__init__.py
@@ -7,10 +7,24 @@
 
 from .auto_sort import auto_sort_memory
 from .paths import ensure_subdirectory, get_logs_dir, get_memory_path
+from ..memory.PY import utils as _legacy_utils
+
+calculate_sum = _legacy_utils.calculate_sum
+convert_image = _legacy_utils.convert_image
+convert_images_in_directory = _legacy_utils.convert_images_in_directory
+convert_jpeg_to_png = _legacy_utils.convert_jpeg_to_png
+setup_logging = _legacy_utils.setup_logging
+validate_input = _legacy_utils.validate_input
 
 __all__ = [
     "auto_sort_memory",
+    "calculate_sum",
+    "convert_image",
+    "convert_images_in_directory",
+    "convert_jpeg_to_png",
     "ensure_subdirectory",
     "get_logs_dir",
     "get_memory_path",
+    "setup_logging",
+    "validate_input",
 ]


### PR DESCRIPTION
### Motivation
- Make the legacy `huey` modules importable from the `src` tree so tests and runtime wrappers can find and share state.  
- Resolve multiple import errors observed during test collection caused by missing compatibility shims and direct relative imports.  
- Avoid hard failures when optional runtime dependencies (notably Pillow) are absent by deferring their import.  

### Description
- Added small compatibility shims and package initialisers under `src/huey` (e.g. `api.py`, `run.py`, `function_registry.py`, `pdf_utils.py`, `cli.py`, `config.py`, `exceptions.py`, `pygpt_integration.py`, `memory/__init__.py`) to expose the legacy `huey.memory.PY` implementations and ensure shared modules are available.  
- For modules where shared mutable state is required we map the wrapper module into `sys.modules` (e.g. `huey.api`, `huey.run`, `huey.pdf_utils`, `huey.function_registry`) so importers observe the same module objects.  
- Re-export utility functions from the legacy compatibility implementation via `src/huey/utils/__init__.py` and update internal imports to use the unified `huey.utils.paths` helpers.  
- Make image helpers lazily import `PIL` by adding `_load_image_module()` to `memory/PY/utils.py` and updated logging/pdf modules to import path helpers from `huey.utils.paths`.  

### Testing
- Ran the full test suite with `pytest` and confirmed the suite completed successfully.  
- Test run summary: `165 passed, 17 skipped`.  
- Also executed several focused tests during development (e.g. `tests/test_api_routes.py::test_healthz_endpoint_returns_service_status`) to validate API and compatibility wrappers.  
- No automated tests failed after changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c64c8f4a8832bbcf8782e82632708)