### PR TITLE
Update changeover release note to Forky + kernel 7.0 positioning

### DIFF
--- a/docs/releases/2025-10-31-changeover.md
+++ b/docs/releases/2025-10-31-changeover.md
@@ -1,19 +1,36 @@
-# 2025-10-31 Changeover — Forky • 6.18.2-hueyos-v1 • Python 3.14
+# 2025-10-31 Changeover — Forky Standard • Kernel 7.0 Active Line • 7.0.0-rc7 Lab Gateway
 
 ## Summary
-(Replace with final notes on the day.)
+This changeover note supersedes the earlier `6.18.2-hueyos-v1` framing.
+
+As of this release line:
+- **Debian 14 "Forky" is the standard platform baseline** for project operations.
+- **Kernel 7.0 is the active kernel line** for engineering, validation, and release tracking.
+- **Kernel 7.0.0-rc7 is a lab gateway build only** (pre-production validation path), **not** the stable production baseline.
 
 ## What changed
-- Debian 14 “Forky” default
-- Kernel 6.18.2-hueyos-v1 baseline
-- Python 3.14 virtualenvs
-- Packaging & CLI updates
+- Platform posture updated from one-off migration messaging to **Forky-as-standard** messaging.
+- Kernel guidance moved from `6.18.2-hueyos-v1` baseline language to **7.0 active-line governance**.
+- `7.0.0-rc7` explicitly classified as a **lab/qualification entry point**, not production default.
+- Release communications updated to avoid treating any `-rc` kernel as generally stable.
+
+## Environment guidance
+### Production
+- Track the current approved **stable 7.0.x** target for production rollout.
+- Do not use `7.0.0-rc7` as the default production kernel.
+
+### Lab / validation
+- Use `7.0.0-rc7` for gateway validation, compatibility triage, and pre-GA test sequencing.
+- Promote to production only after stable 7.0.x approval gates are met.
 
 ## Upgrade steps (condensed)
-(Insert the exact steps you executed.)
+1. Confirm hosts are on the Forky standard image/profile.
+2. Move systems targeting legacy baseline language to the active 7.0 policy track.
+3. Reserve `7.0.0-rc7` deployments for lab scopes.
+4. Validate release notes, runbooks, and rollout checklists reference stable 7.0.x for production.
 
 ## Known issues
-(Link to Known Issues in README; add day-of deltas.)
+- Any reference that still describes `6.18.2-hueyos-v1` as the baseline should be treated as historical and updated.
 
 ## Rollback
-(Brief instructions.)
+- If a 7.0 trial fails validation, roll affected lab nodes back to the currently approved production stable kernel and re-enter qualification after remediation.


### PR DESCRIPTION
### Motivation
- The existing changeover note still presented `6.18.2-hueyos-v1` as a baseline, which is now historical and could mislead operational guidance.
- The project needs a clear framing that Debian 14 “Forky” is the standard platform and that kernel `7.0` is the active kernel line while `7.0.0-rc7` is a lab-only gateway.

### Description
- Rewrote the contents of `docs/releases/2025-10-31-changeover.md` to supersede the old `6.18.2-hueyos-v1` framing and update the document title to reflect “Forky Standard • Kernel 7.0 Active Line • 7.0.0-rc7 Lab Gateway”.
- Added explicit `Production` vs `Lab / validation` guidance that directs production to target stable `7.0.x` and reserves `7.0.0-rc7` for lab validation only.
- Updated the condensed upgrade steps and rollback guidance to reference the new policy of promoting to stable `7.0.x` for production after qualification.

### Testing
- This is a documentation-only change; no unit or runtime tests were required.
- Verified the updated file contents using `nl -ba docs/releases/2025-10-31-changeover.md | sed -n '1,240p'` to confirm the new guidance is present.
- No code or build artifacts were modified, so there is no CI impact from this edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d987417cd4832fbfc743d9b6989e0a)