### PR TITLE
docs: finalize 6.18.2 legacy classification sweep

### DIFF
--- a/docs/releases/2025-10-31-changeover.md
+++ b/docs/releases/2025-10-31-changeover.md
@@ -1,6 +1,9 @@
 # 2025-10-31 Changeover — Forky Standard • Kernel 7.0 Active Line • 7.0.0-rc7 Lab Gateway
 
 ## Summary
+> **Status:** Active release guidance for the 7.0 line.
+> Any 6.18.2 mention in this file is historical context only.
+
 This changeover note supersedes earlier 6.18.2 migration-era framing.
 
 As of this release line:

--- a/docs/version-reference-classification.md
+++ b/docs/version-reference-classification.md
@@ -4,11 +4,11 @@ Date: 2026-04-10
 
 ## Purpose
 
-This report classifies remaining `6.18.2` and `hueyos-v1` references so repository
+This report classifies all remaining `6.18.2` and `hueyos-v1` references so repository
 usage is unambiguous:
 
 - **Kernel 7.0.x is the active line** for current guidance and operations.
-- **6.18.2-era content is legacy or immutable context only**.
+- **6.18.2-era content is legacy, compatibility-fixture, or immutable artifact context only**.
 
 ## Classification policy
 
@@ -21,8 +21,8 @@ These should prefer `7.0.0-hueyos-core`, `7.0.0-hueyos-pulse`, and
 ### Legacy archive
 
 Historical migration notes kept for provenance and post-mortem context. Legacy
-artifacts must be labeled as archive/historical and must not be treated as
-current deployment guidance.
+artifacts must be labeled archive/historical and must not be treated as current
+deployment guidance.
 
 ### Compatibility fixtures
 
@@ -34,17 +34,33 @@ These are intentionally retained.
 Generated or externally constrained content that should not be rewritten during
 terminology sweeps unless regenerated through the canonical release process.
 
-## Sweep results
+### Non-semantic search-hit collisions
 
-- `docs/index.md` now labels the Linux 6.18.2 runbook as a **legacy archive** and
-  promotes the 7.0 Phase 2 runbook as **active guidance**.
-- Prompt JSON documents now use role-based 7.0 kernel examples and include
-  explicit legacy-context notes.
-- Historical mentions in release and hardware documents were rewritten to
-  migration-era language rather than `hueyos-v1` naming where active interpretation
-  could be ambiguous.
-- `6.18.2` references in `tests/` remain intentionally preserved as compatibility
-  fixtures.
+Raw binary/checksum/hash data where `6.18.2` appears as part of a longer token
+(e.g., SHA digest substring) and does **not** represent kernel-version guidance.
+
+## Sweep inventory (repository-wide)
+
+| Path | Classification | Action |
+| --- | --- | --- |
+| `docs/index.md` | Active index + legacy pointer | Keep the 7.0 Phase 2 runbook as active and label 6.18.2 runbook as legacy archive. |
+| `docs/kernel-6.18.2-runbook.md` | Legacy archive | Preserve as historical migration note only. |
+| `docs/releases/2025-10-31-changeover.md` | Active release guidance with historical context | Keep historical references explicitly framed as superseded by 7.0 active line. |
+| `src/huey/memory/MD/HARDWARE.md` | Active platform guidance with historical context | Keep hardware baseline on 7.0 line and frame 6.18.2 line as historical-only context. |
+| `tests/test_system_checks_module.py` | Compatibility fixtures | Retain 6.18.2 release strings for parser/behavior coverage. |
+| `platform/packaging/dists/forky/main/binary-amd64/Packages` | Non-semantic search-hit collision | No edit; values are SHA512 digest data, not version policy text. |
+| `platform/packaging/dists/forky/main/debian-installer/binary-amd64/Packages` | Non-semantic search-hit collision | No edit; values are SHA512 digest data, not version policy text. |
+| `archives/releases/checksums/sha256sum.txt` | Non-semantic search-hit collision | No edit; checksum corpus only. |
+
+## Outcome summary
+
+- 7.0 is reaffirmed as the only active guidance line across index, release, and
+  platform docs.
+- 6.18.2 references are now constrained to one of four explicit buckets:
+  **legacy archive**, **historical context in active docs**, **test fixtures**,
+  or **non-semantic artifact collisions**.
+- No remaining 6.18.2 reference currently reads as authoritative active
+  deployment guidance.
 
 ## Ongoing guardrails
 
@@ -53,3 +69,5 @@ terminology sweeps unless regenerated through the canonical release process.
    clear legacy label.
 3. Sweeps should avoid changing immutable package/checksum artifacts unless they
    are being regenerated as part of a release.
+4. Any repo-wide search report should separate semantic version references from
+   checksum/hash collisions before opening cleanup tickets.

--- a/src/huey/memory/MD/HARDWARE.md
+++ b/src/huey/memory/MD/HARDWARE.md
@@ -13,6 +13,7 @@
 
 > **Current state:** Hardware enablement is standardized on the **Forky + 7.0 kernel family** line.  
 > The former **6.16.12 → 6.18.2 migration-era line** is now historical and is no longer the deployment target for active systems.
+> Any 6.18.2 references in this guide are legacy context markers only, not implementation targets.
 
 ## Kernel Model and Role Split
 


### PR DESCRIPTION
### Motivation

- Ensure all remaining `6.18.2` and `hueyos-v1` mentions are explicitly classified so active guidance uses the 7.0 line and 6.18.2 remains legacy/context only. 
- Prevent ambiguous operational guidance by separating legacy archives, compatibility fixtures, and immutable checksum artifacts.

### Description

- Expanded the version-reference classification into a repository-wide inventory in `docs/version-reference-classification.md` with explicit buckets for legacy archives, active docs with historical context, compatibility fixtures, and non-semantic checksum/hash collisions. 
- Added an explicit status banner to `docs/releases/2025-10-31-changeover.md` clarifying that the file is active 7.0 guidance and any `6.18.2` mentions are historical context only. 
- Updated `src/huey/memory/MD/HARDWARE.md` to mark any `6.18.2` references as legacy context markers and not implementation targets while keeping the hardware baseline on 7.0. 
- Left test fixtures and immutable packaging/checksum artifacts unchanged and classified them as intentionally preserved or non-semantic collisions, respectively.

### Testing

- Verified remaining references with a targeted repository search using `rg -n "6\.18\.2|hueyos-v1"` to confirm references are constrained to legacy/context/fixture buckets. 
- Ran unit tests with `pytest -q tests/test_system_checks_module.py` which passed (`19 passed`). 
- No packaging/checksum artifacts were regenerated as part of this sweep and no other automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d98db7258c832fbd3683e794ff6d6f)