### PR TITLE
Add repository restructure docs and update README repository layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ If you change the governance model, hardware assumptions, or key policies, updat
 
 ## Repository Structure
 
+> Looking to reorganize the repo layout? See `docs/repository-restructure-recommendation.md` for the staged migration plan and `docs/repository-restructure-inventory.md` for the concrete move/rename/fix checklist.
+
 | Path                      | Description                                           |
 | ------------------------- | ----------------------------------------------------- |
 | `.github/`                | CI workflows, CODEOWNERS, issue/PR templates         |

--- a/docs/repository-restructure-inventory.md
+++ b/docs/repository-restructure-inventory.md
@@ -1,0 +1,78 @@
+# Repository Restructure Inventory (Move / Rename / Fix)
+
+This is the concrete inventory requested for the next restructuring pass.
+
+## 1) Move (path relocations)
+
+### Platform + release artifacts → `platform/` and `archives/`
+- `boot/` → `platform/boot/grub/`
+- `EFI/` + `efi.img` → `platform/boot/efi/`
+- `isolinux/` + `live/` → `platform/boot/legacy/`
+- `dists/` → `platform/packaging/dists/`
+- `pool/` → `platform/packaging/pool/`
+- `pool-udeb/` → `platform/packaging/pool-udeb/`
+- `firmware/` → `platform/packaging/firmware/`
+- `6.18.5-hueyos/` → `archives/releases/6.18.5-hueyos/`
+- `md5sum.txt` + `sha256sum.txt` → `archives/releases/checksums/`
+
+### Installers + setup scripts → `platform/installers/`
+- `setup/Debian/` → `platform/installers/debian/`
+- `setup/macOS/` → `platform/installers/macos/`
+- `setup/Windows/` → `platform/installers/windows/`
+- `install/gtk/` → `platform/installers/linux/gtk/`
+- `scripts/installers/` → `platform/installers/shared/`
+
+### Runtime/app code boundaries
+- `src/huey/scripts/` → `apps/huey-core/scripts/`
+- `src/huey/prompts/OLD/` → `archives/prompts/legacy/`
+- `gui/` → `apps/huey-gui/` (if still active) or `archives/gui-prototypes/` (if deprecated)
+- `docker/` + `Dockerfile` + `Dockerfile.vnc` + `docker-compose.yml` → `infra/docker/`
+- `repo/pygpt-MHP/` + `repo/py-gpt/` → `integrations/pygpt/`
+
+### Assets + docs separation
+- `HueyOS-background.png` → `assets/images/HueyOS-background.png`
+- `secrets/` → `infra/secrets/` (templates only)
+- `sources.list` → `platform/installers/debian/sources.list`
+
+## 2) Rename / Consolidate (naming + duplication cleanup)
+
+- `setup/` and `install/` should become one canonical tree: `platform/installers/`.
+- `repo/py-gpt` and `repo/pygpt-MHP` should be consolidated under a single naming scheme (`integrations/pygpt/`).
+- Pick one canonical runtime package namespace between `src/huey/` and `src/hueyos/`; deprecate the other with import shims for one release.
+- `src/huey/pygpt_net` naming should be aligned with integration folder naming (`pygpt_net` vs `pygpt`).
+- Remove or repurpose top-level empty `huey/` directory to avoid confusion with `src/huey/`.
+- Rename release folder `6.18.5-hueyos/` to a consistent archive format (`archives/releases/hueyos-6.18.5/`).
+
+## 3) Fix (docs, metadata, and project hygiene)
+
+### README structure table drift
+The current README "Repository Structure" table references paths that do not exist (or no longer exist) and should be corrected:
+- `master-plan-v16.json` (missing)
+- `reports/` (missing)
+- `shared-host/` (missing)
+
+### Packaging + source clarity
+- Ensure root-level `pyproject.toml` and dependency files point only to canonical source roots after consolidation.
+- Add explicit deprecation notices for any transitional compatibility paths.
+
+### Ignore + generated artifacts policy
+- Ensure generated caches and binaries remain out of source review paths.
+- Confirm `.gitignore` keeps build/runtime caches excluded and preserve only intentional release artifacts under `archives/`.
+
+### Ownership + onboarding
+- Add a `docs/repo-map.md` with owner boundaries (runtime, installers, packaging, integrations, docs).
+- Add CI checks for forbidden top-level path additions outside approved roots.
+
+## 4) Suggested execution order
+
+1. Move platform/installer/release artifacts first (low risk to Python imports).
+2. Consolidate `repo/*` integrations and container definitions.
+3. Resolve runtime package duplication (`src/huey` vs `src/hueyos`).
+4. Apply README/doc/CI cleanup once paths are stable.
+
+## 5) Done criteria for this inventory
+
+- Every top-level directory has a canonical destination.
+- Every duplicated naming pattern has a single target convention.
+- Every missing/outdated README entry is corrected.
+- CI and contributor docs enforce the new structure.

--- a/docs/repository-restructure-recommendation.md
+++ b/docs/repository-restructure-recommendation.md
@@ -1,0 +1,73 @@
+# Repository Restructure Recommendation
+
+This document proposes a practical reorganization so the repository is easier to navigate, safer to maintain, and clearer for contributors.
+
+> For the concrete path-by-path checklist, see `docs/repository-restructure-inventory.md`.
+
+## Goals
+
+- Separate **source code** from **generated artifacts** and **release payloads**.
+- Make ownership boundaries obvious (runtime code, packaging, docs, operations).
+- Keep historical and large binary assets available, but out of day-to-day developer paths.
+- Reduce ambiguity caused by duplicate folders (`setup/` and `install/`, multiple app copies, etc.).
+
+## Recommended Top-Level Layout
+
+```text
+.
+├── apps/                    # runnable applications and entry points
+│   ├── huey-core/           # primary Python runtime (from src/huey + src/monkey_head)
+│   └── hueyos-tools/        # CLI/utilities currently spread across scripts/tools
+├── integrations/
+│   └── pygpt/               # repo/pygpt-MHP and related adapters
+├── platform/
+│   ├── boot/                # boot/grub, EFI, isolinux, live
+│   ├── packaging/           # dists, pool, pool-udeb, firmware metadata
+│   └── installers/          # setup + install scripts by OS
+├── infra/
+│   ├── docker/              # all docker definitions and orchestration helpers
+│   └── ci/                  # workflow support files/scripts
+├── docs/                    # architecture, governance, release notes, runbooks
+├── tests/                   # automated tests
+├── assets/                  # static media (images, diagrams, UI assets)
+├── archives/                # frozen historical snapshots, old release payloads
+└── vendor/                  # vendored third-party dependencies
+```
+
+## What to Move First (Low-Risk Phase)
+
+1. Consolidate installer-related content:
+   - Merge `setup/` and `install/` into `platform/installers/`.
+2. Group boot/distribution artifacts:
+   - Move `boot/`, `EFI/`, `isolinux/`, `live/`, `dists/`, `pool/`, `pool-udeb/` under `platform/`.
+3. Isolate generated release outputs:
+   - Move versioned release blobs (e.g., `6.18.5-hueyos/`, ISO artifacts) into `archives/releases/`.
+4. Clarify app code location:
+   - Keep active Python runtime in one place and mark duplicates as deprecated with README pointers.
+
+## Guardrails for the Migration
+
+- Perform moves in **small batches** with a path-mapping changelog.
+- Add temporary compatibility shims for scripts expecting old paths.
+- Update CI/workflows and Makefile targets immediately after each batch.
+- Keep binary-heavy directories excluded from frequent lint/test loops.
+
+## Suggested Naming Rules
+
+- Use lowercase kebab-case for directories (`huey-core`, `release-artifacts`).
+- Reserve `src/` for Python package code only.
+- Reserve `docs/` for human-readable specs and runbooks only.
+- Keep generated/package outputs under `platform/packaging` or `archives/`, never mixed with app source.
+
+## Success Criteria
+
+- A new contributor can identify runtime code, installers, packaging, and docs in under 2 minutes.
+- CI paths no longer depend on duplicated folder semantics.
+- Release artifacts are preserved but do not obscure active development files.
+
+## Rollout Plan
+
+- **Phase 1:** Move installer and platform artifacts; preserve compatibility shims.
+- **Phase 2:** Consolidate active runtime/app code and integrations.
+- **Phase 3:** Archive legacy snapshots and remove temporary shims.
+- **Phase 4:** Update contributor docs + enforce structure checks in CI.


### PR DESCRIPTION
### Motivation

- Provide a clear, staged plan and concrete inventory for reorganizing top-level repository layout to reduce duplication and improve discoverability.  
- Surface the restructure guidance from operational planning into the repository so contributors and CI can follow a consistent migration path.  

### Description

- Add `docs/repository-restructure-recommendation.md` containing the recommended top-level layout, goals, guardrails, and phased rollout plan.  
- Add `docs/repository-restructure-inventory.md` containing the concrete move/rename/fix checklist with explicit path mappings and done criteria.  
- Update `README.md` repository structure table to reference the new docs and slightly adjust the table layout by inserting a pointer to `docs/repository-restructure-recommendation.md` and `docs/repository-restructure-inventory.md`.  

### Testing

- No automated code tests were run because the change is documentation-only and does not modify executable code.  
- Documentation spellcheck/linting was not executed as part of this change.  
- Manual review of the added files was performed to ensure path examples and recommendations are internally consistent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b239ca2d94832f8af3acdb22cda59f)