### PR TITLE
Make Huey ISO kernel localversion role-aware

### DIFF
--- a/kernel/assemble_kernel_config.sh
+++ b/kernel/assemble_kernel_config.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+  echo "Usage: $0 <role: core|pulse|lab> <output-config> [kernel-config-dir]" >&2
+  exit 1
+fi
+
+ROLE="$1"
+OUTPUT_CONFIG="$2"
+KERNEL_CONFIG_DIR="${3:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+BASE_CONFIG="${KERNEL_CONFIG_DIR}/base.config"
+
+if [[ ! -f "${BASE_CONFIG}" ]]; then
+  echo "Missing base config: ${BASE_CONFIG}" >&2
+  exit 1
+fi
+
+case "${ROLE}" in
+  core)
+    ROLE_CONFIG="${KERNEL_CONFIG_DIR}/core.config"
+    ;;
+  pulse)
+    ROLE_CONFIG="${KERNEL_CONFIG_DIR}/pulse.config"
+    ;;
+  lab)
+    ROLE_CONFIG="${KERNEL_CONFIG_DIR}/lab.config"
+    ;;
+  *)
+    echo "Unsupported role '${ROLE}'. Expected one of: core, pulse, lab." >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "${ROLE_CONFIG}" ]]; then
+  echo "Missing role config: ${ROLE_CONFIG}" >&2
+  exit 1
+fi
+
+cat "${BASE_CONFIG}" "${ROLE_CONFIG}" > "${OUTPUT_CONFIG}"
+echo "Assembled kernel config for role '${ROLE}' -> ${OUTPUT_CONFIG}" >&2

--- a/kernel/lab.config
+++ b/kernel/lab.config
@@ -1,0 +1,26 @@
+# HueyLab kernel profile.
+#
+# Applies to experimental and validation systems used in lab workflows.
+# Intended to be merged with kernel/base.config.
+
+# Keep desktop-oriented hardware coverage.
+CONFIG_DRM_AMDGPU=y
+CONFIG_DRM_I915=y
+CONFIG_DRM_NOUVEAU=y
+CONFIG_DRM_VIRTIO_GPU=y
+CONFIG_SND_USB_AUDIO=y
+
+# Favor instrumentation and traceability in lab runs.
+CONFIG_KALLSYMS_ALL=y
+CONFIG_FTRACE=y
+CONFIG_FUNCTION_TRACER=y
+CONFIG_DYNAMIC_DEBUG=y
+CONFIG_DEBUG_KERNEL=y
+CONFIG_DEBUG_INFO=y
+
+# Developer and test virtualization helpers.
+CONFIG_KVM=y
+CONFIG_KVM_INTEL=y
+CONFIG_KVM_AMD=y
+CONFIG_VFIO=y
+CONFIG_VFIO_PCI=y

--- a/src/huey/memory/SH/build_huey_iso.sh
+++ b/src/huey/memory/SH/build_huey_iso.sh
@@ -7,7 +7,9 @@
 set -euo pipefail
 
 # This script builds a UEFI-only amd64 ISO using Debian live-build
-# and a custom Linux kernel version 7.0.x-hueyos-v1 for Debian Forky.
+# and a custom Linux kernel version 7.0.x with role-aware local version
+# naming (for example: -hueyos-core, -hueyos-pulse, -hueyos-lab)
+# for Debian Forky.
 # Because this container environment
 # doesn't provide a Windows filesystem under /mnt/c, the output
 # directory (OUTWIN) is pointed at the shared folder so that the ISO
@@ -16,14 +18,32 @@ set -euo pipefail
 # wish to change OUTWIN to "/mnt/c/Users/admin/Desktop/${ISO_NAME}".
 
 # --- config ---
-ISO_NAME="huey-v1.0-amd64"
+ROLE="${HUEY_ROLE:-core}"
 KVER="7.0.0"
-LOCALVER="-hueyos-v1"
+LOCALVER="${LOCALVER:-}"
+
+case "${ROLE}" in
+  core|pulse|lab)
+    ;;
+  *)
+    echo "Unsupported role '${ROLE}'. Use core, pulse, or lab." >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "${LOCALVER}" ]]; then
+  LOCALVER="-hueyos-${ROLE}"
+fi
+
+ISO_NAME="${ISO_NAME:-huey-${ROLE}-v1.0-amd64}"
 # Output directory set to shared folder rather than Windows desktop.
 OUTWIN="${OUTWIN:-/home/oai/share/${ISO_NAME}}"
 WORK="$HOME/huey-iso-build"
 JOBS="$(nproc)"
 
+echo "Role: ${ROLE}"
+echo "Kernel local version: ${LOCALVER}"
+echo "ISO name: ${ISO_NAME}"
 echo "Using output directory: $OUTWIN"
 
 # --- prerequisites ---
@@ -47,8 +67,17 @@ KERNEL_TARBALL="linux-${KVER}.tar.xz"
 wget -q "https://cdn.kernel.org/pub/linux/kernel/${KSERIES_PATH}/${KERNEL_TARBALL}"
 tar -xf "${KERNEL_TARBALL}"
 cd linux-${KVER}
-# generate a fresh baseline kernel config instead of inheriting host settings
-make defconfig
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+CONFIG_ASSEMBLER="${REPO_ROOT}/kernel/assemble_kernel_config.sh"
+
+if [[ ! -x "${CONFIG_ASSEMBLER}" ]]; then
+  echo "Missing config assembly script: ${CONFIG_ASSEMBLER}" >&2
+  exit 1
+fi
+
+# generate a role-aware kernel config instead of inheriting host settings
+"${CONFIG_ASSEMBLER}" "${ROLE}" .config
+make olddefconfig
 make -j"$JOBS" bindeb-pkg LOCALVERSION="${LOCALVER}" KDEB_PKGVERSION=1
 cd ..
 
@@ -95,9 +124,9 @@ chmod +x config/hooks/normal/90-grub-default.chroot
 INC="config/includes.binary"
 mkdir -p "${INC}"/{boot,dists,doc,EFI,firmware,huey,install,install.amd,iso,isolinux,live,monkey-head-project,pics,pool,secrets}
 # minimal README on the ISO root
-cat > "${INC}/README.md" <<'EOF_README'
+cat > "${INC}/README.md" <<EOF_README
 # Huey ISO
-UEFI-only, amd64. Kernel 7.0.x-hueyos-v1. Custom Debian Forky live + installer image for Monkey-Head-Project.
+UEFI-only, amd64. Kernel 7.0.x${LOCALVER}. Role: ${ROLE}. Custom Debian Forky live + installer image for Monkey-Head-Project.
 EOF_README
 
 # build
@@ -115,8 +144,8 @@ sudo cp -f "$ISO_BUILT" "${OUTWIN}/${ISO_NAME}.iso"
 sudo xorriso -osirrox on -indev "$ISO_BUILT" -extract / "$OUTWIN"
 
 # also place kernel debs at the root with the exact names you want
-sudo cp -f "../${HDR_DEB}" "${OUTWIN}/linux-headers-${KVER}_${KVER}-1_amd64.deb"
-sudo cp -f "../${IMG_DEB}" "${OUTWIN}/linux-image-${KVER}_${KVER}-1_amd64.deb"
+sudo cp -f "../${HDR_DEB}" "${OUTWIN}/linux-headers-${KVER}${LOCALVER}_${KVER}-1_amd64.deb"
+sudo cp -f "../${IMG_DEB}" "${OUTWIN}/linux-image-${KVER}${LOCALVER}_${KVER}-1_amd64.deb"
 sudo cp -f "../${LIBC_DEB}" "${OUTWIN}/linux-libc-dev_${KVER}-1_amd64.deb"
 
 echo "Wrote: ${OUTWIN}"


### PR DESCRIPTION
### Motivation
- The ISO/kernel builder still used the generic `-hueyos-v1` `LOCALVER` after the 7.0 retarget, so output artifacts and kernel config selection were not role-specific.
- Provide explicit role-based naming (for example `-hueyos-core`, `-hueyos-pulse`, `-hueyos-lab`) and ensure kernel builds use the correct role profile.

### Description
- Refactored `src/huey/memory/SH/build_huey_iso.sh` to accept `HUEY_ROLE` (`core|pulse|lab`), validate the role, default `LOCALVER` to `-hueyos-<role>` when not overridden, and default `ISO_NAME` to `huey-<role>-v1.0-amd64`.
- Switched kernel config generation to a role-aware flow by invoking `kernel/assemble_kernel_config.sh` to assemble `base.config` + role profile into `.config` and then running `make olddefconfig` before building packages.
- Made output filenames role-aware so exported kernel debs preserve the `LOCALVER` suffix (e.g. `linux-image-7.0.0-hueyos-core_7.0.0-1_amd64.deb`).
- Added `kernel/assemble_kernel_config.sh` which merges `kernel/base.config` with `kernel/{core,pulse,lab}.config` and added a new `kernel/lab.config` role profile.

### Testing
- Ran shell syntax checks: `bash -n src/huey/memory/SH/build_huey_iso.sh` and `bash -n kernel/assemble_kernel_config.sh`, both succeeded.
- Performed a smoke assembly: `kernel/assemble_kernel_config.sh core <tmpfile>` and inspected output, which succeeded and printed the assembled header.
- Verified the modified build script runs the assembler and exits with no syntax errors in a local smoke invocation, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9733047ac832fb75d9ef4e0d34fce)