### PR TITLE
Add runtime VNC startup wrapper requiring VNC_PASSWORD

### DIFF
--- a/infra/docker/docker/subos/Dockerfile
+++ b/infra/docker/docker/subos/Dockerfile
@@ -36,6 +36,28 @@ COPY . .
 # Non-root User:
 # Correcting user creation and usage
 RUN useradd -m dlrp && chown -R dlrp:dlrp /subos-workdir
+
+# Add a startup wrapper that configures VNC auth from runtime env vars.
+RUN cat <<'EOF' > /usr/local/bin/start-vnc.sh
+#!/bin/bash
+set -euo pipefail
+
+if [ -z "${VNC_PASSWORD:-}" ]; then
+    echo "ERROR: VNC_PASSWORD is required at runtime." >&2
+    exit 1
+fi
+
+mkdir -p "$HOME/.vnc"
+chmod 700 "$HOME/.vnc"
+umask 077
+printf '%s\n' "$VNC_PASSWORD" | vncpasswd -f > "$HOME/.vnc/passwd"
+chmod 600 "$HOME/.vnc/passwd"
+unset VNC_PASSWORD
+
+exec vncserver "$@"
+EOF
+RUN chmod +x /usr/local/bin/start-vnc.sh
+
 USER dlrp
 
 # Set up VNC server
@@ -49,4 +71,4 @@ RUN chmod +x "$HOME/.vnc/xstartup"
 EXPOSE 5901
 
 # Define the command to run when the container starts
-CMD ["vncserver", "-geometry", "1280x800", "-depth", "24", "-localhost", "no", ":1"]
+CMD ["/usr/local/bin/start-vnc.sh", "-geometry", "1280x800", "-depth", "24", "-localhost", "no", ":1"]


### PR DESCRIPTION
### Motivation
- Ensure VNC authentication material is created only at container runtime and not baked into image layers.
- Fail fast at container startup when a `VNC_PASSWORD` is not provided to avoid silent insecure defaults.
- Enforce restrictive permissions on generated VNC credentials so they are only readable by the container user.

### Description
- Add a build-time creation of the wrapper script at `/usr/local/bin/start-vnc.sh` in `infra/docker/docker/subos/Dockerfile` and make it executable via `chmod +x`.
- The wrapper requires `VNC_PASSWORD` at runtime, exits with an error if it is missing, and then generates `~/.vnc/passwd` using `vncpasswd -f` from the provided environment value.
- The script ensures `~/.vnc` has `700` permissions, the `passwd` file is created with `600` permissions, and the `VNC_PASSWORD` environment variable is unset after use.
- Update the container `CMD` to invoke the wrapper so existing VNC server arguments are passed through to `vncserver` while preserving runtime password handling.

### Testing
- Verified the updated Dockerfile content and extracted the wrapper block with `nl -ba infra/docker/docker/subos/Dockerfile | sed -n '30,110p'`, which completed successfully.
- Reviewed the resulting diff with `git diff -- infra/docker/docker/subos/Dockerfile`, which showed the wrapper addition and `CMD` update as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d96ec6d654832f9d4fd32c1e89d6ac)