### PR TITLE
Harden SubOS VNC startup configuration

### DIFF
--- a/docker/subos/Dockerfile
+++ b/docker/subos/Dockerfile
@@ -38,16 +38,14 @@ RUN useradd -m dlrp && chown -R dlrp:dlrp /subos-workdir
 USER dlrp
 
 # Set up VNC server
-RUN mkdir /root/.vnc
-RUN echo "dlrp" | vncpasswd -f > /root/.vnc/passwd
-RUN chmod 600 /root/.vnc/passwd
+RUN mkdir -p /home/dlrp/.vnc && chmod 700 /home/dlrp/.vnc
 
 # Set up VNC session startup script
-RUN echo "#!/bin/bash\nxrdb $HOME/.Xresources\nstartmate &" > /root/.vnc/xstartup
-RUN chmod +x /root/.vnc/xstartup
+RUN echo "#!/bin/bash\nxrdb $HOME/.Xresources\nstartmate &" > /home/dlrp/.vnc/xstartup
+RUN chmod +x /home/dlrp/.vnc/xstartup
 
 # Expose the necessary port(s)
 EXPOSE 5901
 
 # Define the command to run when the container starts
-CMD ["vncserver", "-geometry", "1280x800", "-depth", "24", "-localhost", "no", ":1"]
+CMD ["bash", "-lc", "set -euo pipefail; : \"${VNC_PASSWORD:?VNC_PASSWORD must be set at runtime}\"; printf '%s\\n' \"$VNC_PASSWORD\" | vncpasswd -f > \"$HOME/.vnc/passwd\"; chmod 600 \"$HOME/.vnc/passwd\"; exec vncserver -geometry 1280x800 -depth 24 -localhost yes :1"]


### PR DESCRIPTION
### Motivation

- Remove an insecure default in the SubOS image that baked a known VNC password into the image and started the VNC server bound to all interfaces, which allowed remote access to port 5901 with a known credential. 
- Apply a minimal fix that eliminates hardcoded credentials and reduces network exposure while preserving the container's VNC functionality for local use and testing.

### Description

- Removed the baked-in VNC password and root /root/.vnc usage and switched the VNC runtime files to the non-root user's home at `/home/dlrp/.vnc` with secure permissions.
- Changed the container entrypoint to require a `VNC_PASSWORD` environment variable at runtime and generate the VNC password file on container start instead of during image build. 
- Changed the VNC server launch to use `-localhost yes` (local-only binding) instead of `-localhost no` to avoid exposing the desktop by default while keeping the same display (`:1`) and port mapping behavior inside the container.
- The change is limited to `docker/subos/Dockerfile` and preserves existing EXPOSE and VNC behavior for local port forwarding or safe deployment behind an authenticated proxy.

### Testing

- Searched the repository for vulnerable patterns (`vncpasswd`, `vncserver`, `-localhost no`, `5901`, `LoadBalancer`) and confirmed the hardcoded password and remote-binding pattern were removed from `docker/subos/Dockerfile` (search succeeded).
- Inspected the updated `docker/subos/Dockerfile` contents to verify the new runtime `VNC_PASSWORD` requirement, the `/home/dlrp/.vnc` path and permission changes, and the `-localhost yes` flag (file inspection succeeded).
- Verified relevant Kubernetes manifests for NanoOS/HostOS/SubOS in the current HEAD are `ClusterIP` services (no LoadBalancer exposing 5901) by scanning the YAML manifests (manifest checks succeeded).
- Runtime execution of the VNC server inside a container could not be validated in this environment because container tooling / VNC binaries were not available, so no live container run was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69b2906f4698832fa6646e1145c0e974)