### PR TITLE
Add explicit lab/test kernel classification and rc policy to system checks

### DIFF
--- a/src/hueyos/system_checks.py
+++ b/src/hueyos/system_checks.py
@@ -27,6 +27,7 @@ SUPPORTED_DISTRO_ID = "debian"
 SUPPORTED_DISTRO_CODENAME = "forky"
 SUPPORTED_KERNEL_FAMILY = "hueyos"
 KERNEL_ROLE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+LAB_KERNEL_ROLES = frozenset({"lab", "test"})
 MIN_PYTHON_VERSION = (3, 13)
 MAX_PYTHON_VERSION = (3, 15)
 REQUIRED_TOOLS: Tuple[str, ...] = ("git", "python3")
@@ -161,6 +162,16 @@ def _extract_kernel_role(raw_release: str) -> str:
     return role.strip()
 
 
+def _is_release_candidate_kernel(raw_release: str) -> bool:
+    """Return ``True`` when the kernel release includes an ``-rcN`` segment."""
+
+    lowered = raw_release.strip().lower()
+    marker = f"-{SUPPORTED_KERNEL_FAMILY}-"
+    marker_index = lowered.find(marker)
+    candidate_segment = lowered if marker_index < 0 else lowered[:marker_index]
+    return re.search(r"-rc\d+\b", candidate_segment) is not None
+
+
 def _check_kernel_naming() -> bool:
     """Return ``True`` when the running kernel follows HueyOS family/role naming."""
 
@@ -187,6 +198,24 @@ def _check_kernel_naming() -> bool:
             role or "missing",
         )
         return False
+
+    is_rc = _is_release_candidate_kernel(lowered)
+    if is_rc and role not in LAB_KERNEL_ROLES:
+        logger.warning(
+            "Kernel release '%s' uses an rc kernel, which is only supported for %s roles.",
+            release,
+            ", ".join(sorted(LAB_KERNEL_ROLES)),
+        )
+        return False
+
+    if role in LAB_KERNEL_ROLES:
+        kernel_type = "release-candidate" if is_rc else "lab/stable"
+        logger.info(
+            "Detected explicit HueyOS %s kernel role '%s' (%s).",
+            SUPPORTED_KERNEL_FAMILY,
+            role,
+            kernel_type,
+        )
 
     return True
 

--- a/tests/test_system_checks_module.py
+++ b/tests/test_system_checks_module.py
@@ -89,6 +89,34 @@ def test_check_kernel_naming_rejects_non_hueyos_suffix(monkeypatch, caplog):
     assert "family/role suffix" in caplog.text
 
 
+def test_check_kernel_naming_accepts_lab_rc_kernel(monkeypatch, caplog):
+    monkeypatch.setattr(
+        system_checks.platform,
+        "release",
+        lambda: "7.0.0-rc7-hueyos-lab",
+    )
+
+    with caplog.at_level(logging.INFO):
+        supported = system_checks._check_kernel_naming()
+
+    assert supported is True
+    assert "Detected explicit HueyOS hueyos kernel role 'lab'" in caplog.text
+
+
+def test_check_kernel_naming_rejects_rc_kernel_for_non_lab_roles(monkeypatch, caplog):
+    monkeypatch.setattr(
+        system_checks.platform,
+        "release",
+        lambda: "7.0.0-rc7-hueyos-core",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        supported = system_checks._check_kernel_naming()
+
+    assert supported is False
+    assert "only supported for lab, test roles" in caplog.text
+
+
 def test_system_check_collects_expected_results(monkeypatch):
     def fake_os_check():
         return None


### PR DESCRIPTION
### Motivation
- Make kernel naming checks explicitly recognize lab/test kernels (e.g. `7.0.0-rc7-hueyos-lab`) and enforce a policy for release-candidate kernels so RC builds are only allowed for appropriate roles.
- Current validation only checked the generic `hueyos-<role>` suffix and did not surface rc-specific handling or role limitations.

### Description
- Add `LAB_KERNEL_ROLES = frozenset({"lab", "test"})` to enumerate explicit lab/test kernel roles in `src/hueyos/system_checks.py`.
- Add helper `_is_release_candidate_kernel` to detect `-rcN` segments in kernel release strings prior to the `-hueyos-` marker.
- Update `_check_kernel_naming` to reject RC kernels for non-lab roles, and to log an informational message when a lab/test role (RC or not) is detected.
- Add unit tests `test_check_kernel_naming_accepts_lab_rc_kernel` and `test_check_kernel_naming_rejects_rc_kernel_for_non_lab_roles` in `tests/test_system_checks_module.py` to verify acceptance and rejection behavior.

### Testing
- Ran `pytest -q tests/test_system_checks_module.py -k kernel_naming` and observed `4 passed, 5 deselected`, indicating the new checks and tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9807e9c80832faa7fc81d5e625af9)