### PR TITLE
Harden CI smoke and security workflows

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,7 +13,8 @@ max-line-length = 88
 # - E501: line length (delegated to Black)
 # - W291: trailing whitespace (handled by pre-commit trailing-whitespace hook)
 # - W293: blank line contains whitespace (also handled by pre-commit)
-extend-ignore = E203, E402, E501, W291, W293
+# - W503: line break before binary operator; Black-compatible wrapping
+extend-ignore = E203, E402, E501, W291, W293, W503
 
 # Enable core Flake8 checks plus flake8-bugbear (configured via pre-commit)
 # B950: soft maximum line length that works well with Black's 88-char style

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -52,8 +52,8 @@ jobs:
         shell: bash
         run: |
           source .pkg-smoke-venv/bin/activate
-          huey --help
-          huey-api --help
+          timeout 15s huey --help
+          timeout 15s huey-api --help
 
       - name: Upload dist artifacts on failure
         if: failure()

--- a/.github/workflows/security-bandit.yml
+++ b/.github/workflows/security-bandit.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Record full Bandit report (debt + new)
         if: always()
         run: |
-          bandit -r src -f json -o bandit-results-full.json
+          bandit -r src -f json -o bandit-results-full.json || true
 
       - name: Enforce no new medium/high findings
         run: |

--- a/.github/workflows/security-dependency-scan.yml
+++ b/.github/workflows/security-dependency-scan.yml
@@ -13,7 +13,6 @@ on:
 permissions:
   contents: read
 
-
 jobs:
   pip-audit:
     runs-on: ubuntu-latest
@@ -34,13 +33,17 @@ jobs:
 
       - name: Prepare requirements for pip-audit
         run: |
-          grep -vE '^\\s*-c\\s+' requirements.txt > audit-requirements.txt
+          grep -vE '^\s*-c\s+' requirements.txt > audit-requirements.txt
 
-      - name: Run pip-audit (human-readable)
-        run: pip-audit -r audit-requirements.txt
+      - name: Record pip-audit JSON output
+        if: always()
+        run: |
+          pip-audit -r audit-requirements.txt --format json --output pip-audit-results.json || true
+          test -f pip-audit-results.json || printf '{"error":"pip-audit did not produce JSON output"}\n' > pip-audit-results.json
 
-      - name: Run pip-audit (JSON output)
-        run: pip-audit -r audit-requirements.txt --format json --output pip-audit-results.json
+      - name: Enforce dependency security audit
+        run: |
+          pip-audit -r audit-requirements.txt
 
       - name: Upload pip-audit results
         if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,7 @@ audio = [
 
 [project.scripts]
 huey = "huey.cli:main"
-# Kept aligned to the current runtime contract pending the source-level entrypoint fix.
+# HueyOS API console entrypoint.
 huey-api = "huey.api:main"
 
 [build-system]

--- a/src/huey/memory/PY/api.py
+++ b/src/huey/memory/PY/api.py
@@ -108,10 +108,8 @@ from hueyos.core.resilience import (
     EmergencyGovernanceController,
 )
 from hueyos.core.task_scheduler import (
-    Agent,
     ResourceProfile,
     TaskPriority,
-    TaskRecord,
     TaskScheduler,
     TaskStatus,
 )
@@ -1159,7 +1157,9 @@ _register_battery_hooks()
 from hueyos.api.routers.network import router as network_router
 from hueyos.api.routers.power import router as power_router
 from hueyos.api.routers.sensors import router as sensors_router
+from hueyos.api.routers.system import healthz
 from hueyos.api.routers.system import router as system_router
+from hueyos.api.routers.system import system_status
 from hueyos.api.routers.tasks import (
     cancel_task,
     get_task,
@@ -1809,16 +1809,41 @@ def admin_health_check() -> Dict[str, str]:
     return healthz()
 
 
-def main() -> None:
-    import os
+def main(argv: Sequence[str] | None = None) -> None:
+    """Run the HueyOS API server from the console entry point."""
+    import argparse
 
     import uvicorn
 
-    host = os.getenv("HUEY_HOST", "127.0.0.1")
-    port = int(os.getenv("HUEY_PORT", "1995"))
-    reload = os.getenv("HUEY_RELOAD", "").strip().lower() in {"1", "true", "yes", "on"}
+    env_reload = os.getenv("HUEY_RELOAD", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
-    uvicorn.run("huey.api:app", host=host, port=port, reload=reload)
+    parser = argparse.ArgumentParser(description="Run the HueyOS API server.")
+    parser.add_argument(
+        "--host",
+        default=os.getenv("HUEY_HOST", "127.0.0.1"),
+        help="Host/interface to bind. Defaults to HUEY_HOST or 127.0.0.1.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("HUEY_PORT", "1995")),
+        help="Port to bind. Defaults to HUEY_PORT or 1995.",
+    )
+    parser.add_argument(
+        "--reload",
+        action="store_true",
+        default=env_reload,
+        help="Enable uvicorn reload mode. Also enabled by HUEY_RELOAD=true.",
+    )
+
+    args = parser.parse_args(argv)
+
+    uvicorn.run("huey.api:app", host=args.host, port=args.port, reload=args.reload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fixes `huey-api --help` so the console entry point prints help instead of starting the API server.
- Adds timeout protection to Package Smoke console-script checks.
- Makes Bandit full-report generation non-gating while keeping baseline enforcement as the actual security gate.
- Makes pip-audit JSON generation non-gating so artifacts are uploaded even when vulnerabilities are found.
- Preserves Black-compatible Flake8 behavior while adding `W503` to the ignored checks.
- Restores legacy API module exports for `healthz` and `system_status`.

## Rationale

Recent checks surfaced workflow and lint issues that made failures hard to diagnose:

- Package Smoke could hang because `huey-api --help` started Uvicorn.
- Bandit failed while recording the full report instead of during baseline enforcement.
- pip-audit skipped JSON output when vulnerabilities were found, causing artifact upload to fail.
- CI lint surfaced undefined legacy API exports and Black/Flake8 formatting friction.

This pass makes the workflows fail in useful places and ensures diagnostic artifacts are created.

## Validation

- `python scripts/check_stale_platform_strings.py`
- `python scripts/check_repo_drift.py`
- `python -m black --check src/huey/memory/PY/api.py`
- `python -m isort --check-only src/huey/memory/PY/api.py`
- `python -m ruff check src/huey/memory/PY/api.py`
- `python -m flake8 src/huey/memory/PY/api.py`