### PR TITLE
Enforce HueyOS kernel family/role naming in system checks

### DIFF
--- a/src/hueyos/system_checks.py
+++ b/src/hueyos/system_checks.py
@@ -10,11 +10,10 @@ from __future__ import annotations
 import logging
 import os
 import platform
+import re
 import shutil
 import sys
 from typing import Dict, Tuple
-
-from packaging.version import InvalidVersion, Version
 
 try:  # pragma: no cover - optional dependency on Linux only
     import distro  # type: ignore
@@ -26,7 +25,8 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_DISTRO_ID = "debian"
 SUPPORTED_DISTRO_CODENAME = "forky"
-MIN_KERNEL_VERSION = Version("6.18.2")
+SUPPORTED_KERNEL_FAMILY = "hueyos"
+KERNEL_ROLE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 MIN_PYTHON_VERSION = (3, 13)
 MAX_PYTHON_VERSION = (3, 15)
 REQUIRED_TOOLS: Tuple[str, ...] = ("git", "python3")
@@ -136,33 +136,65 @@ def check_os_support() -> bool:
 
 
 def _extract_kernel_version(raw_release: str) -> str:
-    """Normalise the kernel release string for comparison."""
+    """Return the numeric kernel version prefix from a release string."""
 
     version = raw_release.split("-")[0]
     version = version.split("+")[0]
     return version.strip()
 
 
-def _check_kernel_version() -> bool:
-    """Return ``True`` when the running kernel meets the minimum requirement."""
+def _extract_kernel_role(raw_release: str) -> str:
+    """Extract the HueyOS kernel role segment from a release string."""
+
+    lowered = raw_release.strip().lower()
+    marker = f"{SUPPORTED_KERNEL_FAMILY}-"
+    index = lowered.find(marker)
+    if index < 0:
+        return ""
+
+    role_start = index + len(marker)
+    remainder = lowered[role_start:]
+    if not remainder:
+        return ""
+
+    role = re.split(r"[+._]", remainder, maxsplit=1)[0]
+    return role.strip()
+
+
+def _check_kernel_naming() -> bool:
+    """Return ``True`` when the running kernel follows HueyOS family/role naming."""
 
     release = platform.release()
     version_str = _extract_kernel_version(release)
-    try:
-        version = Version(version_str)
-    except InvalidVersion:
+    if not version_str:
         logger.warning("Unable to parse kernel version from release '%s'", release)
         return False
 
-    if version < MIN_KERNEL_VERSION:
+    lowered = release.strip().lower()
+    if f"{SUPPORTED_KERNEL_FAMILY}-" not in lowered:
         logger.warning(
-            "Kernel version %s is below the required minimum of %s.",
-            version,
-            MIN_KERNEL_VERSION,
+            "Kernel release '%s' is missing the '%s-<role>' family/role suffix.",
+            release,
+            SUPPORTED_KERNEL_FAMILY,
+        )
+        return False
+
+    role = _extract_kernel_role(lowered)
+    if not role or not KERNEL_ROLE_PATTERN.match(role):
+        logger.warning(
+            "Kernel release '%s' has an invalid HueyOS role segment '%s'.",
+            release,
+            role or "missing",
         )
         return False
 
     return True
+
+
+def _check_kernel_version() -> bool:
+    """Compatibility wrapper for legacy callers expecting this function name."""
+
+    return _check_kernel_naming()
 
 
 def check_python_version() -> bool:

--- a/tests/test_system_checks_module.py
+++ b/tests/test_system_checks_module.py
@@ -69,6 +69,26 @@ def test_check_python_version_accepts_primary_target(monkeypatch, caplog):
     assert "Python 3.13" not in caplog.text
 
 
+def test_check_kernel_naming_accepts_hueyos_family_role(monkeypatch, caplog):
+    monkeypatch.setattr(system_checks.platform, "release", lambda: "6.18.2-hueyos-core")
+
+    with caplog.at_level(logging.WARNING):
+        supported = system_checks._check_kernel_naming()
+
+    assert supported is True
+    assert "Kernel release" not in caplog.text
+
+
+def test_check_kernel_naming_rejects_non_hueyos_suffix(monkeypatch, caplog):
+    monkeypatch.setattr(system_checks.platform, "release", lambda: "6.18.2-generic")
+
+    with caplog.at_level(logging.WARNING):
+        supported = system_checks._check_kernel_naming()
+
+    assert supported is False
+    assert "family/role suffix" in caplog.text
+
+
 def test_system_check_collects_expected_results(monkeypatch):
     def fake_os_check():
         return None


### PR DESCRIPTION
### Motivation
- Replace the brittle minimum-kernel-version gate with a semantic check that ensures the running kernel belongs to the HueyOS kernel family and carries a valid role name (e.g. `hueyos-core`) so HueyOS-specific kernels are reliably detected.
- Avoid depending on a specific numeric kernel version and focus on the project convention of `hueyos-<role>` naming for compatibility and clearer diagnostics.
- Preserve compatibility with existing callers that expect `_check_kernel_version()` to exist.

### Description
- Replaced the numeric minimum-kernel constant with `SUPPORTED_KERNEL_FAMILY = "hueyos"` and added a regular-expression `KERNEL_ROLE_PATTERN` to validate role names in `src/hueyos/system_checks.py`.
- Added `_extract_kernel_role()` to parse the `hueyos-<role>` segment from `platform.release()` and `_check_kernel_naming()` which validates presence of the family suffix and the role format, emitting warnings for missing/invalid patterns.
- Kept `_check_kernel_version()` as a compatibility wrapper that now delegates to ` _check_kernel_naming()` so existing call sites remain unchanged, and removed the packaging `Version` dependency for kernel checks.
- Added unit tests in `tests/test_system_checks_module.py` that assert acceptance of `6.18.2-hueyos-core` and rejection of `6.18.2-generic` kernel release strings.

### Testing
- Ran the targeted test suite with `pytest -q tests/test_system_checks_module.py tests/test_os_check.py tests/test_os_check_fallback.py` and observed that the tests completed successfully with the new checks (final result: all targeted tests passed and one OS test was skipped due to missing `distro`).
- All automated assertions in the updated `tests/test_system_checks_module.py` for kernel naming passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9673acd24832f90ce57c05020156d)