### PR TITLE
Add hueyos compatibility shims and Honeycomb utilities

### DIFF
--- a/memory.placeholder.txt
+++ b/memory.placeholder.txt
@@ -1,0 +1,1 @@
+src/huey/memory

--- a/src/hueyos/api/__init__.py
+++ b/src/hueyos/api/__init__.py
@@ -1,5 +1,21 @@
-"""Maintained API namespace scaffold for :mod:`hueyos`."""
+"""HueyOS API package.
 
-from .app import SCHEDULER, app, main
+Keep this package initializer lightweight so importing router modules such as
+``hueyos.api.routers.system`` does not eagerly import the full legacy API app.
+The concrete ASGI app remains available from ``hueyos.api.app``.
+"""
+
+from __future__ import annotations
 
 __all__ = ["app", "main", "SCHEDULER"]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        from . import app as _app_module
+
+        value = getattr(_app_module, name)
+        globals()[name] = value
+        return value
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/hueyos/core/resilience.py
+++ b/src/hueyos/core/resilience.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.core.resilience via hueyos.core.resilience."""
+from huey.core.resilience import *  # noqa: F401,F403

--- a/src/hueyos/core/task_scheduler.py
+++ b/src/hueyos/core/task_scheduler.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.core.task_scheduler via hueyos.core.task_scheduler."""
+from huey.core.task_scheduler import *  # noqa: F401,F403

--- a/src/hueyos/hardware/__init__.py
+++ b/src/hueyos/hardware/__init__.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.hardware via hueyos.hardware."""
+from huey.hardware import *  # noqa: F401,F403

--- a/src/hueyos/hardware/plugins.py
+++ b/src/hueyos/hardware/plugins.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.hardware.plugins via hueyos.hardware.plugins."""
+from huey.hardware.plugins import *  # noqa: F401,F403

--- a/src/hueyos/honeycomb/__init__.py
+++ b/src/hueyos/honeycomb/__init__.py
@@ -1,0 +1,27 @@
+"""Canonical Honeycomb package for HueyOS.
+
+This package provides the maintained ``hueyos.honeycomb`` import path while
+legacy ``huey.honeycomb`` modules remain compatibility shims.
+"""
+
+from .backup import BackupError, BackupResult, perform_rsync_snapshot, restore_snapshot
+from .index import HoneycombContentMapping, HoneycombIndex
+from .monitor import HoneycombMonitor, HoneycombUsageTotals
+from .retention import RetentionPolicy, parse_duration
+from .storage import HoneycombRecord, HoneycombStorage, SCHEMA_VERSION
+
+__all__ = [
+    "BackupError",
+    "BackupResult",
+    "HoneycombContentMapping",
+    "HoneycombIndex",
+    "HoneycombMonitor",
+    "HoneycombRecord",
+    "HoneycombStorage",
+    "HoneycombUsageTotals",
+    "RetentionPolicy",
+    "SCHEMA_VERSION",
+    "parse_duration",
+    "perform_rsync_snapshot",
+    "restore_snapshot",
+]

--- a/src/hueyos/honeycomb/backup.py
+++ b/src/hueyos/honeycomb/backup.py
@@ -1,0 +1,151 @@
+"""Backup and restore helpers for Honeycomb storage."""
+
+from __future__ import annotations
+
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+class BackupError(RuntimeError):
+    """Raised when a Honeycomb backup or restore operation fails."""
+
+
+@dataclass(frozen=True)
+class BackupResult:
+    """Result metadata for a Honeycomb backup or restore operation."""
+
+    source: Path
+    destination: Path
+    files_copied: int
+    bytes_copied: int
+    started_at: float
+    finished_at: float
+    operation: str = "backup"
+
+    @property
+    def elapsed_seconds(self) -> float:
+        return self.finished_at - self.started_at
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "source": str(self.source),
+            "destination": str(self.destination),
+            "files_copied": self.files_copied,
+            "bytes_copied": self.bytes_copied,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "elapsed_seconds": self.elapsed_seconds,
+            "operation": self.operation,
+        }
+
+
+def _copy_tree(source: Path, destination: Path, *, overwrite: bool = False) -> tuple[int, int]:
+    if not source.exists():
+        raise BackupError(f"source does not exist: {source}")
+
+    if source.is_file():
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists() and not overwrite:
+            raise BackupError(f"destination already exists: {destination}")
+        shutil.copy2(source, destination)
+        return 1, destination.stat().st_size
+
+    if destination.exists() and not overwrite:
+        raise BackupError(f"destination already exists: {destination}")
+
+    files_copied = 0
+    bytes_copied = 0
+    destination.mkdir(parents=True, exist_ok=True)
+
+    for item in source.rglob("*"):
+        relative = item.relative_to(source)
+        target = destination / relative
+
+        if item.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, target)
+        files_copied += 1
+        bytes_copied += target.stat().st_size
+
+    return files_copied, bytes_copied
+
+
+def perform_rsync_snapshot(
+    source: str | Path,
+    destination: str | Path,
+    *,
+    overwrite: bool = False,
+    label: Optional[str] = None,
+) -> BackupResult:
+    """Create a Honeycomb snapshot.
+
+    The historical function name references rsync, but this implementation uses
+    Python's standard library so it works on Windows development machines too.
+    """
+
+    started = time.time()
+    source_path = Path(source).expanduser().resolve()
+    destination_path = Path(destination).expanduser()
+
+    if label:
+        destination_path = destination_path / label
+
+    destination_path = destination_path.resolve()
+
+    try:
+        files, size = _copy_tree(source_path, destination_path, overwrite=overwrite)
+    except Exception as exc:
+        if isinstance(exc, BackupError):
+            raise
+        raise BackupError(str(exc)) from exc
+
+    finished = time.time()
+    return BackupResult(
+        source=source_path,
+        destination=destination_path,
+        files_copied=files,
+        bytes_copied=size,
+        started_at=started,
+        finished_at=finished,
+        operation="backup",
+    )
+
+
+def restore_snapshot(
+    snapshot: str | Path,
+    destination: str | Path,
+    *,
+    overwrite: bool = False,
+) -> BackupResult:
+    """Restore a Honeycomb snapshot to ``destination``."""
+
+    started = time.time()
+    snapshot_path = Path(snapshot).expanduser().resolve()
+    destination_path = Path(destination).expanduser().resolve()
+
+    try:
+        files, size = _copy_tree(snapshot_path, destination_path, overwrite=overwrite)
+    except Exception as exc:
+        if isinstance(exc, BackupError):
+            raise
+        raise BackupError(str(exc)) from exc
+
+    finished = time.time()
+    return BackupResult(
+        source=snapshot_path,
+        destination=destination_path,
+        files_copied=files,
+        bytes_copied=size,
+        started_at=started,
+        finished_at=finished,
+        operation="restore",
+    )
+
+
+__all__ = ["BackupError", "BackupResult", "perform_rsync_snapshot", "restore_snapshot"]

--- a/src/hueyos/honeycomb/index.py
+++ b/src/hueyos/honeycomb/index.py
@@ -1,0 +1,9 @@
+"""Canonical Honeycomb index exports."""
+
+from hueyos.honeycomb_index import (
+    HoneycombContentMapping,
+    HoneycombIndex,
+    HoneycombIndexRecord,
+)
+
+__all__ = ["HoneycombContentMapping", "HoneycombIndex", "HoneycombIndexRecord"]

--- a/src/hueyos/honeycomb/monitor.py
+++ b/src/hueyos/honeycomb/monitor.py
@@ -1,0 +1,5 @@
+"""Canonical Honeycomb monitor exports."""
+
+from hueyos.honeycomb_monitor import HoneycombMonitor, HoneycombUsageTotals
+
+__all__ = ["HoneycombMonitor", "HoneycombUsageTotals"]

--- a/src/hueyos/honeycomb/retention.py
+++ b/src/hueyos/honeycomb/retention.py
@@ -1,0 +1,74 @@
+"""Retention helpers for Honeycomb storage."""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+_DURATION_RE = re.compile(r"^\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>[smhdwMy]?)\s*$")
+
+
+def parse_duration(value: str | int | float | None) -> Optional[float]:
+    """Parse a retention duration into seconds.
+
+    Supported suffixes:
+    s = seconds, m = minutes, h = hours, d = days, w = weeks,
+    M = 30-day months, y = 365-day years.
+
+    ``None`` or an empty string means no retention limit.
+    """
+
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    match = _DURATION_RE.match(text)
+    if not match:
+        raise ValueError(f"invalid duration: {value!r}")
+
+    number = float(match.group("value"))
+    unit = match.group("unit") or "s"
+
+    multipliers = {
+        "s": 1,
+        "m": 60,
+        "h": 60 * 60,
+        "d": 60 * 60 * 24,
+        "w": 60 * 60 * 24 * 7,
+        "M": 60 * 60 * 24 * 30,
+        "y": 60 * 60 * 24 * 365,
+    }
+
+    return number * multipliers[unit]
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    """Simple age-based retention policy."""
+
+    max_age: str | int | float | None = None
+
+    @property
+    def max_age_seconds(self) -> Optional[float]:
+        return parse_duration(self.max_age)
+
+    def should_retain(self, timestamp: float, *, now: float | None = None) -> bool:
+        limit = self.max_age_seconds
+        if limit is None:
+            return True
+        current = time.time() if now is None else now
+        return (current - float(timestamp)) <= limit
+
+    def should_prune(self, timestamp: float, *, now: float | None = None) -> bool:
+        return not self.should_retain(timestamp, now=now)
+
+
+__all__ = ["RetentionPolicy", "parse_duration"]

--- a/src/hueyos/honeycomb/storage.py
+++ b/src/hueyos/honeycomb/storage.py
@@ -1,0 +1,5 @@
+"""Canonical Honeycomb storage exports."""
+
+from hueyos.honeycomb_storage import HoneycombRecord, HoneycombStorage, SCHEMA_VERSION
+
+__all__ = ["HoneycombStorage", "HoneycombRecord", "SCHEMA_VERSION"]

--- a/src/hueyos/network.py
+++ b/src/hueyos/network.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.network via hueyos.network."""
+from huey.network import *  # noqa: F401,F403

--- a/src/hueyos/pdf_utils.py
+++ b/src/hueyos/pdf_utils.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.pdf_utils via hueyos.pdf_utils."""
+from huey.pdf_utils import *  # noqa: F401,F403

--- a/src/hueyos/power.py
+++ b/src/hueyos/power.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.power via hueyos.power."""
+from huey.power import *  # noqa: F401,F403

--- a/src/hueyos/system_checks.py
+++ b/src/hueyos/system_checks.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.system_checks via hueyos.system_checks."""
+from huey.system_checks import *  # noqa: F401,F403

--- a/src/hueyos/utils/auto_sort.py
+++ b/src/hueyos/utils/auto_sort.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.utils.auto_sort via hueyos.utils.auto_sort."""
+from huey.utils.auto_sort import *  # noqa: F401,F403

--- a/src/hueyos/utils/paths.py
+++ b/src/hueyos/utils/paths.py
@@ -1,0 +1,2 @@
+"""Compatibility shim exposing legacy huey.utils.paths via hueyos.utils.paths."""
+from huey.utils.paths import *  # noqa: F401,F403


### PR DESCRIPTION
Introduce a new hueyos compatibility layer and Honeycomb utilities. Adds lightweight api package initializer with lazy __getattr__ for app/SCHEDULER/main, numerous compatibility shim modules (core, hardware, network, pdf_utils, power, system_checks, utils.*) and canonical hueyos.honeycomb package. Implements Honeycomb helpers: backup/restore (perform_rsync_snapshot, restore_snapshot) with BackupResult/BackupError, index/monitor/storage exports, and retention utilities (parse_duration, RetentionPolicy). Also adds small task_scheduler/resilience shims and a memory.placeholder.txt. These changes provide maintained hueyos import paths while preserving legacy huey modules and add cross-platform snapshot utilities.

## Summary
- 

## Why
- 

## Scope
- In scope:
  - 
- Out of scope:
  - 

## Tests run
- [ ] `...`
- [ ] `...`

## Screenshots/logs if UI
- N/A or attach screenshots/log snippets.

## Security considerations
- Any security impact, sensitive surfaces touched, or risk mitigations.

## Docs updated
- [ ] Yes
- [ ] No (explain why)

## Dependency changes
- [ ] None
- [ ] Yes (list package, version change, and reason)

## Boundary check
- [ ] Does this keep PyHuey as cockpit/tooling?
- [ ] Does this keep Huey Brain V1 on Legion Go?
- [ ] Does this avoid implying Huey Body/HIMS/live mic are active?
