### PR TITLE
Harden SubOS VNC configuration to remove hardcoded credential and restrict binding

### DIFF
--- a/docker/subos/Dockerfile
+++ b/docker/subos/Dockerfile
@@ -36,18 +36,28 @@ COPY . .
 # Correcting user creation and usage
 RUN useradd -m dlrp && chown -R dlrp:dlrp /subos-workdir
 USER dlrp
+ENV HOME=/home/dlrp
 
 # Set up VNC server
-RUN mkdir /root/.vnc
-RUN echo "dlrp" | vncpasswd -f > /root/.vnc/passwd
-RUN chmod 600 /root/.vnc/passwd
+RUN mkdir -p "$HOME/.vnc"
 
 # Set up VNC session startup script
-RUN echo "#!/bin/bash\nxrdb $HOME/.Xresources\nstartmate &" > /root/.vnc/xstartup
-RUN chmod +x /root/.vnc/xstartup
+RUN echo "#!/bin/bash\nxrdb $HOME/.Xresources\nstartmate &" > "$HOME/.vnc/xstartup"
+RUN chmod +x "$HOME/.vnc/xstartup"
+
+# Start VNC with a runtime-provided password and localhost-only binding
+RUN printf '%s\n' '#!/bin/bash' \
+    'set -euo pipefail' \
+    ': "${VNC_PASSWORD:?Set VNC_PASSWORD at runtime}"' \
+    'mkdir -p "$HOME/.vnc"' \
+    'printf "%s" "$VNC_PASSWORD" | vncpasswd -f > "$HOME/.vnc/passwd"' \
+    'chmod 600 "$HOME/.vnc/passwd"' \
+    'exec vncserver -geometry 1280x800 -depth 24 -localhost yes :1' \
+    > /usr/local/bin/start-vnc.sh \
+ && chmod +x /usr/local/bin/start-vnc.sh
 
 # Expose the necessary port(s)
 EXPOSE 5901
 
 # Define the command to run when the container starts
-CMD ["vncserver", "-geometry", "1280x800", "-depth", "24", "-localhost", "no", ":1"]
+CMD ["/usr/local/bin/start-vnc.sh"]


### PR DESCRIPTION
### Motivation
- The SubOS container image baked a static VNC password (`dlrp`) into the image and launched `vncserver` with `-localhost no`, exposing a network-reachable desktop with a known credential.  
- A minimal configuration change was needed to eliminate the static credential and restrict VNC to localhost while preserving runtime behavior.

### Description
- Updated `docker/subos/Dockerfile` to stop writing a hardcoded password into `/root/.vnc` and to use the non-root user's home directory (`ENV HOME=/home/dlrp`) for VNC artifacts.  
- Added an image-provided startup wrapper `/usr/local/bin/start-vnc.sh` (created during build) that requires a runtime `VNC_PASSWORD` environment variable and writes the password into the user's `~/.vnc/passwd`.  
- Changed the VNC invocation to use `-localhost yes` (listen only on loopback) and switched the container `CMD` to execute the hardened startup wrapper while keeping the same geometry/depth settings.  
- Kept existing desktop startup (`xstartup`) behavior and relocated VNC files to the non-root user's home to avoid embedding credentials in image layers.

### Testing
- Ran repository pattern searches with `rg` to locate the original vulnerable patterns and confirm the Dockerfile now contains `VNC_PASSWORD` and `start-vnc.sh` (success).  
- Displayed the updated file diff and inspected `docker/subos/Dockerfile` lines (`nl`/`sed`) to verify removal of the hardcoded `dlrp` password and presence of the new startup script and `-localhost yes` flag (success).  
- Verified the Dockerfile now creates the runtime wrapper that enforces `VNC_PASSWORD` and no longer echoes a static credential into an image layer (success).  
- Attempted `python -m py_compile docker/subos/subos.yaml` which failed because the command was run against a YAML manifest (syntax checker misuse) and is unrelated to the Dockerfile changes (expected/irrelevant failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69b28e0b5954832fad0146a4bad4b486)