### PR TITLE
chore(deps): refresh requirements pins and keep constraint-held versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Monkey-Head-Project / HueyOS
 # Full pinned dependency baseline for reproducible developer, lab, and staging installs.
-# Target Python: 3.13.x
+# Target Python: 3.12.x and 3.13.x (3.14.x pending pygpt-net support)
 # Package/runtime contract: see pyproject.toml and README v25.
 #
 # Typical usage:
@@ -19,9 +19,9 @@
 
 # --- Core ---
 aiofiles==25.1.0
-aiohttp==3.13.4
+aiohttp==3.13.5
 aiosqlite==0.22.1
-anyio==4.12.1
+anyio==4.13.0
 attrs==26.1.0
 certifi==2026.2.25
 cryptography==46.0.7
@@ -33,9 +33,9 @@ psutil==7.2.2
 pydantic==2.12.5
 pydantic-settings==2.13.1
 PyYAML==6.0.3
-python-multipart==0.0.22
-requests==2.33.0
-sse-starlette==3.3.2
+python-multipart==0.0.26
+requests==2.33.1
+sse-starlette==3.3.4
 starlette==1.0.0
 typing-extensions==4.15.0
 uvicorn[standard]==0.41.0; sys_platform != 'emscripten'
@@ -44,57 +44,57 @@ uvicorn[standard]==0.41.0; sys_platform != 'emscripten'
 accelerate==1.13.0
 aiohappyeyeballs==2.6.1
 aiosignal==1.4.0
-anthropic[bedrock,vertex]==0.84.0
+anthropic[bedrock,vertex]==0.94.0
 audioop-lts==0.2.2; python_version >= '3.13' and python_version < '3.15'
 faster-whisper==1.2.1
-google-ai-generativelanguage==0.6.15
-google-genai==1.66.0
+google-ai-generativelanguage==0.11.0
+google-genai==1.72.0
 google-generativeai==0.8.6
-huggingface-hub==1.7.1
-llama-cloud==1.6.0
+huggingface-hub==1.10.1
+llama-cloud==2.3.0
 llama-cloud-services==0.6.94
-llama-index==0.13.0
-llama-index-core==0.12.52.post1
-llama-index-embeddings-azure-openai==0.3.9
-llama-index-embeddings-gemini==0.3.2
-llama-index-embeddings-huggingface-api==0.3.1
-llama-index-embeddings-mistralai==0.3.0
-llama-index-embeddings-ollama==0.6.0
-llama-index-indices-managed-llama-cloud==0.6.11
-llama-index-instrumentation==0.4.3
-llama-index-llms-anthropic==0.7.6
-llama-index-llms-azure-openai==0.3.4
-llama-index-llms-deepseek==0.2.0
-llama-index-llms-gemini==0.5.0
-llama-index-llms-google-genai==0.2.6
-llama-index-llms-huggingface-api==0.5.0
-llama-index-llms-mistralai==0.6.1
-llama-index-llms-ollama==0.6.2
-llama-index-llms-openai==0.4.7
-llama-index-llms-openai-like==0.4.0
-llama-index-llms-perplexity==0.3.7
-llama-index-multi-modal-llms-openai==0.5.3
+llama-index==0.14.20
+llama-index-core==0.14.20
+llama-index-embeddings-azure-openai==0.5.2
+llama-index-embeddings-gemini==0.4.2
+llama-index-embeddings-huggingface-api==0.5.0
+llama-index-embeddings-mistralai==0.5.0
+llama-index-embeddings-ollama==0.9.0
+llama-index-indices-managed-llama-cloud==0.11.1
+llama-index-instrumentation==0.5.0
+llama-index-llms-anthropic==0.11.2
+llama-index-llms-azure-openai==0.5.3
+llama-index-llms-deepseek==0.3.0
+llama-index-llms-gemini==0.6.2
+llama-index-llms-google-genai==0.9.1
+llama-index-llms-huggingface-api==0.7.0
+llama-index-llms-mistralai==0.10.1
+llama-index-llms-ollama==0.10.1
+llama-index-llms-openai==0.7.5
+llama-index-llms-openai-like==0.7.1
+llama-index-llms-perplexity==0.5.1
+llama-index-multi-modal-llms-openai==0.6.2
 llama-index-program-openai==0.3.2
 llama-index-question-gen-openai==0.3.1
-llama-index-readers-chatgpt-plugin==0.3.0
-llama-index-readers-database==0.4.0
-llama-index-readers-file==0.4.8
-llama-index-readers-github==0.7.0
-llama-index-readers-google==0.6.2.post1
-llama-index-readers-llama-parse==0.4.0
-llama-index-readers-microsoft-onedrive==0.3.0
-llama-index-readers-twitter==0.3.0
-llama-index-readers-web==0.4.5
-llama-index-utils-huggingface==0.3.0
-llama-index-workflows==2.17.1
+llama-index-readers-chatgpt-plugin==0.5.0
+llama-index-readers-database==0.6.0
+llama-index-readers-file==0.6.0
+llama-index-readers-github==0.11.2
+llama-index-readers-google==0.7.2
+llama-index-readers-llama-parse==0.6.1
+llama-index-readers-microsoft-onedrive==0.5.0
+llama-index-readers-twitter==0.5.0
+llama-index-readers-web==0.6.0
+llama-index-utils-huggingface==0.5.0
+llama-index-workflows==2.17.3
 llama-parse==0.6.94
-mistralai==1.12.4
-numpy==2.4.3
+mistralai==2.3.2
+numpy==2.4.4
 ollama==0.6.1
-onnxruntime==1.24.3
-openai==2.30.0
-openai-agents==0.3.3
-pillow==12.1.1
+onnxruntime==1.24.4
+openai==2.31.0
+openai-agents==0.13.6
+pillow==12.2.0
 pygpt-net==2.0.154
 safetensors==0.7.0
 sentencepiece==0.2.1
@@ -109,40 +109,40 @@ transformers==5.4.0
 
 # --- Data/Vector stores ---
 chroma-hnswlib==0.7.6
-chromadb==1.5.5
-duckdb==1.5.0
+chromadb==1.5.7
+duckdb==1.5.1
 elastic-transport==9.2.1
 elasticsearch==9.3.0
 faiss-cpu==1.13.2; sys_platform != 'win32'
-pandas==3.0.1
-pinecone==8.1.0
+pandas==3.0.2
+pinecone==8.1.2
 pinecone-client==6.0.0
-pinecone-plugin-assistant==3.0.2
+pinecone-plugin-assistant==3.0.3
 pinecone-plugin-interface==0.0.7
-qdrant-client==1.17.0
-weaviate-client==4.20.4
+qdrant-client==1.17.1
+weaviate-client==4.20.5
 
 # --- Cloud SDKs ---
-azure-core==1.38.2
-azure-identity==1.25.2
-boto3==1.42.66
-botocore==1.42.66
-google-cloud-aiplatform==1.141.0
-google-cloud-storage==3.4.1
+azure-core==1.39.0
+azure-identity==1.25.3
+boto3==1.42.88
+botocore==1.42.88
+google-cloud-aiplatform==1.147.0
+google-cloud-storage==3.10.1
 s3transfer==0.16.0
 
 # --- Dev toolchain ---
 bandit==1.9.4
 black==26.3.1
 chromedriver-autoinstaller==0.6.4
-click==8.3.1
+click==8.3.2
 coloredlogs==15.0.1
 debugpy==1.8.20
 docker==7.1.0
 flake8==7.3.0
 flake8-bugbear==25.11.29
 httpx==0.28.1
-ipython==9.11.0
+ipython==9.12.0
 isort==8.0.1
 mypy==1.19.1
 pip-tools==7.5.3
@@ -152,8 +152,8 @@ pytest-asyncio==1.3.0
 pytest-cov==7.0.0
 rich==14.3.3
 ruff==0.15.5
-types-PyYAML==6.0.12.20250915
-types-requests==2.32.4.20260107
+types-PyYAML==6.0.12.20260408
+types-requests==2.33.0.20260408
 uv==0.11.6
 
 # --- Audio IO ---
@@ -172,21 +172,21 @@ annotated-types==0.7.0
 asttokens==3.0.1
 authlib==1.6.9
 av==17.0.0
-azure-cognitiveservices-speech==1.48.2
+azure-cognitiveservices-speech==1.49.0
 banks==2.4.1
 bcrypt==5.0.0
 beautifulsoup4==4.14.3
-build==1.4.0
+build==1.4.3
 cffi==2.0.0
 cfgv==3.5.0
-charset-normalizer==3.4.5
+charset-normalizer==3.4.7
 colorama==0.4.6
-coverage==7.13.4
-croniter==6.0.0
+coverage==7.13.5
+croniter==6.2.2
 cssselect==1.4.0
 ctranslate2==4.7.1
 cuda-bindings==13.2.0 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-cuda-pathfinder==1.4.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+cuda-pathfinder==1.5.2 ; platform_machine == 'x86_64' and sys_platform == 'linux'
 dataclasses-json==0.6.7
 decorator==5.2.1
 defusedxml==0.7.1
@@ -207,29 +207,29 @@ filelock==3.25.2
 filetype==1.2.0
 flatbuffers==25.12.19
 frozenlist==1.8.0
-fsspec==2026.2.0
+fsspec==2026.3.0
 future==1.0.0
-gkeepapi==0.15.1
-google-api-core==2.25.2
-google-api-python-client==2.192.0
-google-auth==2.49.0
-google-auth-httplib2==0.2.1
-google-auth-oauthlib==1.3.0
-google-cloud-bigquery==3.40.1
-google-cloud-core==2.5.0
-google-cloud-resource-manager==1.16.0
+gkeepapi==0.17.1
+google-api-core==2.30.3
+google-api-python-client==2.194.0
+google-auth==2.49.2
+google-auth-httplib2==0.3.1
+google-auth-oauthlib==1.3.1
+google-cloud-bigquery==3.41.0
+google-cloud-core==2.5.1
+google-cloud-resource-manager==1.17.0
 google-crc32c==1.8.0
-google-resumable-media==2.8.0
-googleapis-common-protos==1.73.0
+google-resumable-media==2.8.2
+googleapis-common-protos==1.74.0
 gpsoauth==2.0.0
-greenlet==3.3.2
-griffe==2.0.0
-grpc-google-iam-v1==0.14.3
-grpcio==1.78.0
-grpcio-status==1.71.2
+greenlet==3.4.0
+griffe==2.0.2
+grpc-google-iam-v1==0.14.4
+grpcio==1.80.0
+grpcio-status==1.80.0
 h11==0.16.0
 h2==4.3.0
-hf-xet==1.4.0 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
 hpack==4.1.0
 html2text==2025.4.15
 httpcore==1.0.9
@@ -238,56 +238,56 @@ httptools==0.7.1
 httpx-sse==0.4.3
 humanfriendly==10.0
 hyperframe==6.1.0
-identify==2.6.17
+identify==2.6.18
 idna==3.11
 importlib-metadata==9.0.0
 importlib-resources==6.5.2
 iniconfig==2.3.0
-invoke==2.2.1
+invoke==3.0.3
 ipython-pygments-lexers==1.1.1
 jedi==0.19.2
 jieba3k==0.35.1
 jinja2==3.1.6
-jiter==0.13.0
+jiter==0.14.0
 jmespath==1.1.0
 joblib==1.5.3
 jsonpatch==1.33
-jsonpointer==3.0.0
+jsonpointer==3.1.1
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 kubernetes==35.0.0
-langchain==1.2.12
-langchain-classic==1.0.2
+langchain==1.2.15
+langchain-classic==1.0.3
 langchain-community==0.4.1
 langchain-core==1.2.28
 langchain-experimental==0.4.1
-langchain-openai==1.1.9
+langchain-openai==1.1.12
 langchain-text-splitters==1.1.1
-langgraph==1.1.1
+langgraph==1.1.6
 langgraph-checkpoint==4.0.1
-langgraph-prebuilt==1.0.8
-langgraph-sdk==0.3.11
-langsmith==0.7.16
-librt==0.8.1 ; platform_python_implementation != 'PyPy'
+langgraph-prebuilt==1.0.9
+langgraph-sdk==0.3.13
+langsmith==0.7.30
+librt==0.9.0 ; platform_python_implementation != 'PyPy'
 llama-hub==0.0.79.post1
 llama-index-agent-openai==0.4.12
-llama-index-cli==0.4.4
-llama-index-embeddings-openai==0.3.1
-lxml==6.0.2
+llama-index-cli==0.5.7
+llama-index-embeddings-openai==0.6.0
+lxml==6.0.3
 lxml-html-clean==0.4.4
 macholib==1.16.4 ; sys_platform == 'darwin'
 markdown==3.10.2
 markdown-it-py==4.0.0
 markdownify==1.2.2
 markupsafe==3.0.3
-marshmallow==3.26.2
+marshmallow==4.3.0
 matplotlib-inline==0.2.1
 mccabe==0.7.0
-mcp==1.26.0
+mcp==1.27.0
 mdurl==0.1.2
 mmh3==5.2.1
-mpmath==1.3.0
-msal==1.35.1
+mpmath==1.4.1
+msal==1.36.0
 msal-extensions==1.3.1
 multidict==6.7.1
 mypy-extensions==1.1.0
@@ -296,31 +296,31 @@ networkx==3.6.1
 newspaper3k==0.2.8
 nltk==3.9.4
 nodeenv==1.10.0
-nvidia-cublas-cu12==12.8.4.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cuda-cupti-cu12==12.8.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cuda-nvrtc-cu12==12.8.93 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cuda-runtime-cu12==12.8.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cudnn-cu12==9.10.2.21 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cufft-cu12==11.3.3.83 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cufile-cu12==1.13.1.3 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-curand-cu12==10.3.9.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cusolver-cu12==11.7.3.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cusparse-cu12==12.5.8.93 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-cusparselt-cu12==0.7.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-nccl-cu12==2.27.5 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-nvjitlink-cu12==12.8.93 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-nvshmem-cu12==3.4.5 ; platform_machine == 'x86_64' and sys_platform == 'linux'
-nvidia-nvtx-cu12==12.8.90 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cublas-cu12==12.9.2.10 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cuda-cupti-cu12==12.9.79 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cuda-nvrtc-cu12==12.9.86 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cuda-runtime-cu12==12.9.79 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cudnn-cu12==9.20.0.48 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cufft-cu12==11.4.1.4 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cufile-cu12==1.14.1.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-curand-cu12==10.3.10.19 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cusolver-cu12==11.7.5.82 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cusparse-cu12==12.5.10.65 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-cusparselt-cu12==0.8.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-nccl-cu12==2.29.7 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-nvjitlink-cu12==12.9.86 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-nvshmem-cu12==3.6.5 ; platform_machine == 'x86_64' and sys_platform == 'linux'
+nvidia-nvtx-cu12==12.9.79 ; platform_machine == 'x86_64' and sys_platform == 'linux'
 oauth2client==4.1.3
 oauthlib==3.3.1
 opencv-python==4.13.0.92
-opentelemetry-api==1.40.0
-opentelemetry-exporter-otlp-proto-common==1.40.0
-opentelemetry-exporter-otlp-proto-grpc==1.40.0
-opentelemetry-exporter-otlp-proto-http==1.40.0
-opentelemetry-proto==1.40.0
-opentelemetry-sdk==1.40.0
-opentelemetry-semantic-conventions==0.61b0
+opentelemetry-api==1.41.0
+opentelemetry-exporter-otlp-proto-common==1.41.0
+opentelemetry-exporter-otlp-proto-grpc==1.41.0
+opentelemetry-exporter-otlp-proto-http==1.41.0
+opentelemetry-proto==1.41.0
+opentelemetry-sdk==1.41.0
+opentelemetry-semantic-conventions==0.62b0
 ormsgpack==1.12.2
 outcome==1.3.0.post0
 overrides==7.7.0
@@ -329,14 +329,14 @@ parso==0.8.6
 pathspec==1.0.4
 pefile==2024.8.26 ; sys_platform == 'win32'
 pexpect==4.9.0 ; sys_platform != 'emscripten' and sys_platform != 'win32'
-platformdirs==4.9.4
+platformdirs==4.9.6
 playwright==1.58.0
 pluggy==1.6.0
 portalocker==3.2.0
 prompt-toolkit==3.0.52
 propcache==0.4.1
-proto-plus==1.27.1
-protobuf==5.29.6
+proto-plus==1.27.2
+protobuf==7.34.1
 ptyprocess==0.7.0 ; sys_platform != 'emscripten' and sys_platform != 'win32'
 pure-eval==0.2.3
 pyaml==26.2.1
@@ -347,27 +347,27 @@ pybase64==1.4.3
 pycodestyle==2.14.0
 pycparser==3.0 ; implementation_name != 'PyPy'
 pycryptodomex==3.23.0
-pydantic-core==2.41.5
+pydantic-core==2.45.0
 pydrive==1.3.1
 pyee==13.0.1
 pyflakes==3.4.0
 pygame==2.6.1
-pygments==2.19.2
+pygments==2.20.0
 pyinstaller==6.19.0
-pyinstaller-hooks-contrib==2026.3
-pyjwt==2.11.0
+pyinstaller-hooks-contrib==2026.4
+pyjwt==2.12.1
 pyparsing==3.3.2
 pypdf==6.10.0
 pypika==0.51.1
 pyproject-hooks==1.2.0
 pyreadline3==3.5.4 ; sys_platform == 'win32'
 pyserial==3.5
-pyside6==6.10.2
-pyside6-addons==6.10.2
-pyside6-essentials==6.10.2
+pyside6==6.11.0
+pyside6-addons==6.11.0
+pyside6-essentials==6.11.0
 pysocks==1.7.1
 python-dateutil==2.9.0.post0
-python-discovery==1.1.3
+python-discovery==1.2.2
 python-dotenv==1.2.2
 pytokens==0.4.1
 pytz==2026.1.post1
@@ -376,31 +376,31 @@ pywin32-ctypes==0.2.3 ; sys_platform == 'win32'
 pyxdg==0.28 ; sys_platform == 'linux'
 qt-material==2.17
 referencing==0.37.0
-regex==2026.2.28
+regex==2026.4.4
 requests-file==3.0.1
 requests-oauthlib==2.0.0
 requests-toolbelt==1.0.0
 retrying==1.4.2
 rpds-py==0.30.0
 rsa==4.9.1
-selenium==4.41.0
+selenium==4.43.0
 sgmllib3k==1.0.0
 shellingham==1.5.4
-shiboken6==6.10.2
+shiboken6==6.11.0
 show-in-file-manager==1.1.6
 six==1.17.0
 sniffio==1.3.1
 soupsieve==2.8.3
-speechrecognition==3.15.1
-spider-client==0.0.27
-sqlalchemy==2.0.48
+speechrecognition==3.16.0
+spider-client==0.1.88
+sqlalchemy==2.0.49
 stack-data==0.6.3
 standard-chunk==3.13.0
 stevedore==5.7.0
-striprtf==0.0.26
+striprtf==0.0.29
 sympy==1.14.0
 tenacity==9.1.4
-tinysegmenter==0.3
+tinysegmenter==0.4
 tldextract==5.3.1
 tokenizers==0.22.2
 tqdm==4.67.3
@@ -411,13 +411,13 @@ tweepy==4.16.0
 typer==0.24.1
 typing-inspect==0.9.0
 typing-inspection==0.4.2
-tzdata==2025.3 ; sys_platform == 'emscripten' or sys_platform == 'win32'
+tzdata==2026.1 ; sys_platform == 'emscripten' or sys_platform == 'win32'
 uritemplate==4.2.0
 urllib3==2.6.3
 uuid-utils==0.14.1
 uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'
 validators==0.35.0
-virtualenv==21.2.0
+virtualenv==21.2.1
 watchfiles==1.1.1
 wcwidth==0.6.0
 websocket-client==1.9.0


### PR DESCRIPTION
### Motivation
- Bring `requirements.txt` up to date with the newest releases on PyPI for unconstrained packages while preserving the pinned anchors in `constraints.txt` for reproducible installs.
- Keep runtime compatibility notes accurate by documenting active support for Python 3.12.x and 3.13.x and deferring 3.14.x until `pygpt-net` supports it.

### Description
- Updated `requirements.txt` with latest available versions from PyPI for unconstrained packages (151 version bumps across core, ML/SDKs, data/cloud, dev, and transitive sections). 
- Preserved all versions listed in `constraints.txt` so anchored runtime/dev packages (e.g., `pygpt-net`, `torch`, `pytest`, etc.) were not overridden. 
- Adjusted the top-of-file target Python comment in `requirements.txt` to `3.12.x and 3.13.x (3.14.x pending pygpt-net support)`. 
- No other files were modified; `constraints.txt` and project metadata remain unchanged.

### Testing
- Ran a Python sync script that queried `https://pypi.org/pypi/<package>/json` to update unconstrained pins, which reported `changes: 151` and successfully updated `requirements.txt`. 
- Ran a post-check script to verify there are zero constraint mismatches between `constraints.txt` and `requirements.txt` (output: `violations 0`). 
- Created a commit for the updated `requirements.txt` (commit created successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d9912656fc832f91653fd7a66b7219)