### PR TITLE
kernel: tighten pulse role config for Linux 7.0 symbols and scope

### DIFF
--- a/kernel/pulse.config
+++ b/kernel/pulse.config
@@ -6,13 +6,17 @@
 # Deterministic scheduling / lower jitter
 CONFIG_PREEMPT_RT=y
 CONFIG_NO_HZ_FULL=y
-CONFIG_HZ_1000=y
 CONFIG_CPU_FREQ_DEFAULT_GOV_PERFORMANCE=y
 
-# Keep footprint smaller than desktop builds
+# Keep footprint and boot path smaller than desktop builds
+# CONFIG_DRM is not set
 # CONFIG_DRM_AMDGPU is not set
 # CONFIG_DRM_NOUVEAU is not set
+# CONFIG_SOUND is not set
+# CONFIG_SND is not set
+# CONFIG_SND_HDA_INTEL is not set
 # CONFIG_SND_HDA_CODEC_HDMI is not set
+# CONFIG_BT_HCIBTUSB is not set
 
 # Control buses + industrial/sensor interfaces
 CONFIG_I2C=y
@@ -42,7 +46,7 @@ CONFIG_USB_SERIAL_CP210X=y
 CONFIG_USB_SERIAL_FTDI_SIO=y
 
 # Reliability + watchdog coverage
-CONFIG_WATCHDOG=y
+# WATCHDOG is already enabled in base.config; keep device coverage here.
 CONFIG_SOFT_WATCHDOG=y
 CONFIG_ITCO_WDT=y
 CONFIG_GPIO_WATCHDOG=y
@@ -51,6 +55,6 @@ CONFIG_BOOTPARAM_HUNG_TASK_PANIC=y
 
 # Remote maintenance / observability
 CONFIG_NETCONSOLE=y
-CONFIG_MAGIC_SYSRQ=y
+# MAGIC_SYSRQ is already enabled in base.config.
 CONFIG_PSTORE=y
 CONFIG_PSTORE_RAM=y


### PR DESCRIPTION
### Motivation
- Ensure `kernel/pulse.config` is a 7.0-ready HueyPulse role fragment focused on control/sensor/watchdog use-cases and not desktop features.
- Remove or document settings that duplicate the canonical `kernel/base.config` to reduce overlap and surprise in merged configs.
- Keep deterministic scheduling, serial, GPIO, I2C, SPI, watchdog device coverage, and sensor framework intact for field deployments.

### Description
- Removed role-level duplication of baseline configs by dropping `CONFIG_HZ_1000`, `CONFIG_WATCHDOG`, and `CONFIG_MAGIC_SYSRQ` and documenting inheritance in comments.
- Explicitly tightened scope away from desktop stacks by adding commented `# CONFIG_DRM is not set`, `# CONFIG_SOUND is not set`, `# CONFIG_SND`/`# CONFIG_SND_HDA_INTEL` and `# CONFIG_BT_HCIBTUSB is not set` lines.
- Preserved and kept enabled field-relevant symbols such as `PREEMPT_RT`, `NO_HZ_FULL`, `CPU_FREQ_DEFAULT_GOV_PERFORMANCE`, `I2C`/`SPI`/`GPIO_CDEV`, `IIO` sensor pieces, serial/USB adapters, soft/ITCO/GPIO watchdog entries, `PANIC_TIMEOUT`, `BOOTPARAM_HUNG_TASK_PANIC`, `NETCONSOLE`, and `PSTORE_RAM`.

### Testing
- Assembled merged config with `kernel/assemble_kernel_config.sh pulse /tmp/pulse-assembled.config` and inspected the tail of the output to verify the merged observability lines were present (success).
- Enumerated `CONFIG_` symbols in `kernel/pulse.config` with a short script and ran upstream Kconfig presence checks via `curl` + `rg` for key symbols (`PREEMPT_RT`, `NO_HZ_FULL`, `CPU_FREQ_DEFAULT_GOV_PERFORMANCE`, `GPIO_CDEV`, `IIO_TRIGGER`, `SOFT_WATCHDOG`, `SERIAL_8250`, `NETCONSOLE`, `PSTORE_RAM`), which located the symbols in upstream Kconfig sources.
- Verified `BOOTPARAM_HUNG_TASK_PANIC` by checking `lib/Kconfig.debug` when the direct `kernel/Kconfig.hung_task` path returned a 404, confirming the symbol is available upstream (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d97e811648832f9fb97bf56bf58752)