### PR TITLE
Add pavucontrol to pulse profile requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -160,6 +160,8 @@ uv==0.11.6
 pydub==0.25.1
 sounddevice==0.5.5
 soundfile==0.13.1
+# System package requirement (not pip-installable):
+# - pavucontrol (PulseAudio/PipeWire volume control UI used by HueyOS pulse profile)
 
 pip==26.0.1
 setuptools==82.0.1

--- a/src/huey/system_checks.py
+++ b/src/huey/system_checks.py
@@ -62,6 +62,7 @@ ROLE_REQUIRED_TOOLS: Dict[str, Tuple[str, ...]] = {
         "ethtool",
         "nmcli",
         "iostat",
+        "pavucontrol",
     ),
 }
 

--- a/tests/test_system_checks_module.py
+++ b/tests/test_system_checks_module.py
@@ -279,3 +279,9 @@ def test_system_check_collects_expected_results(monkeypatch):
     assert results["kernel_policy"]["lab_supported"] is True
     assert results["git_available"] is True
     assert results["python3_available"] is True
+
+
+def test_required_tools_for_pulse_role_includes_pavucontrol() -> None:
+    tools = system_checks._required_tools_for_role("pulse")
+
+    assert "pavucontrol" in tools


### PR DESCRIPTION
### Motivation
- Document that `pavucontrol` is a required system package for the HueyOS Pulse profile and ensure tooling checks reflect that dependency.
- Ensure the Pulse kernel role validation recognizes `pavucontrol` as an expected runtime tool so system checks and diagnostics surface missing audio UI tooling.

### Description
- Annotated `requirements.txt` with a comment documenting `pavucontrol` as a non-pip system package requirement for the Pulse profile.
- Added `"pavucontrol"` to the `ROLE_REQUIRED_TOOLS` tuple for the `pulse` role in `src/huey/system_checks.py` so it is validated by `_check_required_tools` and `system_check`.
- Added a unit test `test_required_tools_for_pulse_role_includes_pavucontrol` to `tests/test_system_checks_module.py` that asserts `_required_tools_for_role("pulse")` contains `pavucontrol`.

### Testing
- Ran `python -m py_compile src/huey/system_checks.py tests/test_system_checks_module.py` which completed successfully.
- Ran `pytest -q tests/test_system_checks_module.py -k "required_tools_for_pulse_role_includes_pavucontrol or system_check_collects_expected_results"` which failed during collection with `ModuleNotFoundError: No module named 'hueyos'` in the current environment.
- Queried package availability with `python -m pip index versions pavucontrol` which returned `ERROR: No matching distribution found for pavucontrol`, confirming `pavucontrol` is a system package and not a pip-installable dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69db4e512358832fbb425d3d3ec1b86b)