### PR TITLE
docs: reframe kernel 6.18.2 runbook as legacy migration history

### DIFF
--- a/docs/kernel-6.18.2-runbook.md
+++ b/docs/kernel-6.18.2-runbook.md
@@ -1,190 +1,55 @@
-# Linux 6.18.2 Upgrade Runbook (DKMS-Free)
+# Historical Note: Linux 6.18.2 Migration (Legacy)
 
-This guide walks through building and deploying a DKMS-free Linux 6.18.2 kernel with
-Apple CS8409 audio support tuned for HueyOS hosts (for example, iMac18,3). It closely
-follows the proven playbook used during validation.
+> **Status:** Legacy documentation for a completed migration.
+> **Current guidance:** Do **not** use this as a live runbook for new hosts.
 
-## 0. Install build dependencies (one-time)
+This document preserves the context of a past upgrade wave where HueyOS hosts
+were moved to a DKMS-free `6.18.2-hueyos-v1` kernel with Apple CS8409 audio
+support. It is retained as historical reference only.
 
-```bash
-sudo apt update
-sudo apt install -y build-essential bc bison flex libelf-dev libssl-dev \
-  libncurses-dev dwarves pahole rsync xz-utils cpio kmod python3 fakeroot \
-  git wget
-```
+## Why this note exists
 
-## 1. Fetch 6.18.2 sources and seed configuration
+The original `6.18.2` runbook was written as operational guidance during that
+specific rollout. The environment, package baselines, and kernel assumptions
+have since changed for the 7.0-era platform.
 
-```bash
-mkdir -p ~/kernels && cd ~/kernels
-wget https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.18.2.tar.xz
-tar -xf linux-6.18.2.tar.xz
-cd linux-6.18.2
+Treat all commands from the former runbook as **time-bound artifacts** rather
+than current instructions.
 
-# use the working kernel config as base
-cp -v /boot/config-$(uname -r) .config || zcat /proc/config.gz > .config
-yes "" | make olddefconfig
-```
+## What was migrated in the 6.18.2 cycle
 
-## 2. Enable required audio modules
+The completed migration generally included:
 
-Keep HDA as the primary path and retain SOF modules as a fallback.
+- Building and installing a custom `6.18.2-hueyos-v1` kernel.
+- Preferring HDA/CS8409 in-kernel audio modules with SOF retained as fallback.
+- Optional Secure Boot module-signing setup.
+- Post-upgrade validation (`dmesg`, ALSA/PipeWire, sink verification).
+- Supplemental Broadcom firmware sanity steps for affected iMac18,3 hosts.
 
-```bash
-# HDA core + codecs
-./scripts/config --module CONFIG_SND_HDA_INTEL
-./scripts/config --module CONFIG_SND_HDA_GENERIC
-./scripts/config --module CONFIG_SND_HDA_CODEC_HDMI
-./scripts/config --module CONFIG_SND_HDA_CODEC_CIRRUS
-./scripts/config --module CONFIG_SND_HDA_CODEC_CS8409
+## 7.0-era interpretation
 
-# helper scodecs (names may be absent)
-./scripts/config --module CONFIG_SND_HDA_SCODEC_CIRRUS 2>/dev/null || true
-./scripts/config --module CONFIG_SND_HDA_SCODEC_CS35L41 2>/dev/null || true
+For 7.0-era systems, this legacy migration should be interpreted as:
 
-# SOF modules kept available (blacklist initially)
-./scripts/config --module CONFIG_SND_SOC_SOF
-./scripts/config --module CONFIG_SND_SOC_SOF_INTEL_PCI
-./scripts/config --module CONFIG_SND_SOC_SOF_HDA_COMMON
+- A record of **what was changed historically**.
+- A source of troubleshooting clues if you are diagnosing an old
+  `6.18.2-hueyos-v1` installation.
+- **Not** a baseline for present-day kernel build/deploy procedures.
 
-yes "" | make olddefconfig
-```
+If you need current procedures, use the active kernel/platform upgrade docs in
+this repository and treat any 6.18.2-specific toggles, blacklists, and firmware
+symlinks as potentially obsolete.
 
-> Quick check: run `make menuconfig`, press `/`, search for `CS8409` — it should be set to `M`.
+## Legacy markers to watch for
 
-## 3. Optional: Secure Boot module signing
+If these appear on a machine, you are likely looking at a host that followed
+this historical path:
 
-Skip if Secure Boot is disabled. This avoids unsigned module issues after reboot.
+- Kernel release string matching `6.18.2-hueyos-v1`.
+- Modprobe snippets that explicitly blacklist SOF to force HDA.
+- Manually created Broadcom firmware symlinks for Apple iMac18,3 naming.
 
-```bash
-mkdir -p ~/keys && cd ~/keys
-openssl req -new -x509 -newkey rsa:2048 -keyout MOK.priv -out MOK.pem \
-  -nodes -days 36500 -subj "/CN=Huey Kernel Module Key/"
-openssl x509 -outform der -in MOK.pem -out MOK.der
-sudo mokutil --import MOK.der   # enroll at the next reboot (blue MOK screen)
+## Preservation policy
 
-cd ~/kernels/linux-6.18.2
-./scripts/config --enable CONFIG_MODULE_SIG
-./scripts/config --enable CONFIG_MODULE_SIG_ALL
-./scripts/config --set-str CONFIG_MODULE_SIG_KEY "$(readlink -f ~/keys/MOK.pem)"
-yes "" | make olddefconfig
-```
-
-## 4. Build and install the kernel
-
-```bash
-export LOCALVERSION=-hueyos-v1
-make -j"$(nproc)"
-sudo make modules_install INSTALL_MOD_STRIP=1
-sudo make install
-
-KV=$(make kernelrelease)          # expected: 6.18.2-hueyos-v1
-sudo update-initramfs -c -k "$KV"
-sudo update-grub
-```
-
-## 5. First boot with HDA-only audio (recommended)
-
-Blacklist SOF modules so the in-kernel CS8409 HDA path claims the device cleanly.
-
-```bash
-sudo tee /etc/modprobe.d/90-hda-preferred.conf >/dev/null <<'EOF'
-blacklist snd_soc_avs
-blacklist snd_sof_pci_intel_skl
-blacklist snd_sof_pci
-blacklist snd_sof
-# Apple quirks—disable DMIC, no power-save pops
-options snd_hda_intel dmic_detect=0 power_save=0
-EOF
-
-sudo update-initramfs -u -k "$KV"
-sudo reboot
-```
-
-At the GRUB prompt select **6.18.2-hueyos-v1**.
-
-## 6. Verify audio stack after boot
-
-```bash
-uname -r
-lsmod | egrep 'cs8409|cirrus|snd_hda'
-sudo dmesg -T | egrep -i 'cs8409|cirrus|hdaudio|fixup|quirk' | tail -n 200
-
-cat /proc/asound/cards
-aplay -l
-systemctl --user restart wireplumber pipewire pipewire-pulse
-sleep 2
-pactl list short cards
-pactl list short sinks
-pactl set-default-sink 0
-amixer -c 0 sset Master 80% unmute 2>/dev/null || true
-amixer -c 0 sset Speaker 80% unmute 2>/dev/null || true
-amixer -c 0 sset Headphone 80% unmute 2>/dev/null || true
-amixer -c 0 sset 'Auto-Mute Mode' Disabled 2>/dev/null || true
-
-speaker-test -c 2 -t pink -l 1
-```
-
-If PulseAudio still reports **Dummy Output**, flip to the SOF path:
-
-```bash
-sudo rm -f /etc/modprobe.d/90-hda-preferred.conf
-sudo apt install -y sof-firmware alsa-ucm-conf
-sudo update-initramfs -u -k "$(uname -r)"
-sudo reboot
-
-sudo dmesg -T | egrep -i 'sof|cs8409|hdaudio|fixup|quirk' | tail -n 200
-aplay -l
-pactl list short sinks
-speaker-test -c 2 -t pink -l 1
-```
-
-## 7. Broadcom Wi-Fi firmware sanity (if needed)
-
-```bash
-echo 'deb http://deb.debian.org/debian trixie main contrib non-free-firmware' | \
-  sudo tee /etc/apt/sources.list.d/firmware.list
-sudo apt update
-sudo apt install -y firmware-brcm80211
-
-cd /lib/firmware/brcm
-sudo ln -sf brcmfmac43602-pcie.bin        "brcmfmac43602-pcie.Apple Inc.-iMac18,3.bin"
-sudo ln -sf brcmfmac43602-pcie.txt        "brcmfmac43602-pcie.Apple Inc.-iMac18,3.txt"
-sudo ln -sf brcmfmac43602-pcie.clm_blob   "brcmfmac43602-pcie.Apple Inc.-iMac18,3.clm_blob"
-sudo ln -sf brcmfmac43602-pcie.txcap_blob "brcmfmac43602-pcie.Apple Inc.-iMac18,3.txcap_blob"
-sudo update-initramfs -u -k "$(uname -r)"
-sudo modprobe -r brcmfmac brcmutil
-sudo modprobe brcmfmac
-```
-
-## 8. Quality-of-life and safeguards
-
-```bash
-# keep previous kernel selectable as default
-sudo sed -i 's/^GRUB_DEFAULT=.*/GRUB_DEFAULT=saved/' /etc/default/grub
-echo 'GRUB_SAVEDEFAULT=true' | sudo tee -a /etc/default/grub
-sudo update-grub
-
-# quieter boot logs
-sudo sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT="/GRUB_CMDLINE_LINUX_DEFAULT="quiet loglevel=3 splash /' /etc/default/grub
-sudo update-grub
-
-# eliminate idle HDA clicks
-echo 'options snd_hda_intel power_save=0 power_save_controller=N' | \
-  sudo tee /etc/modprobe.d/disable-hda-powersave.conf
-sudo update-initramfs -u -k "$(uname -r)"
-```
-
-## 9. Troubleshooting checklist
-
-If audio still fails after the first boot, collect the following diagnostics and share them for quirk tuning:
-
-```bash
-uname -r
-lsmod | egrep 'cs8409|cirrus|snd_hda|sof'
-sudo dmesg -T | egrep -i 'cs8409|cirrus|sof|hdaudio|fixup|quirk' | tail -n 300
-aplay -l
-pactl list short sinks
-```
-
-Following this runbook yields a predictable, DKMS-free upgrade to **6.18.2-hueyos-v1** with an in-kernel CS8409 path and a clean fallback to SOF when required.
+This file intentionally remains short and historical so it no longer reads as
+current guidance while still documenting the intent and scope of the 6.18.2
+migration.


### PR DESCRIPTION
### Motivation
- Remove an actionable, time-bound runbook that could be mistaken for current guidance and reframe it as historical context appropriate for the 7.0-era repository.
- Prevent maintainers or operators from following obsolete kernel build and audio-workaround steps that no longer reflect platform baselines.
- Preserve searchable indicators and migration rationale so old hosts and past decisions remain diagnosable without presenting deprecated instructions as current practice.

### Description
- Replaced the step-by-step `docs/kernel-6.18.2-runbook.md` content with a concise historical note titled `Historical Note: Linux 6.18.2 Migration (Legacy)` and a prominent legacy status banner.
- Removed executable command blocks and procedural instructions while preserving a summary of what was changed during the 6.18.2 cycle and the legacy markers to watch for on affected machines.
- Added a 7.0-era interpretation section and a short preservation policy to guide readers to active upgrade docs instead of the legacy procedures.

### Testing
- Verified the new file content with `sed -n '1,220p' docs/kernel-6.18.2-runbook.md`, which displayed the updated legacy note successfully.
- Committed the change with `git commit` and confirmed the commit summary and statistics with `git show --stat --oneline HEAD`, which reported the file modifications as expected.
- Ran `git status --short` to confirm the working tree was clean after the change, which returned no outstanding modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d985478738832f8e08e99be20ac7b5)