### PR TITLE
Replace active Debian13 references with Forky-era platform installer paths

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,7 +58,7 @@ HueyOS is designed and tested primarily against:
 * **OS**
 
   * Debian 14 “Forky” (stable) — **primary supported** platform.
-  * Debian 13 “Trixie” — **historical/migration-only** compatibility target for legacy nodes.
+  * Debian “Trixie” — **historical/migration-only** compatibility target for legacy nodes.
 * **Architecture**
 
   * `amd64` (x86_64). Other architectures (ARM, RISC‑V, etc.) may work, but are currently out of scope for security guarantees.

--- a/integrations/pygpt/pygpt-mhp/src/pygpt_net/tools/manager/__init__.py
+++ b/integrations/pygpt/pygpt-mhp/src/pygpt_net/tools/manager/__init__.py
@@ -31,14 +31,15 @@ class MonkeyManager(BaseTool):
     def _setup_paths(self) -> None:
         root = Path(__file__).resolve().parents[4]
         setup_dir = root / "setup"
+        platform_installers = root / "platform" / "installers" / "debian" / "Debian"
         system = platform.system()
         if system == "Linux":
-            self.install_path = setup_dir / "Debian13" / "install.sh"
-            self.update_path = setup_dir / "Debian13" / "update.sh"
+            self.install_path = platform_installers / "install-deb.sh"
+            self.update_path = platform_installers / "update-deb.sh"
             self.run_path = root / "run.sh"
         elif system == "Darwin":
             self.install_path = setup_dir / "macOS" / "install.sh"
-            self.update_path = setup_dir / "Debian13" / "update.sh"
+            self.update_path = platform_installers / "update-deb.sh"
             self.run_path = root / "run.sh"
         elif system == "Windows":
             self.install_path = setup_dir / "Windows11" / "01-FULL.bat"

--- a/src/huey/memory/MD/os-debloating.md
+++ b/src/huey/memory/MD/os-debloating.md
@@ -12,16 +12,16 @@ setup\Windows10\windows-remove-tool.bat
 
 This debloating step is optional but recommended for systems dedicated to the project.
 
-## Debian 13
+## Debian Forky
 
-While no automatic script is supplied for Linux, you can achieve a lightweight installation by uninstalling packages you do not require and disabling unused services:
+While no automatic script is supplied for Linux, you can achieve a lightweight Forky installation by uninstalling packages you do not require and disabling unused services:
 
 ```bash
 sudo apt-get purge libreoffice-* games-* thunderbird
 sudo systemctl disable cups.service
 ```
 
-After cleaning up, update the system and install only the packages listed in `setup/Debian13/install.sh`.
+After cleaning up, update the system and install only the packages listed in `platform/installers/debian/Debian/install-deb.sh`.
 
 ## macOS
 

--- a/src/huey/memory/PY/installer.py
+++ b/src/huey/memory/PY/installer.py
@@ -16,12 +16,14 @@ import os
 import platform
 import subprocess
 import sys
+from pathlib import Path
 
 from hueyos.core.system_checks import ensure_admin
 from hueyos.license_cli import show_license_cli
 from hueyos.license_gui import show_license_gui
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
 
 # Hardware selection options for manual installation
 HARDWARE_OPTIONS = [
@@ -139,7 +141,9 @@ def display_license() -> None:
         show_license_cli()
 
 
-LINUX_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Debian13", "install.sh")
+LINUX_INSTALL = str(
+    PROJECT_ROOT / "platform" / "installers" / "debian" / "Debian" / "install-deb.sh"
+)
 MAC_INSTALL = os.path.join(SCRIPT_DIR, "setup", "macOS", "install.sh")
 WINDOWS_INSTALL = os.path.join(SCRIPT_DIR, "setup", "Windows11", "01-FULL.bat")
 

--- a/src/huey/memory/PY/main_ui.py
+++ b/src/huey/memory/PY/main_ui.py
@@ -183,16 +183,17 @@ class MainUI:
 
     def setup_paths(self):
         """Determine installer paths based on the current platform."""
-        root = Path(__file__).resolve().parents[1]
+        root = Path(__file__).resolve().parents[4]
         setup_dir = root / "setup"
+        platform_installers = root / "platform" / "installers" / "debian" / "Debian"
         system = platform.system()
         if system == "Linux":
-            self.install_path = setup_dir / "Debian13" / "install.sh"
-            self.update_path = setup_dir / "Debian13" / "update.sh"
+            self.install_path = platform_installers / "install-deb.sh"
+            self.update_path = platform_installers / "update-deb.sh"
             self.run_path = root / "run.sh"
         elif system == "Darwin":
             self.install_path = setup_dir / "macOS" / "install.sh"
-            self.update_path = setup_dir / "Debian13" / "update.sh"
+            self.update_path = platform_installers / "update-deb.sh"
             self.run_path = root / "run.sh"
         elif system == "Windows":
             self.install_path = setup_dir / "Windows11" / "01-FULL.bat"

--- a/src/huey/memory/PY/uninstaller.py
+++ b/src/huey/memory/PY/uninstaller.py
@@ -9,10 +9,19 @@ import os
 import platform
 import subprocess
 import sys
+from pathlib import Path
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
 
-LINUX_UNINSTALL = os.path.join(SCRIPT_DIR, "setup", "Debian13", "uninstall.sh")
+LINUX_UNINSTALL = str(
+    PROJECT_ROOT
+    / "platform"
+    / "installers"
+    / "debian"
+    / "Debian"
+    / "uninstall-deb.sh"
+)
 MAC_UNINSTALL = os.path.join(SCRIPT_DIR, "setup", "macOS", "uninstall.sh")
 WINDOWS_UNINSTALL = os.path.join(SCRIPT_DIR, "setup", "Windows11", "03-CLEANUP.bat")
 

--- a/src/huey/memory/PY/update_sources_to_trixie.py
+++ b/src/huey/memory/PY/update_sources_to_trixie.py
@@ -2,7 +2,7 @@
 # Monkey Head Project
 # By: Dylan L.R. Pollock
 # www.dlrp.ca
-# MIGRATION-ONLY: historical helper retained for legacy Debian 13 Trixie nodes.
+# MIGRATION-ONLY: historical helper retained for legacy Debian Trixie nodes.
 
 # ==================================================
 # This file is a part of the 'Monkey Head Project'

--- a/src/huey/memory/SH/install.sh
+++ b/src/huey/memory/SH/install.sh
@@ -18,7 +18,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 case "$(uname)" in
-    Linux*)  INSTALL_SCRIPT="$SCRIPT_DIR/setup/Debian13/install.sh" ;;
+    Linux*)  INSTALL_SCRIPT="$SCRIPT_DIR/../../../../platform/installers/debian/Debian/install-deb.sh" ;;
     Darwin*) INSTALL_SCRIPT="$SCRIPT_DIR/setup/macOS/install.sh" ;;
     *)
         echo "Unsupported operating system" >&2

--- a/src/huey/memory/SH/uninstall.sh
+++ b/src/huey/memory/SH/uninstall.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 case "$(uname)" in
-    Linux*)  UNINSTALL_SCRIPT="$SCRIPT_DIR/setup/Debian13/uninstall.sh" ;;
+    Linux*)  UNINSTALL_SCRIPT="$SCRIPT_DIR/../../../../platform/installers/debian/Debian/uninstall-deb.sh" ;;
     Darwin*) UNINSTALL_SCRIPT="$SCRIPT_DIR/setup/macOS/uninstall.sh" ;;
     *)
         echo "Unsupported operating system" >&2

--- a/src/huey/pygpt_net/tools/manager/__init__.py
+++ b/src/huey/pygpt_net/tools/manager/__init__.py
@@ -31,14 +31,15 @@ class MonkeyManager(BaseTool):
     def _setup_paths(self) -> None:
         root = Path(__file__).resolve().parents[4]
         setup_dir = root / "setup"
+        platform_installers = root / "platform" / "installers" / "debian" / "Debian"
         system = platform.system()
         if system == "Linux":
-            self.install_path = setup_dir / "Debian13" / "install.sh"
-            self.update_path = setup_dir / "Debian13" / "update.sh"
+            self.install_path = platform_installers / "install-deb.sh"
+            self.update_path = platform_installers / "update-deb.sh"
             self.run_path = root / "run.sh"
         elif system == "Darwin":
             self.install_path = setup_dir / "macOS" / "install.sh"
-            self.update_path = setup_dir / "Debian13" / "update.sh"
+            self.update_path = platform_installers / "update-deb.sh"
             self.run_path = root / "run.sh"
         elif system == "Windows":
             self.install_path = setup_dir / "Windows11" / "01-FULL.bat"


### PR DESCRIPTION
### Motivation

- Remove active references to `Debian 13`/`Debian13` from runtime code and active docs and align installer wiring to the current Forky-era platform layout while preserving historical Trixie context only in migration/archived helpers.

### Description

- Updated documentation and guidance to stop using the literal `Debian 13` label and reference the Forky baseline or generic Trixie historical wording, for example in `SECURITY.md` and `src/huey/memory/MD/os-debloating.md`.
- Rewired runtime installer/uninstaller script paths in Python entrypoints by introducing `PROJECT_ROOT`/`platform/installers/debian/Debian/*-deb.sh` usage in `src/huey/memory/PY/installer.py` and `src/huey/memory/PY/uninstaller.py` instead of `setup/Debian13/*` paths.
- Adjusted UI and PyGPT manager path resolution in `src/huey/memory/PY/main_ui.py`, `src/huey/pygpt_net/tools/manager/__init__.py`, and the integration mirror at `integrations/pygpt/pygpt-mhp/...` to use the `platform/installers/debian/Debian` installer/update scripts.
- Updated shell wrappers `src/huey/memory/SH/install.sh` and `src/huey/memory/SH/uninstall.sh` to call the platform installer/uninstaller (`install-deb.sh`/`uninstall-deb.sh`) and fixed small documentation/header text issues (e.g., `update_sources_to_trixie.py`).

### Testing

- Ran `python -m py_compile` on modified Python files (`src/huey/memory/PY/installer.py`, `src/huey/memory/PY/uninstaller.py`, `src/huey/memory/PY/main_ui.py`, `src/huey/pygpt_net/tools/manager/__init__.py`, and the integration mirror) which completed successfully.
- Linted shell scripts with `bash -n src/huey/memory/SH/install.sh src/huey/memory/SH/uninstall.sh` which reported no syntax errors.
- Verified there are no remaining active `Debian 13|Debian13` matches with `rg -n "Debian 13|Debian13" .` (no matches).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d98e585d84832fb88b664a09e67d5c)