### PR TITLE
Fix kernel download path for 7.x in Huey ISO builder

### DIFF
--- a/src/huey/memory/SH/build_huey_iso.sh
+++ b/src/huey/memory/SH/build_huey_iso.sh
@@ -41,8 +41,11 @@ rm -rf "$WORK" && mkdir -p "$WORK"
 cd "$WORK"
 
 # --- build kernel 7.0.x → .debs ---
-wget -q https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${KVER}.tar.xz
-tar -xf linux-${KVER}.tar.xz
+KMAJOR="${KVER%%.*}"
+KSERIES_PATH="v${KMAJOR}.x"
+KERNEL_TARBALL="linux-${KVER}.tar.xz"
+wget -q "https://cdn.kernel.org/pub/linux/kernel/${KSERIES_PATH}/${KERNEL_TARBALL}"
+tar -xf "${KERNEL_TARBALL}"
 cd linux-${KVER}
 # generate a fresh baseline kernel config instead of inheriting host settings
 make defconfig


### PR DESCRIPTION
### Motivation
- The ISO build script sets `KVER=7.0.0` but still downloaded the kernel from the hardcoded `v6.x` kernel.org directory, causing wrong tarball paths for 7.x kernels.
- The change aims to make the download URL follow the kernel.org major-series layout so `7.x` (and future major versions) are handled correctly without manual edits.

### Description
- Updated `src/huey/memory/SH/build_huey_iso.sh` to compute `KMAJOR` from `KVER` and derive `KSERIES_PATH="v${KMAJOR}.x"` instead of using a hardcoded `v6.x` path. 
- Introduced `KERNEL_TARBALL="linux-${KVER}.tar.xz"` and used it for both the `wget` URL and the `tar -xf` extraction command. 
- The download now uses `https://cdn.kernel.org/pub/linux/kernel/${KSERIES_PATH}/${KERNEL_TARBALL}` so `KVER=7.0.0` will fetch from `v7.x` and future major-version bumps work automatically.

### Testing
- Ran a shell syntax check with `bash -n src/huey/memory/SH/build_huey_iso.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d971b5d7a4832f9cf21ec08da25cd5)