### PR TITLE
Reconcile pyhuey connector path

### DIFF
--- a/docs/security/tool_permission_boundaries.md
+++ b/docs/security/tool_permission_boundaries.md
@@ -1,6 +1,7 @@
 # Tool and Plugin Permission Boundaries (PyHuey/MonkeyManager)
 
-This note documents execution boundaries for `huey.pygpt_net.tools.manager.MonkeyManager`.
+This note documents execution boundaries for
+`huey.connectors.pyhuey.tools.manager.MonkeyManager`.
 
 ## Execution surfaces
 

--- a/src/huey/memory/PY/run.py
+++ b/src/huey/memory/PY/run.py
@@ -99,7 +99,7 @@ def launch_gui(source: str | None = None) -> None:
 
     from pygpt_net.app import run as pygpt_run
 
-    from huey.pygpt_net.tools.manager import MonkeyManager
+    from huey.connectors.pyhuey.tools.manager import MonkeyManager
 
     pygpt_run(tools=[MonkeyManager()])
 

--- a/tests/test_run_entrypoint.py
+++ b/tests/test_run_entrypoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 
@@ -95,3 +96,26 @@ def test_main_pyhuey_info_invokes_report(monkeypatch):
     huey_run.main(["--pyhuey-info", "--pyhuey-source", "vendor"])
 
     assert called["source"] == "vendor"
+
+
+def test_launch_gui_uses_canonical_connector_manager(monkeypatch):
+    from huey import run as huey_run
+    from huey.pyhuey_integration import prepare_pygpt, reset_pygpt_state
+
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    monkeypatch.delitem(sys.modules, "pygpt_net", raising=False)
+
+    reset_pygpt_state()
+    assert prepare_pygpt(source="package")
+
+    app_module = importlib.import_module("pygpt_net.app")
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(*, tools=None):
+        captured["modules"] = [tool.__class__.__module__ for tool in tools or ()]
+
+    monkeypatch.setattr(app_module, "run", fake_run)
+
+    huey_run.launch_gui(source="package")
+
+    assert captured["modules"] == ["huey.connectors.pyhuey.tools.manager"]

--- a/vendor/pygpt/README.md
+++ b/vendor/pygpt/README.md
@@ -6,10 +6,13 @@ and constrained developer environments.
 The active runtime integration is resolved by `huey.pyhuey_integration` in this
 order:
 
-1. the packaged compatibility tree under `src/huey/pygpt_net`,
+1. the packaged connector tree under `src/huey/connectors/pyhuey`,
 2. the full `integrations/pyhuey` submodule,
 3. these vendored mirrors,
 4. legacy checkout locations.
+
+Legacy imports through `huey.pygpt_net` remain supported as a compatibility shim
+that points at the packaged connector tree.
 
 Keep live adapter and submodule work under `integrations/`; keep static mirrors
 here under `vendor/`.


### PR DESCRIPTION
The pyhuey audit found one live GUI code path still reaching the manager through the legacy `huey.pygpt_net` shim. This keeps the compatibility layer in place, but moves the active launch path onto the canonical connector tree so the runtime path and the audit classification match.

## What changed

- switch `launch_gui()` to import `MonkeyManager` from `huey.connectors.pyhuey.tools.manager`
- add a regression test that asserts the GUI launch path wires in the canonical connector manager module
- update the affected docs to describe `src/huey/connectors/pyhuey` as the packaged connector tree and clarify that `huey.pygpt_net` remains a compatibility shim

## Notes for reviewers

This is intentionally narrow. The PR does not remove the legacy shim or rename compatibility-facing `pygpt_net` references that are still needed for runtime fallback, tests, vendored mirrors, or provenance. The only behavior change is the connector path reconciliation on the live GUI entrypoint.