### PR TITLE
Remove hardcoded VNC password from subos Docker image build

### DIFF
--- a/infra/docker/docker/subos/Dockerfile
+++ b/infra/docker/docker/subos/Dockerfile
@@ -39,8 +39,6 @@ USER dlrp
 
 # Set up VNC server
 RUN mkdir /root/.vnc
-RUN echo "dlrp" | vncpasswd -f > /root/.vnc/passwd
-RUN chmod 600 /root/.vnc/passwd
 
 # Set up VNC session startup script
 RUN echo "#!/bin/bash\nxrdb $HOME/.Xresources\nstartmate &" > /root/.vnc/xstartup


### PR DESCRIPTION
### Motivation
- Prevent baking a static VNC secret into image layers by removing the build-time creation of the hardcoded `dlrp` password at `/root/.vnc/passwd`.

### Description
- Deleted the build-time commands that executed `echo "dlrp" | vncpasswd -f > /root/.vnc/passwd` and the corresponding `chmod 600` so no fixed VNC password file is created during image build, while leaving the runtime `CMD` (`vncserver ...`) unchanged.

### Testing
- Ran `git diff -- infra/docker/docker/subos/Dockerfile`, `git status --short`, and `git commit -m "Remove hardcoded VNC password from subos image build"`, and inspected the updated `infra/docker/docker/subos/Dockerfile` (via `nl`/`sed`) to confirm the removal; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d96d408a80832fa2a5ee0e2248f6a3)