### PR TITLE
fix(api): bind huey-api to localhost by default

### DIFF
--- a/src/huey/memory/PY/api.py
+++ b/src/huey/memory/PY/api.py
@@ -1884,7 +1884,7 @@ def main() -> None:
     import os
     import uvicorn
 
-    host = os.getenv("HUEY_HOST", "0.0.0.0")
+    host = os.getenv("HUEY_HOST", "127.0.0.1")
     port = int(os.getenv("HUEY_PORT", "1995"))
     reload = os.getenv("HUEY_RELOAD", "").strip().lower() in {"1", "true", "yes", "on"}
 


### PR DESCRIPTION
### Motivation
- The `huey-api` console entrypoint previously defaulted `HUEY_HOST` to `0.0.0.0`, which can unintentionally expose an unauthenticated control API to external networks, so the default should be restricted to localhost.

### Description
- Updated `src/huey/memory/PY/api.py` to use `os.getenv("HUEY_HOST", "127.0.0.1")` in `main()`, preserving behavior for operators who explicitly set `HUEY_HOST`.

### Testing
- Verified the change and repository state using `git diff -- src/huey/memory/PY/api.py`, a Python content check to ensure `0.0.0.0` was removed and `127.0.0.1` added, `nl`/`sed` to inspect the modified lines, and `git status --short`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69c973435df0832f970d70e8c2982155)