### PR TITLE
Harden Debian PyGPT/PyGPT-net installer with audio runtime and Python deps

### DIFF
--- a/setup/Debian/install-deb.sh
+++ b/setup/Debian/install-deb.sh
@@ -52,6 +52,14 @@ BASE_PACKAGES=(
     gnupg
     ca-certificates
 )
+AUDIO_SYSTEM_PACKAGES=(
+    ffmpeg
+    libasound2-dev
+    libportaudio2
+    libportaudiocpp0
+    portaudio19-dev
+    libsndfile1
+)
 GUI_PACKAGES=(
     mate-desktop-environment-core
 )
@@ -253,6 +261,8 @@ function update_sources() {
 function install_packages() {
     echo "Installing required packages ..."
     apt-get install -y --no-install-recommends "${BASE_PACKAGES[@]}"
+    echo "Installing audio runtime packages for PyGPT/PyGPT-net ..."
+    apt-get install -y --no-install-recommends "${AUDIO_SYSTEM_PACKAGES[@]}"
     if [[ $INSTALL_GUI -eq 1 ]]; then
         echo "Installing optional GUI packages ..."
         apt-get install -y --no-install-recommends "${GUI_PACKAGES[@]}"
@@ -367,6 +377,15 @@ function install_python_requirements() {
                 echo "Unknown extras group '$extra' (supported: ml,data,cloud)" >&2
             fi
         done
+    fi
+
+    echo "Installing PyGPT-net and audio Python dependencies ..."
+    "$pip_bin" install --upgrade "pygpt-net>=2.6.67" pydub sounddevice soundfile
+
+    local submodule_path="$PROJECT_ROOT/repo/pygpt-MHP"
+    if [[ -d $submodule_path ]]; then
+        echo "Installing local pygpt-MHP integration in editable mode ..."
+        "$pip_bin" install -e "$submodule_path"
     fi
 }
 

--- a/setup/Debian/update-deb.sh
+++ b/setup/Debian/update-deb.sh
@@ -151,6 +151,14 @@ function update_system_packages() {
 
     local project_root="$1"
     local updater=""
+    local audio_packages=(
+        ffmpeg
+        libasound2-dev
+        libportaudio2
+        libportaudiocpp0
+        portaudio19-dev
+        libsndfile1
+    )
 
     echo "System update requested. Target apt codename: ${DEBIAN_CODENAME}"
 
@@ -180,6 +188,9 @@ function update_system_packages() {
     echo "Running apt update + dist-upgrade ..."
     run_as_root apt-get update -y
     run_as_root apt-get dist-upgrade -y
+
+    echo "Ensuring audio runtime packages for PyGPT/PyGPT-net are installed ..."
+    run_as_root apt-get install -y --no-install-recommends "${audio_packages[@]}"
 }
 
 function git_pull_updates() {
@@ -262,6 +273,15 @@ function update_python_deps() {
 
     echo "Reinstalling project in editable mode ..."
     "$pip_bin" install -e "$project_root"
+
+    echo "Updating PyGPT-net and audio Python dependencies ..."
+    "$pip_bin" install --upgrade "pygpt-net>=2.6.67" pydub sounddevice soundfile
+
+    local submodule_path="$project_root/repo/pygpt-MHP"
+    if [[ -d "$submodule_path" ]]; then
+        echo "Reinstalling local pygpt-MHP integration in editable mode ..."
+        "$pip_bin" install -e "$submodule_path"
+    fi
 
     # Optional extras
     declare -A extras_map=(


### PR DESCRIPTION
### Motivation
- Ensure PyGPT/PyGPT-net audio features work out-of-the-box by provisioning missing system audio libraries and runtime tools during Debian install/update flows.
- Make local development/submodule workflows smoother by automatically installing the local `repo/pygpt-MHP` package when present.
- Reduce manual post-install steps for audio support and PyGPT Python packages on target systems.

### Description
- Added `AUDIO_SYSTEM_PACKAGES` to `setup/Debian/install-deb.sh` and ensured those packages (`ffmpeg`, `libasound2-dev`, `libportaudio2`, `libportaudiocpp0`, `portaudio19-dev`, `libsndfile1`) are installed during `install_packages`.
- Extended `setup/Debian/update-deb.sh` to install the same audio runtime packages during `--system` updates via a new `audio_packages` list and an apt install step.
- Augmented both `install_python_requirements` and `update_python_deps` paths to explicitly install/upgrade `pygpt-net>=2.6.67` and audio-related Python packages `pydub`, `sounddevice`, and `soundfile` with the venv `pip`.
- Added conditional editable install of the local `repo/pygpt-MHP` submodule (if present) in both install and update flows to keep local integration synchronized.

### Testing
- Performed shell syntax checks with `bash -n setup/Debian/install-deb.sh`, which completed successfully.
- Performed shell syntax checks with `bash -n setup/Debian/update-deb.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b23cae2cc0832f923516f70c149b7d)