### PR TITLE
Add CI guard for stale platform strings and kernel validation checklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -58,6 +60,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ format:
 	isort src tests conftest.py
 
 lint:
+	$(PYTHON) scripts/check_stale_platform_strings.py
 	black --check src tests conftest.py
 	isort --check-only src tests conftest.py
 	ruff check src tests conftest.py

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ the platform and how to operate core services.
 - [API reference](api-reference.md)
 - [Governance & resilience](governance.md)
 - [Kernel 7.0 Phase 2 runbook (active guidance)](kernel-upgrade-phase2.md)
+- [Kernel validation checklist](kernel-validation-checklist.md)
 - [Linux 6.18.2 migration runbook (legacy archive)](kernel-6.18.2-runbook.md)
 - [Version reference classification report](version-reference-classification.md)
 - [Phase 9 rollback hooks report](phase-9-rollback.md)

--- a/docs/kernel-validation-checklist.md
+++ b/docs/kernel-validation-checklist.md
@@ -1,0 +1,34 @@
+# Kernel Validation Checklist
+
+Use this checklist before merging kernel-facing or platform-string changes.
+
+## 1) Baseline and naming validation
+
+- [ ] Confirm active guidance remains on the 7.0 active-line baseline (not migration-era naming).
+- [ ] Run `python scripts/check_stale_platform_strings.py` and verify no new stale strings were added outside approved legacy/archive paths.
+- [ ] If historical references are necessary, store them only in approved legacy/archive paths and label them as historical context.
+
+## 2) Build/config validation
+
+- [ ] Validate the assembled kernel config still succeeds:
+  - `bash kernel/assemble_kernel_config.sh`
+- [ ] If fragment files changed, confirm expected options in the assembled output and note any intentional deltas.
+- [ ] If release naming or boot logic changed, validate install/update helper scripts still parse expected values.
+
+## 3) Runtime sanity checks
+
+- [ ] Boot and confirm kernel release string is the expected active target.
+- [ ] Verify platform checks in application startup continue to pass (`src/hueyos/system_checks.py`, `src/huey/main.py`).
+- [ ] Run the relevant smoke checks for services that depend on kernel capabilities (storage, sensors, graphics, virtualization).
+
+## 4) Test and CI checks
+
+- [ ] Run `make lint`.
+- [ ] Run `make test` (or targeted tests when working in constrained environments).
+- [ ] Ensure CI passes on pull request and any kernel-related warning is either fixed or documented in the PR.
+
+## 5) Documentation and release hygiene
+
+- [ ] Update active runbooks/docs if behavior changed.
+- [ ] Keep legacy migration notes in historical docs only.
+- [ ] Add a release note entry describing kernel-facing impacts, rollback notes, and operator action items.

--- a/scripts/check_stale_platform_strings.py
+++ b/scripts/check_stale_platform_strings.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Fail CI when newly added stale platform strings appear in active paths."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+BANNED_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\btrixie\b", re.IGNORECASE),
+    re.compile(r"\b6\.18\.2\b"),
+    re.compile(r"\bhueyos-v1\b", re.IGNORECASE),
+    re.compile(r"\bdebian\s+13\b", re.IGNORECASE),
+)
+
+APPROVED_PATH_PREFIXES: tuple[str, ...] = (
+    "archives/",
+    ".migration/",
+    "tests/",
+)
+
+APPROVED_PATHS: tuple[str, ...] = (
+    "docs/kernel-6.18.2-runbook.md",
+    "docs/version-reference-classification.md",
+    "src/huey/memory/PY/update_sources_to_trixie.py",
+    "scripts/check_stale_platform_strings.py",
+)
+
+
+def run_git(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def resolve_base_ref(explicit_base: str | None) -> str:
+    if explicit_base:
+        return explicit_base
+
+    base_ref = os.getenv("GITHUB_BASE_REF")
+    if base_ref:
+        candidate = f"origin/{base_ref}"
+        try:
+            run_git("rev-parse", "--verify", candidate)
+            return run_git("merge-base", "HEAD", candidate)
+        except subprocess.CalledProcessError:
+            pass
+
+    try:
+        return run_git("rev-parse", "HEAD~1")
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "Unable to determine a diff base. Pass --base explicitly."
+        ) from exc
+
+
+def iter_added_lines(base_ref: str) -> Iterable[tuple[str, str, int]]:
+    diff = run_git("diff", "--unified=0", "--no-color", f"{base_ref}...HEAD", "--")
+
+    current_file: str | None = None
+    current_line = 0
+
+    for raw_line in diff.splitlines():
+        if raw_line.startswith("+++ b/"):
+            current_file = raw_line[6:]
+            continue
+
+        if raw_line.startswith("@@"):
+            plus_segment = raw_line.split("+", 1)[1].split(" ", 1)[0]
+            line_token = plus_segment.split(",", 1)[0]
+            current_line = int(line_token)
+            continue
+
+        if raw_line.startswith("+") and not raw_line.startswith("+++") and current_file:
+            yield current_file, raw_line[1:], current_line
+            current_line += 1
+
+
+def is_approved_path(path: str) -> bool:
+    if path in APPROVED_PATHS:
+        return True
+
+    return any(path.startswith(prefix) for prefix in APPROVED_PATH_PREFIXES)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", help="Git base ref/commit to diff against")
+    args = parser.parse_args()
+
+    base_ref = resolve_base_ref(args.base)
+    violations: list[str] = []
+
+    for path, line, line_number in iter_added_lines(base_ref):
+        if is_approved_path(path):
+            continue
+
+        for pattern in BANNED_PATTERNS:
+            if pattern.search(line):
+                violations.append(
+                    f"{path}:{line_number}: found stale platform string ({pattern.pattern})"
+                )
+                break
+
+    if violations:
+        print("Stale platform string check failed. Move these references to approved legacy/archive paths:")
+        for violation in violations:
+            print(f"- {violation}")
+        return 1
+
+    print("Stale platform string check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Prevent regressions where newly added code introduces active references to legacy/migration-era platform strings (`trixie`, `6.18.2`, `hueyos-v1`, `Debian 13`) outside approved legacy/archive locations.
- Provide a short pre-merge checklist for kernel/config changes to keep kernel-facing changes consistent with the 7.0 active-line governance.

### Description

- Add `scripts/check_stale_platform_strings.py`, a lightweight checker that inspects newly added diff lines and fails when banned tokens appear in non-approved paths, resolving a sensible merge-base for PR diffs.
- Run the new check as part of `make lint` by invoking `$(PYTHON) scripts/check_stale_platform_strings.py` so it executes in CI's lint stage.
- Update CI checkout steps in `.github/workflows/ci.yml` to use `fetch-depth: 0` to ensure merge-base diffing works reliably in PR environments.
- Add `docs/kernel-validation-checklist.md` with kernel/platform validation steps and link it from `docs/index.md`.

### Testing

- Ran `python3 scripts/check_stale_platform_strings.py --base HEAD~1` and it passed (no new stale strings found).
- Ran `make lint`; the new stale-string check passes but `make lint` overall failed due to repository-wide formatting issues reported by `black --check` (pre-existing and unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d990691954832fb6dbea8ee254c0c3)