### PR TITLE
Lock subos VNC to localhost in container startup

### DIFF
--- a/infra/docker/docker/subos/Dockerfile
+++ b/infra/docker/docker/subos/Dockerfile
@@ -71,4 +71,4 @@ RUN chmod +x "$HOME/.vnc/xstartup"
 EXPOSE 5901
 
 # Define the command to run when the container starts
-CMD ["/usr/local/bin/start-vnc.sh", "-geometry", "1280x800", "-depth", "24", "-localhost", "no", ":1"]
+CMD ["/usr/local/bin/start-vnc.sh", "-geometry", "1280x800", "-depth", "24", "-localhost", "yes", ":1"]


### PR DESCRIPTION
### Motivation
- Restrict the VNC server to listen only on the loopback interface and ensure startup goes through the existing wrapper script so runtime VNC auth and environment handling remain in place.

### Description
- Updated `infra/docker/docker/subos/Dockerfile` `CMD` so the VNC server is launched via `/usr/local/bin/start-vnc.sh` with `-localhost yes` instead of `-localhost no`, preserving `-geometry 1280x800`, `-depth 24`, and the `~/.vnc/xstartup` behavior.

### Testing
- Ran the patch/apply and reviewed the Dockerfile diff with `git diff` and file listing (`nl -ba ... | sed -n '60,90p'`) to confirm the single-argument change, and the patch/commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d96fd22290832fb2742f968fcc2fff)