### PR TITLE
Require VNC authentication in Dockerfile.vnc (x11vnc -rfbauth)

### DIFF
--- a/src/huey/memory/DOCKER/Dockerfile.vnc
+++ b/src/huey/memory/DOCKER/Dockerfile.vnc
@@ -27,6 +27,7 @@ set -euo pipefail
 RES="${RES:-1920x1080}"                 # 1920x1080, 2560x1440, 3840x2160
 ENABLE_RESIZE="${ENABLE_RESIZE:-1}"     # 1 = allow resize (xrandr), 0 = fixed size
 NOVNC_PORT="${NOVNC_PORT:-1995}"        # noVNC listen port (served by websockify)
+VNC_PASSWORD="${VNC_PASSWORD:-}"        # VNC password (auto-generated if empty)
 
 # Safe, broadly compatible defaults:
 # -noxdamage often improves redraw correctness
@@ -62,8 +63,17 @@ if [[ "${ENABLE_RESIZE}" == "1" ]]; then
   XRANDR_FLAG="-xrandr"
 fi
 
+if [[ -z "${VNC_PASSWORD}" ]]; then
+  VNC_PASSWORD="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 20)"
+  echo "[start-vnc-pygpt] Generated VNC password: ${VNC_PASSWORD}"
+fi
+
+VNC_PASSWD_FILE="/tmp/x11vnc.pass"
+x11vnc -storepasswd "${VNC_PASSWORD}" "${VNC_PASSWD_FILE}" >/dev/null
+chmod 600 "${VNC_PASSWD_FILE}"
+
 # Prefer IPv4 bind noise-free; x11vnc handles clients fine via localhost anyway
-x11vnc -display :1 -forever -shared -nopw -rfbport 5900 ${XRANDR_FLAG} ${VNC_EXTRA_FLAGS} &
+x11vnc -display :1 -forever -shared -rfbauth "${VNC_PASSWD_FILE}" -rfbport 5900 ${XRANDR_FLAG} ${VNC_EXTRA_FLAGS} &
 
 # noVNC web client on NOVNC_PORT, landing on vnc.html (no directory listing)
 websockify --web=/usr/share/novnc/ --index vnc.html "${NOVNC_PORT}" localhost:5900 &


### PR DESCRIPTION
### Motivation
- The VNC/noVNC startup previously launched `x11vnc` with `-nopw` and exposed noVNC via `websockify`, allowing unauthenticated remote desktop access to the container.
- This gives remote attackers interactive desktop control and potential full compromise of the PyGPT runtime, so the startup must require authentication by default.

### Description
- Added a `VNC_PASSWORD` environment variable to the generated `start-vnc-pygpt.sh` and support for auto-generating a secure random password when unset.
- Store the password using `x11vnc -storepasswd` into `/tmp/x11vnc.pass` and restrict it with `chmod 600` to protect credentials at runtime.
- Replaced the `-nopw` option with `-rfbauth "/tmp/x11vnc.pass"` when launching `x11vnc`, preserving existing `websockify`/noVNC behavior and startup flow.

### Testing
- Confirmed the fix by running `rg -n -- '-nopw|rfbauth|VNC_PASSWORD' src/huey/memory/DOCKER/Dockerfile.vnc` which shows `-rfbauth` and `VNC_PASSWORD` are present (success).
- Performed a shell syntax check on the embedded startup script via `awk '...start-vnc-pygpt.sh...' | bash -n` which returned no syntax errors (success).
- Inspected the `git diff` of `src/huey/memory/DOCKER/Dockerfile.vnc` to verify the intended patch was applied and committed (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69b240d57064832f95cd8abfd4b7c84f)