### PR TITLE
Move subos VNC state to non-root home directory

### DIFF
--- a/infra/docker/docker/subos/Dockerfile
+++ b/infra/docker/docker/subos/Dockerfile
@@ -7,7 +7,8 @@ LABEL maintainer="admin@subos.com"
 
 # Set environment variables to minimize issues and configure Python not to create .pyc files
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    HOME=/home/dlrp
 
 # Update the package repository and install necessary packages
 # Using 'apt-get install -y --no-install-recommends' to keep the installation small
@@ -38,11 +39,11 @@ RUN useradd -m dlrp && chown -R dlrp:dlrp /subos-workdir
 USER dlrp
 
 # Set up VNC server
-RUN mkdir /root/.vnc
+RUN mkdir -p "$HOME/.vnc"
 
 # Set up VNC session startup script
-RUN echo "#!/bin/bash\nxrdb $HOME/.Xresources\nstartmate &" > /root/.vnc/xstartup
-RUN chmod +x /root/.vnc/xstartup
+RUN echo "#!/bin/bash\nxrdb $HOME/.Xresources\nstartmate &" > "$HOME/.vnc/xstartup"
+RUN chmod +x "$HOME/.vnc/xstartup"
 
 # Expose the necessary port(s)
 EXPOSE 5901


### PR DESCRIPTION
### Motivation
- Ensure VNC artifacts are created under the non-root user's home so the container does not rely on `/root/.vnc` for normal operation.

### Description
- Set `HOME=/home/dlrp` in `infra/docker/docker/subos/Dockerfile`.
- Create the VNC directory with `mkdir -p "$HOME/.vnc"` instead of `/root/.vnc`.
- Write the `xstartup` script to `"$HOME/.vnc/xstartup"` and set executable permissions with `chmod +x`.
- Kept all other Dockerfile configuration unchanged and left the container running as the `dlrp` non-root user.

### Testing
- Ran `rg -n '/root/\.vnc|HOME=|\.vnc' infra/docker/docker/subos/Dockerfile` to verify references and the `HOME` env, which succeeded and shows `HOME=/home/dlrp` and `$HOME/.vnc` usages with no `/root/.vnc` occurrences. 
- Committed the change with `git commit -m "Update subos VNC paths to non-root home"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d96e05d7a0832fb13542218ff56aad)