### PR TITLE
Refactor Huey ISO build script to use fresh kernel config

### DIFF
--- a/src/huey/memory/SH/build_huey_iso.sh
+++ b/src/huey/memory/SH/build_huey_iso.sh
@@ -44,13 +44,8 @@ cd "$WORK"
 wget -q https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${KVER}.tar.xz
 tar -xf linux-${KVER}.tar.xz
 cd linux-${KVER}
-# seed config from running kernel if available
-if [ -f "/boot/config-$(uname -r)" ]; then
-  cp "/boot/config-$(uname -r)" .config
-  yes "" | make olddefconfig
-else
-  make defconfig
-fi
+# generate a fresh baseline kernel config instead of inheriting host settings
+make defconfig
 make -j"$JOBS" bindeb-pkg LOCALVERSION="${LOCALVER}" KDEB_PKGVERSION=1
 cd ..
 


### PR DESCRIPTION
### Motivation
- Remove reliance on the host's kernel config (`/boot/config-$(uname -r)`) so the kernel build is deterministic and does not inherit host-specific settings.

### Description
- Replace the conditional copy of `/boot/config-$(uname -r)` and `make olddefconfig` with a direct `make defconfig` in `src/huey/memory/SH/build_huey_iso.sh` so a fresh baseline kernel config is always used.

### Testing
- Ran `bash -n src/huey/memory/SH/build_huey_iso.sh` which produced no syntax errors.
- Verified the change is present in the working tree with `git -C /workspace/Monkey-Head-Project status --short`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9650402f8832f94dc20a262066e83)