### PR TITLE
Add unified installer wrapper

### DIFF
--- a/unified_installer.py
+++ b/unified_installer.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Unified installer for HueyOS setup scripts."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent
+SETUP_ROOT = REPO_ROOT / "setup"
+
+
+def _read_os_release() -> dict[str, str]:
+    os_release = {}
+    os_release_path = Path("/etc/os-release")
+    if not os_release_path.exists():
+        return os_release
+    for line in os_release_path.read_text(encoding="utf-8").splitlines():
+        if not line or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os_release[key.strip()] = value.strip().strip('"')
+    return os_release
+
+
+def detect_target() -> str:
+    system = platform.system().lower()
+    if system == "windows":
+        return "windows"
+    if system == "darwin":
+        return "macos"
+    if system == "linux":
+        os_release = _read_os_release()
+        os_id = os_release.get("ID", "").lower()
+        id_like = os_release.get("ID_LIKE", "").lower()
+        if os_id == "debian" or "debian" in id_like:
+            return "debian"
+        return "linux"
+    return "unknown"
+
+
+def select_script(target: str) -> Path:
+    if target == "windows":
+        return SETUP_ROOT / "Windows" / "install-win.ps1"
+    if target == "macos":
+        return SETUP_ROOT / "macOS" / "install-mac.sh"
+    if target == "debian":
+        return SETUP_ROOT / "Debian" / "install-deb.sh"
+    raise RuntimeError(f"Unsupported OS target: {target}")
+
+
+def build_command(target: str, script_path: Path, passthrough: list[str]) -> list[str]:
+    if target == "windows":
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        if script_path.suffix.lower() == ".ps1" and powershell:
+            return [
+                powershell,
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                str(script_path),
+                *passthrough,
+            ]
+        bat_script = SETUP_ROOT / "Windows" / "install-win.bat"
+        return ["cmd", "/c", str(bat_script), *passthrough]
+    return ["bash", str(script_path), *passthrough]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the platform-specific HueyOS installer from setup/."
+    )
+    parser.add_argument(
+        "--target",
+        choices=["debian", "macos", "windows"],
+        help="Override detected OS target.",
+    )
+    parser.add_argument(
+        "passthrough",
+        nargs=argparse.REMAINDER,
+        help="Arguments passed directly to the platform installer.",
+    )
+    args = parser.parse_args()
+
+    target = args.target or detect_target()
+    if target in {"linux", "unknown"}:
+        print(
+            "Unsupported OS. Supported targets are Debian, macOS, and Windows. "
+            "Use --target to override if appropriate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    script_path = select_script(target)
+    if not script_path.exists():
+        print(f"Installer script not found: {script_path}", file=sys.stderr)
+        return 1
+
+    passthrough = args.passthrough
+    if passthrough and passthrough[0] == "--":
+        passthrough = passthrough[1:]
+
+    command = build_command(target, script_path, passthrough)
+    print(f"Detected target: {target}")
+    print(f"Running installer: {' '.join(command)}")
+
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a single entrypoint to run the platform-specific installers stored under `setup/` instead of requiring callers to pick a script manually.
- Detect the host OS (Debian, macOS, Windows) and dispatch to the appropriate installer to simplify installation workflows.
- Allow callers to override detection with `--target` and forward any extra arguments to the platform installer.
- Keep behavior predictable and script-driven so existing platform-specific installers remain unchanged.

### Description
- Add `unified_installer.py` which implements `detect_target()`, `select_script()`, and `build_command()` to map the host to `setup/Debian/install-deb.sh`, `setup/macOS/install-mac.sh`, or `setup/Windows/install-win.ps1`.
- Use `/etc/os-release` parsing to detect Debian derivatives and `platform.system()` for macOS/Windows detection.
- Provide a CLI with `--target` override and pass-through support via `argparse` and execute the selected installer using `subprocess.run()` with PowerShell/`cmd` or `bash` as appropriate.
- Validate that the selected installer exists and return non-zero exit codes on errors.

### Testing
- No automated tests were executed for this change.
- The new file was added and committed as `unified_installer.py` but no unit or integration test run was requested.
- No CI/lint or pre-commit hooks were invoked as part of this change.
- Recommend running platform-specific smoke tests by invoking `python unified_installer.py --target <debian|macos|windows> -- <args>` on each target OS.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c7142d010832baafda423d6e32b6c)