### PR TITLE
Integrate Huey package entry points with lazy imports and legacy fallbacks

### DIFF
--- a/src/huey/__init__.py
+++ b/src/huey/__init__.py
@@ -7,4 +7,60 @@
 
 from __future__ import annotations
 
+import importlib
+import logging
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+_CORE_MODULES = (
+    "api",
+    "cli",
+    "config",
+    "exceptions",
+    "function_registry",
+    "pdf_utils",
+    "pygpt_integration",
+    "run",
+    "utils",
+    "memory",
+)
+
 __all__ = []
+
+
+def _optional_import(module_name: str) -> Any | None:
+    """Import ``module_name`` from :mod:`huey` and log failures."""
+
+    try:
+        return importlib.import_module(f"{__name__}.{module_name}")
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional path
+        _LOGGER.debug("Optional module %s not available: %s", module_name, exc)
+        return None
+
+
+for _module_name in _CORE_MODULES:
+    _module = _optional_import(_module_name)
+    if _module is not None:
+        globals()[_module_name] = _module
+        __all__.append(_module_name)
+
+_LEGACY_PREFIX = f"{__name__}.memory.PY"
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically expose legacy modules from :mod:`huey.memory.PY`."""
+
+    try:
+        module = importlib.import_module(f"{__name__}.{name}")
+    except ModuleNotFoundError:
+        try:
+            module = importlib.import_module(f"{_LEGACY_PREFIX}.{name}")
+        except ModuleNotFoundError as exc:  # pragma: no cover - error path
+            raise AttributeError(f"module '{__name__}' has no attribute {name!r}") from exc
+    globals()[name] = module
+    return module
+
+
+def __dir__() -> list[str]:  # pragma: no cover - convenience helper
+    return sorted(set(__all__) | set(globals()))

--- a/src/huey/memory/__init__.py
+++ b/src/huey/memory/__init__.py
@@ -7,4 +7,50 @@
 
 from __future__ import annotations
 
+import importlib
+import logging
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+_CORE_MODULES = (
+    "core",
+    "utils",
+    "PY",
+)
+
 __all__ = []
+
+
+def _optional_import(module_name: str) -> Any | None:
+    """Import ``module_name`` from :mod:`huey.memory` and log failures."""
+
+    try:
+        return importlib.import_module(f"{__name__}.{module_name}")
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional path
+        _LOGGER.debug("Optional module %s not available: %s", module_name, exc)
+        return None
+
+
+for _module_name in _CORE_MODULES:
+    _module = _optional_import(_module_name)
+    if _module is not None:
+        globals()[_module_name] = _module
+        __all__.append(_module_name)
+
+_LEGACY_PREFIX = f"{__name__}.PY"
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically expose legacy modules from :mod:`huey.memory.PY`."""
+
+    try:
+        module = importlib.import_module(f"{_LEGACY_PREFIX}.{name}")
+    except ModuleNotFoundError as exc:  # pragma: no cover - error path
+        raise AttributeError(f"module '{__name__}' has no attribute {name!r}") from exc
+    globals()[name] = module
+    return module
+
+
+def __dir__() -> list[str]:  # pragma: no cover - convenience helper
+    return sorted(set(__all__) | set(globals()))


### PR DESCRIPTION
### Motivation
- Surface and expose core Huey modules from the `src` layout so the package is usable when imported from source.
- Provide backward compatibility for legacy modules located under `huey.memory.PY` so old import paths continue to work.
- Avoid import-time failures for optional subsystems by making module loading lazy and logging missing optional modules.

### Description
- Updated `src/huey/__init__.py` to declare a `_CORE_MODULES` list and lazily import each module into `globals()` while populating `__all__` and adding an `_optional_import` helper. 
- Added a `__getattr__` implementation in `src/huey/__init__.py` that falls back to legacy `huey.memory.PY` modules when a direct `huey.<name>` import is not present, and added a `__dir__` helper.
- Updated `src/huey/memory/__init__.py` to lazily expose core memory submodules (`core`, `utils`, `PY`) via `_optional_import`, to route legacy imports through `_LEGACY_PREFIX`, and to provide `__dir__`.
- Introduced lightweight logging for optional import failures to aid diagnostics without raising at import time.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c79f5b490832b84dc47a744bde86e)