### PR TITLE
Wire Huey ISO kernel config build to repo-managed assembler

### DIFF
--- a/src/huey/memory/SH/build_huey_iso.sh
+++ b/src/huey/memory/SH/build_huey_iso.sh
@@ -68,15 +68,17 @@ wget -q "https://cdn.kernel.org/pub/linux/kernel/${KSERIES_PATH}/${KERNEL_TARBAL
 tar -xf "${KERNEL_TARBALL}"
 cd linux-${KVER}
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
-CONFIG_ASSEMBLER="${REPO_ROOT}/kernel/assemble_kernel_config.sh"
+CONFIG_ASSEMBLER="${REPO_ROOT}/scripts/kernel/assemble_config.sh"
+KERNEL_CONFIG_DIR="${REPO_ROOT}/kernel"
 
 if [[ ! -x "${CONFIG_ASSEMBLER}" ]]; then
   echo "Missing config assembly script: ${CONFIG_ASSEMBLER}" >&2
   exit 1
 fi
 
-# generate a role-aware kernel config instead of inheriting host settings
-"${CONFIG_ASSEMBLER}" "${ROLE}" .config
+# generate a repo-managed role-aware kernel config:
+#   kernel/base.config + kernel/<role>.config -> .config
+"${CONFIG_ASSEMBLER}" "${ROLE}" .config "${KERNEL_CONFIG_DIR}"
 make olddefconfig
 make -j"$JOBS" bindeb-pkg LOCALVERSION="${LOCALVER}" KDEB_PKGVERSION=1
 cd ..


### PR DESCRIPTION
### Motivation
- The ISO builder fell back to `make defconfig` and did not use the repo-managed `kernel/base.config` plus role profiles, so role-specific kernel configs were not being applied to ISO builds.

### Description
- Updated `src/huey/memory/SH/build_huey_iso.sh` to invoke `scripts/kernel/assemble_config.sh` and pass the repo `kernel` directory so `.config` is assembled from `kernel/base.config` + `kernel/<role>.config`, while keeping the subsequent `make olddefconfig` step.

### Testing
- Performed a static shell syntax check with `bash -n src/huey/memory/SH/build_huey_iso.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d97a6c719c832f85c10c2c44bfa91c)