### PR TITLE
Tighten Huey Core kernel config around AMD hardware direction

### DIFF
--- a/kernel/core.config
+++ b/kernel/core.config
@@ -1,6 +1,6 @@
 # Huey Core kernel profile.
 #
-# Applies to desktop + AI + graphics oriented Huey Core systems.
+# Applies to AMD desktop + AI/developer-oriented Huey Core systems.
 # Intended to be merged with kernel/base.config.
 
 CONFIG_PREEMPT=y
@@ -13,21 +13,17 @@ CONFIG_SMP=y
 CONFIG_SCHED_MC=y
 CONFIG_SCHED_SMT=y
 
-# GPU / display stack
+# GPU / display stack (AMD-focused for Core hardware direction)
 CONFIG_DRM_AMDGPU=y
-CONFIG_DRM_I915=y
-CONFIG_DRM_NOUVEAU=y
-CONFIG_DRM_VIRTIO_GPU=y
 CONFIG_DRM_SIMPLEDRM=y
 CONFIG_FB_EFI=y
 
-# Compute / acceleration
+# Compute / acceleration (AMD AI/ML path)
 CONFIG_DRM_ACCEL=y
 CONFIG_HSA_AMD=y
 CONFIG_KFD_AMD=y
 CONFIG_IOMMU_SUPPORT=y
 CONFIG_AMD_IOMMU=y
-CONFIG_INTEL_IOMMU=y
 CONFIG_VFIO=y
 CONFIG_VFIO_PCI=y
 
@@ -37,17 +33,11 @@ CONFIG_SND_USB_AUDIO=y
 CONFIG_HID_MULTITOUCH=y
 CONFIG_HIDRAW=y
 
-# AI/developer friendly virtualization stack
+# AI/developer-friendly virtualization stack
 CONFIG_KVM=y
-CONFIG_KVM_INTEL=y
 CONFIG_KVM_AMD=y
 CONFIG_VHOST_NET=y
 CONFIG_VHOST_VSOCK=y
 CONFIG_VIRTIO=y
 CONFIG_VIRTIO_PCI=y
 CONFIG_VIRTIO_BALLOON=y
-
-# Filesystems commonly used by desktop/dev workflows
-CONFIG_FUSE_FS=y
-CONFIG_EXFAT_FS=y
-CONFIG_NTFS3_FS=y

--- a/kernel/optional-desktop-compat.config
+++ b/kernel/optional-desktop-compat.config
@@ -1,0 +1,18 @@
+# Optional desktop compatibility fragment.
+#
+# Use this fragment in addition to kernel/base.config + a role profile
+# when broad cross-vendor desktop support is required.
+
+# Cross-vendor graphics drivers
+CONFIG_DRM_I915=y
+CONFIG_DRM_NOUVEAU=y
+CONFIG_DRM_VIRTIO_GPU=y
+
+# Cross-vendor virtualization/IOMMU coverage
+CONFIG_INTEL_IOMMU=y
+CONFIG_KVM_INTEL=y
+
+# Filesystems commonly needed for mixed-OS desktop interoperability
+CONFIG_FUSE_FS=y
+CONFIG_EXFAT_FS=y
+CONFIG_NTFS3_FS=y


### PR DESCRIPTION
### Motivation
- Align `kernel/core.config` with an AMD-first Huey Core hardware direction and avoid enabling a broad cross-vendor desktop/graphics stack in the Core profile.
- Move generic, legacy, or optional desktop compatibility bits into a separate fragment so Core stays intentionally focused and smaller.

### Description
- Reduced `kernel/core.config` to an AMD-focused profile, preserving AMD GPU/compute (`CONFIG_DRM_AMDGPU`, `CONFIG_DRM_ACCEL`, `CONFIG_HSA_AMD`, `CONFIG_KFD_AMD`, `CONFIG_AMD_IOMMU`), VFIO/virtio/vhost virtualization, KVM for AMD, and desktop audio/HID entries.
- Removed cross-vendor display and Intel-specific items from Core, including `CONFIG_DRM_I915`, `CONFIG_DRM_NOUVEAU`, `CONFIG_DRM_VIRTIO_GPU`, `CONFIG_INTEL_IOMMU`, `CONFIG_KVM_INTEL`, and mixed-OS filesystem options.
- Added `kernel/optional-desktop-compat.config` as an explicit optional fragment that contains the moved items (cross-vendor graphics, Intel IOMMU/KVM, and `CONFIG_FUSE_FS`/`CONFIG_EXFAT_FS`/`CONFIG_NTFS3_FS`) for cases that require broader desktop interoperability.
- Kept the assembly/layering mechanism unchanged so profiles still compose with `kernel/base.config` via the existing `kernel/assemble_kernel_config.sh` script.

### Testing
- Ran `bash kernel/assemble_kernel_config.sh core /tmp/core.merged` which completed successfully (exit code 0) and printed `Assembled kernel config for role 'core' -> /tmp/core.merged`.
- Verified the resulting merged configuration and the produced diff to confirm the fragments compose without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d97d64f5c8832fbdf110ee8f855051)