### PR TITLE
Sweep remaining hueyos-v1 references into legacy/archive context

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,9 @@ the platform and how to operate core services.
 - [Honeycomb storage operations](honeycomb-storage.md)
 - [API reference](api-reference.md)
 - [Governance & resilience](governance.md)
-- [Linux 6.18.2 upgrade runbook](kernel-6.18.2-runbook.md)
-- [Kernel upgrade Phase 2 log](kernel-upgrade-phase2.md)
+- [Kernel 7.0 Phase 2 runbook (active guidance)](kernel-upgrade-phase2.md)
+- [Linux 6.18.2 migration runbook (legacy archive)](kernel-6.18.2-runbook.md)
+- [Version reference classification report](version-reference-classification.md)
 - [Phase 9 rollback hooks report](phase-9-rollback.md)
 
 ## CLI quick reference

--- a/docs/releases/2025-10-31-changeover.md
+++ b/docs/releases/2025-10-31-changeover.md
@@ -1,7 +1,7 @@
 # 2025-10-31 Changeover — Forky Standard • Kernel 7.0 Active Line • 7.0.0-rc7 Lab Gateway
 
 ## Summary
-This changeover note supersedes the earlier `6.18.2-hueyos-v1` framing.
+This changeover note supersedes earlier 6.18.2 migration-era framing.
 
 As of this release line:
 - **Debian 14 "Forky" is the standard platform baseline** for project operations.
@@ -10,7 +10,7 @@ As of this release line:
 
 ## What changed
 - Platform posture updated from one-off migration messaging to **Forky-as-standard** messaging.
-- Kernel guidance moved from `6.18.2-hueyos-v1` baseline language to **7.0 active-line governance**.
+- Kernel guidance moved from 6.18.2 migration-era baseline language to **7.0 active-line governance**.
 - `7.0.0-rc7` explicitly classified as a **lab/qualification entry point**, not production default.
 - Release communications updated to avoid treating any `-rc` kernel as generally stable.
 
@@ -30,7 +30,7 @@ As of this release line:
 4. Validate release notes, runbooks, and rollout checklists reference stable 7.0.x for production.
 
 ## Known issues
-- Any reference that still describes `6.18.2-hueyos-v1` as the baseline should be treated as historical and updated.
+- Any reference that still describes 6.18.2 migration-era kernels as the baseline should be treated as historical and updated.
 
 ## Rollback
 - If a 7.0 trial fails validation, roll affected lab nodes back to the currently approved production stable kernel and re-enter qualification after remediation.

--- a/docs/version-reference-classification.md
+++ b/docs/version-reference-classification.md
@@ -1,0 +1,55 @@
+# Version Reference Classification Report
+
+Date: 2026-04-10
+
+## Purpose
+
+This report classifies remaining `6.18.2` and `hueyos-v1` references so repository
+usage is unambiguous:
+
+- **Kernel 7.0.x is the active line** for current guidance and operations.
+- **6.18.2-era content is legacy or immutable context only**.
+
+## Classification policy
+
+### Active guidance
+
+References that define current runbooks, release guidance, and role-based naming.
+These should prefer `7.0.0-hueyos-core`, `7.0.0-hueyos-pulse`, and
+`7.0.0-rc7-hueyos-lab` examples.
+
+### Legacy archive
+
+Historical migration notes kept for provenance and post-mortem context. Legacy
+artifacts must be labeled as archive/historical and must not be treated as
+current deployment guidance.
+
+### Compatibility fixtures
+
+References used by tests to assert parser behavior and downgrade/error handling.
+These are intentionally retained.
+
+### Immutable packaging/checksum artifacts
+
+Generated or externally constrained content that should not be rewritten during
+terminology sweeps unless regenerated through the canonical release process.
+
+## Sweep results
+
+- `docs/index.md` now labels the Linux 6.18.2 runbook as a **legacy archive** and
+  promotes the 7.0 Phase 2 runbook as **active guidance**.
+- Prompt JSON documents now use role-based 7.0 kernel examples and include
+  explicit legacy-context notes.
+- Historical mentions in release and hardware documents were rewritten to
+  migration-era language rather than `hueyos-v1` naming where active interpretation
+  could be ambiguous.
+- `6.18.2` references in `tests/` remain intentionally preserved as compatibility
+  fixtures.
+
+## Ongoing guardrails
+
+1. New operational docs must use 7.0 role-based naming.
+2. If a `6.18.2` reference is added outside tests/archives, it must include a
+   clear legacy label.
+3. Sweeps should avoid changing immutable package/checksum artifacts unless they
+   are being regenerated as part of a release.

--- a/src/huey/memory/MD/HARDWARE.md
+++ b/src/huey/memory/MD/HARDWARE.md
@@ -12,7 +12,7 @@
 **Kernel Family**: HueyOS **7.0-based** custom RT kernels
 
 > **Current state:** Hardware enablement is standardized on the **Forky + 7.0 kernel family** line.  
-> The former **6.16.12 → 6.18.2-hueyos-v1** migration path is now historical and is no longer the deployment target for active systems.
+> The former **6.16.12 → 6.18.2 migration-era line** is now historical and is no longer the deployment target for active systems.
 
 ## Kernel Model and Role Split
 

--- a/src/huey/prompts/master-plan-v2-final.json
+++ b/src/huey/prompts/master-plan-v2-final.json
@@ -81,7 +81,12 @@
   },
   "os_stack": {
     "base": "Debian 14 (Forky preferred, Trixie migration-only)",
-    "kernels": ["6.18.2-hueyos-v1", "6.18.2+hueyos-amd64"],
+    "kernels": [
+      "7.0.0-hueyos-core",
+      "7.0.0-hueyos-pulse",
+      "7.0.0-rc7-hueyos-lab"
+    ],
+    "legacy_context": "Historical 6.18.2 references remain only for compatibility archives and fixtures; active guidance follows role-based 7.0 kernel naming.",
     "orchestrator": "PyGPT-net",
     "llm_server": "Ollama",
     "models": ["Mistral 7B-KM", "LLaMA 3.1", "DeepSeek-R1"],

--- a/src/huey/prompts/master-plan-v3.json
+++ b/src/huey/prompts/master-plan-v3.json
@@ -93,10 +93,12 @@
     },
     "kernels": {
       "examples": [
-        "6.18.2-hueyos-v1",
-        "6.18.2+hueyos-amd64"
+        "7.0.0-hueyos-core",
+        "7.0.0-hueyos-pulse",
+        "7.0.0-rc7-hueyos-lab"
       ],
-      "project_standard_series": "6.18.x",
+      "project_standard_series": "7.0.x",
+      "legacy_context": "6.18.2-series names are retained only in compatibility fixtures and historical archives.",
       "tuning_goals": [
         "Strip heavy debug/tracing for performance.",
         "Integrate required drivers directly into the kernel where practical.",

--- a/src/huey/prompts/master-plan-v5.json
+++ b/src/huey/prompts/master-plan-v5.json
@@ -109,10 +109,12 @@
     },
     "kernels": {
       "examples": [
-        "6.18.2-hueyos-v1",
-        "6.18.2+hueyos-amd64"
+        "7.0.0-hueyos-core",
+        "7.0.0-hueyos-pulse",
+        "7.0.0-rc7-hueyos-lab"
       ],
-      "project_standard_series": "6.18.x",
+      "project_standard_series": "7.0.x",
+      "legacy_context": "6.18.2-series names are retained only in compatibility fixtures and historical archives.",
       "tuning_goals": [
         "Strip heavy debug/tracing for performance.",
         "Integrate required drivers directly into the kernel where practical.",


### PR DESCRIPTION
### Motivation
- Remove ambiguity by classifying remaining `6.18.2`/`hueyos-v1` mentions as legacy or migration-era context so repository guidance treats the 7.0 family as the active kernel line.
- Preserve historical artifacts, compatibility fixtures, and immutable packaging content while preventing accidental use of 6.18.2 as current guidance.

### Description
- Relabeled the docs index so `docs/index.md` promotes the Kernel 7.0 Phase 2 runbook as active guidance and marks the `6.18.2` runbook as a legacy archive, and added a link to the new classification report at `docs/version-reference-classification.md`.
- Added `docs/version-reference-classification.md` to document sweep results, the active/legacy/compatibility/immutable classification policy, and ongoing guardrails.
- Updated prompt JSONs (`src/huey/prompts/master-plan-v2-final.json`, `src/huey/prompts/master-plan-v3.json`, and `src/huey/prompts/master-plan-v5.json`) to use role-based 7.0 kernel examples and to include explicit `legacy_context` notes about retained 6.18.2 references.
- Reworded release and hardware docs (`docs/releases/2025-10-31-changeover.md`, `src/huey/memory/MD/HARDWARE.md`) to refer to 6.18.2 as migration-era historical context and intentionally left test fixtures and immutable artifacts that reference 6.18.2 unchanged.

### Testing
- Validated JSON syntax with `python -m json.tool` for `src/huey/prompts/master-plan-v2-final.json`, `src/huey/prompts/master-plan-v3.json`, and `src/huey/prompts/master-plan-v5.json`, which all succeeded.
- Ran `pytest -q tests/test_system_checks_module.py` and received `19 passed` indicating no regressions in the system-check tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d98c0a327c832fbbefa9fcc1a37151)