### PR TITLE
Restrict Python support policy to 3.13.x

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,7 +10,7 @@
 # - preserve flexibility for platform-specific packages by leaving most markers in requirements.txt
 #
 # Target Python:
-#   >=3.13,<3.15
+#   3.13.x only (>=3.13,<3.14); Python 3.14.x is research-only
 
 # --- Packaging / installer toolchain ---
 pip==26.1.1

--- a/docs/development/python-support-policy.md
+++ b/docs/development/python-support-policy.md
@@ -1,0 +1,43 @@
+# Python Support Policy
+
+## Current supported Python version
+
+Monkey-Head-Project / HueyOS currently supports **Python 3.13.x only**.
+
+Supported range:
+
+```text
+>=3.13,<3.14
+```
+
+## Not currently supported
+
+The following Python versions are not part of the current supported runtime contract:
+
+- Python 3.11.x
+- Python 3.12.x
+- Python 3.14.x
+
+## Python 3.14.x research status
+
+Python 3.14.x is considered **research-stage only**.
+
+It may be explored in isolated branches or throwaway environments, but it should not be treated as the supported project runtime until the dependency stack, audio compatibility packages, ML packages, PyGPT/PyHuey integration, and HueyOS runtime path have all been validated.
+
+## Reason
+
+The active project target is a reproducible V1 runtime. A narrow Python support window reduces dependency churn and keeps the current lab baseline testable.
+
+## Current rule
+
+Use Python 3.13.x for:
+
+- development installs
+- lab installs
+- staging installs
+- editable installs
+- requirements validation
+- dependency freeze records
+- V1 proof-loop work
+
+Do not claim support for another Python version until it has been validated and promoted through a dedicated compatibility pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "hueyos"
 version = "0.2.0"
 description = "HueyOS: offline-first embodied AI / OS for Huey and the Monkey-Head-Project."
-requires-python = ">=3.13,<3.15"
+requires-python = ">=3.13,<3.14"
 readme = "README.md"
 authors = [
   { name = "Dylan L. R. Pollock" },
@@ -22,7 +22,6 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
   "Operating System :: POSIX :: Linux",
 ]
@@ -63,7 +62,7 @@ ml = [
   "aiohappyeyeballs==2.6.1",
   "aiosignal==1.4.0",
   "anthropic[bedrock,vertex]==0.100.0",
-  "audioop-lts==0.2.2; python_version >= '3.13' and python_version < '3.15'",
+  "audioop-lts==0.2.2; python_version >= '3.13' and python_version < '3.14'",
   "faster-whisper==1.2.1",
   "google-ai-generativelanguage==0.11.0",
   "google-genai==2.2.0",
@@ -117,7 +116,7 @@ ml = [
   "safetensors==0.7.0",
   "sentencepiece==0.2.1",
   "sortedcontainers==2.4.0",
-  "standard-aifc==3.13.0; python_version >= '3.13' and python_version < '3.15'",
+  "standard-aifc==3.13.0; python_version >= '3.13' and python_version < '3.14'",
   "tiktoken==0.12.0",
   "torch==2.12.0; sys_platform != 'win32'",
   "torchaudio==2.11.0; sys_platform != 'win32'",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Monkey-Head-Project / HueyOS
 # v101.0 requirements baseline for reproducible developer, lab, and staging installs.
-# Target Python: >=3.13,<3.15
+# Target Python: 3.13.x only (>=3.13,<3.14); Python 3.14.x is research-only.
 # V1 scope: Huey Brain / Legion Go controlled MP3 fixture -> transcription -> cognition bridge -> structured log.
 # Package/runtime contract: keep aligned with pyproject.toml, constraints.txt, README-v101.0.md, and master-plan-v101.0.json.
 #
@@ -56,7 +56,7 @@ accelerate==1.13.0
 aiohappyeyeballs==2.6.1
 aiosignal==1.4.0
 anthropic[bedrock,vertex]==0.100.0
-audioop-lts==0.2.2; python_version >= '3.13' and python_version < '3.15'
+audioop-lts==0.2.2; python_version >= '3.13' and python_version < '3.14'
 faster-whisper==1.2.1
 google-ai-generativelanguage==0.11.0
 google-genai==2.2.0
@@ -110,7 +110,7 @@ pygpt-net==2.7.12
 safetensors==0.7.0
 sentencepiece==0.2.1
 sortedcontainers==2.4.0
-standard-aifc==3.13.0; python_version >= '3.13' and python_version < '3.15'
+standard-aifc==3.13.0; python_version >= '3.13' and python_version < '3.14'
 tiktoken==0.12.0
 torch==2.12.0; sys_platform != 'win32'
 torchaudio==2.11.0; sys_platform != 'win32'


### PR DESCRIPTION
## Summary

- Restricts the project runtime support window to Python 3.13.x only.
- Updates `requirements.txt`, `constraints.txt`, and `pyproject.toml` from `>=3.13,<3.15` to `>=3.13,<3.14`.
- Removes Python 3.14 from supported package classifiers.
- Adds a Python support policy document.
- Marks Python 3.14.x as research-stage only.

## Rationale

The active HueyOS / Monkey-Head-Project V1 target needs a narrow, reproducible runtime baseline. Python 3.13.x is the current supported target; Python 3.14.x should remain isolated to future compatibility research until the dependency stack is validated.

## Validation

- Branch pushed: `python-313-support-policy`
- Branch is ahead of `main` by 1 commit and not behind.
- Changed files are limited to runtime support metadata and documentation.
- Search hits for `3.11`, `3.14`, and `3.15` that remain are package versions or explicit research-only notes, not support declarations.