### PR TITLE
docs: rewrite phase-2 kernel upgrade guide for Forky + 7.0 family

### DIFF
--- a/docs/kernel-upgrade-phase2.md
+++ b/docs/kernel-upgrade-phase2.md
@@ -1,38 +1,79 @@
-# Kernel Upgrade Phase 2 (6.18.x Jump)
+# Kernel Upgrade Phase 2 (Forky + 7.0 Family)
 
-This record captures the requested Phase 2 kernel upgrade activities. The work was
-performed inside the kata container, which limits kernel management features (no
-bootloader access, no running systemd instance, and no audio stack).
+This Phase 2 document defines the 7.0-era kernel model used by this repository.
+It replaces old pre-7.0 migration notes and removes legacy references
+that are no longer operationally correct.
 
-## K-01 — Install distro kernel 6.18.x (baseline)
+## Scope
 
-* `sudo apt update`
-  * Completed successfully; the package lists refreshed without error.
-* `sudo apt install -y linux-image-amd64 linux-headers-amd64`
-  * Failed because the Ubuntu 24.04 mirrors in this environment do not publish
-    the `linux-image-amd64` or `linux-headers-amd64` meta-packages yet. Apt
-    reports "no installation candidate" for both packages, so no kernel was
-    installed.
-* `uname -r`
-  * Still reports `6.12.13`, confirming that the runtime kernel remained
-    unchanged after the failed installation attempt.
+Phase 2 now covers:
 
-## K-02 — Install packaged 6.18.2-hueyos-v1 build
+1. Aligning hosts to Debian 14 (Forky) kernel packaging assumptions.
+2. Selecting the correct 7.0 family track (`base`, `core`, or `pulse`).
+3. Using `7.0.0-rc7` only as the **lab-gateway** build for validation and
+   cross-track promotion decisions.
 
-Custom Huey kernel packages are not available in this environment. As a result the
-`dpkg -i` and `update-initramfs` steps were not executed.
+## 7.0 Kernel Family Structure
 
-## K-03 — iMac 5K audio mitigation (post-boot)
+The 7.0 era is organized as a family of roles rather than a single monolithic
+kernel label.
 
-The container does not provide PulseAudio/PipeWire services or expose iMac audio
-hardware. Creating and testing the proposed `huey-audio-setup.sh` autostart script
-was therefore skipped.
+### `base`
 
-## K-04 — iio-sensor-proxy service masking
+The conservative track for broad compatibility and lowest operational risk.
+Use for general-purpose systems and default fleet rollouts.
 
-* `sudo install -d -m 0755 /etc/systemd/system`
-  * Directory already exists; command completed with no changes.
-* `sudo systemctl mask iio-sensor-proxy.service`
-  * `systemctl` created the `/etc/systemd/system/iio-sensor-proxy.service ->
-    /dev/null` symlink. The container lacks a running systemd instance, so this
-    only records the mask on disk; it cannot be exercised within the kata.
+### `core`
+
+The production-optimized track for standard platform workloads after validation
+on `base` and lab-gateway acceptance criteria are met.
+
+### `pulse`
+
+The fast-iteration track for feature velocity, tighter validation loops, and
+short-cycle experimentation before changes graduate to `core`.
+
+## Lab-Gateway Role of `7.0.0-rc7`
+
+`7.0.0-rc7` is the 7.0-era **lab gateway**.
+
+It is used to:
+
+- qualify candidate changes early,
+- exercise integration and hardware edge cases,
+- decide readiness for promotion into supported family tracks.
+
+It is **not** the default broad-deployment baseline for all hosts.
+
+## Phase 2 Workflow (7.0 Era)
+
+### K-01 — Forky alignment and baseline readiness
+
+- Confirm the node is aligned with Forky-era package sources and kernel tooling.
+- Verify the host can install and boot the selected 7.0 family artifacts.
+
+### K-02 — Track selection and install (`base` / `core` / `pulse`)
+
+- Assign each node a track according to its role.
+- Install the corresponding 7.0 family kernel/config package set.
+- Record the selected track in deployment metadata.
+
+### K-03 — `7.0.0-rc7` lab-gateway qualification
+
+- Run pre-promotion validation on `7.0.0-rc7` in lab-gateway environments.
+- Capture regressions and stabilization deltas before production promotion.
+- Promote only validated changes from lab-gateway outcomes into the relevant
+  7.0 family track.
+
+### K-04 — Post-upgrade service and policy verification
+
+- Validate required services and boot-time policies after kernel transition.
+- Ensure environment-specific masks/overrides are intentional and documented.
+
+## Terminology and Legacy Status
+
+- Pre-7.0 kernel naming language is retired from this Phase 2 procedure.
+- Any remaining pre-7.0 references in the repository are historical context
+  only and must not be interpreted as current upgrade guidance.
+
+This file is the canonical Phase 2 reference for the Forky + 7.0 kernel era.


### PR DESCRIPTION
### Motivation

- Replace an outdated Phase 2 upgrade log that references `6.18.2-hueyos-v1` with a current 7.0-era reference aligned to Debian 14 (Forky) and the new kernel family model. 
- Remove stale pre-7.0 naming and operational guidance so this document no longer surfaces as legacy migration instructions in search results.

### Description

- Rewrote `docs/kernel-upgrade-phase2.md` into a canonical Forky + 7.0-era Phase 2 guide that replaces the previous 6.18.x-focused content. 
- Added a `7.0` kernel family structure with the `base`, `core`, and `pulse` tracks and concise guidance for each track. 
- Clarified that `7.0.0-rc7` serves as a `lab-gateway` build for validation and promotion decisions and is not the default deployment baseline. 
- Updated the Phase 2 workflow (K-01..K-04) to reflect Forky alignment, track selection/install, lab-gateway qualification, and post-upgrade verification, and removed pre-7.0 wording.

### Testing

- Ran a token search `rg -n "6\.18\.2|hueyos-v1" docs/kernel-upgrade-phase2.md` to confirm the retired pre-7.0 tokens are no longer present in the updated file. 
- Opened and reviewed the updated `docs/kernel-upgrade-phase2.md` content to verify the new structure, terminology, and workflow steps render as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d986917574832f8d4e631ef8dc0bed)