### PR TITLE
Add unified Python integration and Command Center layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PORT ?= 1995
 APP ?= huey.api:app
 PKG_COV ?= --cov=huey
 
-.PHONY: help setup install install-dev precommit-install format lint check-drift check-legacy-hueyos check-canon check-deps-sync test coverage run run-reload health
+.PHONY: help setup install install-dev precommit-install format lint check-drift check-legacy-hueyos check-command-center check-canon check-deps-sync test coverage run run-reload health
 
 help:
 	@echo "Common targets:"
@@ -23,6 +23,7 @@ help:
 	@echo "  make lint             - run drift checks + black/isort/ruff/flake8"
 	@echo "  make check-drift      - run repository drift checker"
 	@echo "  make check-legacy-hueyos - block new legacy hueyos imports"
+	@echo "  make check-command-center - verify Command Center backend contract"
 	@echo "  make check-deps-sync  - check pyproject/requirements/constraints sync"
 	@echo "  make test             - run pytest"
 	@echo "  make coverage         - run pytest with coverage for huey"
@@ -50,6 +51,7 @@ lint:
 	$(PYTHON) scripts/repo/check_stale_platform_strings.py
 	$(PYTHON) scripts/repo/check_repo_drift.py
 	$(PYTHON) scripts/repo/check_legacy_hueyos_imports.py
+	$(PYTHON) scripts/check_command_center_contract.py
 	black --check src tests scripts conftest.py
 	isort --check-only src tests scripts conftest.py
 	ruff check src tests scripts conftest.py
@@ -60,6 +62,9 @@ check-drift:
 
 check-legacy-hueyos:
 	$(PYTHON) scripts/repo/check_legacy_hueyos_imports.py
+
+check-command-center:
+	$(PYTHON) scripts/check_command_center_contract.py
 
 check-canon:
 	$(PYTHON) scripts/repo/check_canon_terms.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ audio = [
 huey = "huey.cli:main"
 # HueyOS API console entrypoint.
 huey-api = "huey.api:main"
+huey-command-center = "huey.apps.command_center.cli:main"
 
 [build-system]
 requires = [

--- a/scripts/check_api_surface.py
+++ b/scripts/check_api_surface.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Audit the exposed API surface for duplicates and documentation gaps."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+VENDOR = ROOT / "vendor"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(VENDOR) not in sys.path:
+    sys.path.insert(0, str(VENDOR))
+
+from fastapi.routing import APIRoute
+
+
+def _load_app():
+    os.environ.setdefault("HUEY_ENV", "development")
+    module = importlib.import_module("huey.api")
+    return module.app
+
+
+def _route_signature(route: APIRoute) -> tuple[str, tuple[str, ...]]:
+    methods = tuple(
+        sorted(
+            method
+            for method in (route.methods or set())
+            if method not in {"HEAD", "OPTIONS"}
+        )
+    )
+    return route.path, methods
+
+
+def main() -> int:
+    app = _load_app()
+    seen: set[tuple[str, tuple[str, ...]]] = set()
+    duplicates: list[str] = []
+    undocumented: list[str] = []
+    orphaned: list[str] = []
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        signature = _route_signature(route)
+        if signature in seen:
+            duplicates.append(f"{route.path} {sorted(route.methods or set())}")
+        else:
+            seen.add(signature)
+        if not (
+            route.summary or route.description or (route.endpoint.__doc__ or "").strip()
+        ):
+            undocumented.append(route.path)
+        if not route.tags:
+            orphaned.append(route.path)
+
+    if duplicates or undocumented or orphaned:
+        if duplicates:
+            print("Duplicate endpoints:")
+            for item in duplicates:
+                print(f"  - {item}")
+        if undocumented:
+            print("Undocumented endpoints:")
+            for item in undocumented:
+                print(f"  - {item}")
+        if orphaned:
+            print("Orphan endpoints without tags:")
+            for item in orphaned:
+                print(f"  - {item}")
+        return 1
+
+    print("API surface check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_command_center_contract.py
+++ b/scripts/check_command_center_contract.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Verify the read-only Command Center backend contract."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def assert_imports() -> None:
+    import huey.apps.command_center  # noqa: F401
+    import huey.gui  # noqa: F401
+
+
+def assert_routes() -> None:
+    from huey.apps.command_center.server import create_app
+
+    app = create_app()
+    paths = {route.path: route.methods for route in app.routes}
+    required = {
+        "/command-center/meta",
+        "/command-center/safety",
+        "/command-center/repos",
+        "/command-center/phases",
+        "/command-center/validation",
+        "/command-center/operator-panel",
+        "/command-center/v1-runs/sample",
+        "/command-center/prompts/phase/{phase_id}",
+    }
+    missing = sorted(required.difference(paths))
+    if missing:
+        raise AssertionError(f"Missing routes: {missing}")
+    for path, methods in paths.items():
+        if not path.startswith("/command-center/"):
+            continue
+        if "POST" in (methods or set()):
+            raise AssertionError(f"Route must remain read-only: {path}")
+
+
+def assert_safety_policy() -> None:
+    from huey.gui.safety import default_safety_policy
+    from huey.gui.validation import all_validation_commands
+
+    policy = default_safety_policy()
+    assert policy.mock_only is True
+    assert policy.allow_command_execution is False
+    assert policy.allow_task_execution is False
+    assert policy.allow_memory_mutation is False
+    assert all(command.copy_only for command in all_validation_commands())
+
+
+def main() -> int:
+    try:
+        assert_imports()
+        assert_routes()
+        assert_safety_policy()
+    except (AssertionError, ImportError, RuntimeError, ValueError) as exc:
+        print(f"Command Center contract check failed: {exc}")
+        return 1
+    print("Command Center contract check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/export_command_center_seed.py
+++ b/scripts/export_command_center_seed.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Export canonical Command Center seed data."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from huey.apps.command_center.static_config import export_frontend_config
+from huey.gui.defaults import (
+    default_migration_phases,
+    default_operator_panel_state,
+    default_repositories,
+)
+from huey.gui.models import dataclass_list_to_dicts, dataclass_to_dict
+from huey.gui.safety import safety_banner
+from huey.gui.theme import as_css_variables, as_json
+from huey.gui.v1_runs import sample_v1_runs
+from huey.gui.validation import all_validation_commands
+
+
+def build_seed_payload() -> dict[str, object]:
+    """Build the repository/phase/theme/safety seed payload."""
+
+    return {
+        "config": export_frontend_config(),
+        "theme": as_json(),
+        "theme_css": as_css_variables(),
+        "safety": safety_banner(),
+        "repositories": dataclass_list_to_dicts(default_repositories()),
+        "phases": dataclass_list_to_dicts(default_migration_phases()),
+        "validation_commands": dataclass_list_to_dicts(all_validation_commands()),
+        "operator_panel": dataclass_to_dict(default_operator_panel_state()),
+        "v1_runs": dataclass_list_to_dicts(sample_v1_runs()),
+    }
+
+
+def write_seed(path: Path) -> Path:
+    """Write the seed payload to disk."""
+
+    payload = build_seed_payload()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export Command Center seed JSON")
+    parser.add_argument(
+        "--output",
+        default="docs/tools/command-center-seed.json",
+        help="Output path for the exported seed payload.",
+    )
+    args = parser.parse_args()
+    path = write_seed(Path(args.output))
+    print(f"Wrote Command Center seed to {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_repo_map.py
+++ b/scripts/generate_repo_map.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Generate a Markdown repository map for the current checkout."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _should_skip(path: Path) -> bool:
+    return path.name.startswith(".") or path.name == "__pycache__"
+
+
+def _tree_lines(root: Path, *, max_depth: int, depth: int = 0) -> list[str]:
+    if depth > max_depth:
+        return []
+    indent = "  " * depth
+    lines = [f"{indent}- {root.name}/" if root.is_dir() else f"{indent}- {root.name}"]
+    if root.is_file() or depth == max_depth:
+        return lines
+    children = [child for child in sorted(root.iterdir()) if not _should_skip(child)]
+    for child in children:
+        lines.extend(_tree_lines(child, max_depth=max_depth, depth=depth + 1))
+    return lines
+
+
+def build_repository_map(root: Path, *, max_depth: int = 3) -> str:
+    """Return a Markdown repository map."""
+
+    sections = []
+    for name in ("src", "tests", "scripts", "docs", "integrations"):
+        target = root / name
+        if target.exists():
+            sections.append(
+                f"## {name}\n\n" + "\n".join(_tree_lines(target, max_depth=max_depth))
+            )
+    header = "# Repository Map\n\nGenerated from the current checkout.\n"
+    return header + "\n\n".join(sections) + "\n"
+
+
+def write_repository_map(path: Path, *, root: Path, max_depth: int = 3) -> Path:
+    """Write the repository map to disk."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(build_repository_map(root, max_depth=max_depth), encoding="utf-8")
+    return path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate docs/repository-map.md")
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--output", default="docs/repository-map.md")
+    parser.add_argument("--max-depth", type=int, default=3)
+    args = parser.parse_args()
+    root = Path(args.root).expanduser().resolve()
+    output = Path(args.output).expanduser().resolve()
+    write_repository_map(output, root=root, max_depth=args.max_depth)
+    print(f"Wrote repository map to {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repo/check_active_dependency_surface.py
+++ b/scripts/repo/check_active_dependency_surface.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Inspect the active dependency surface for obvious drift and duplicates."""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+
+def _parse_requirements(path: Path) -> dict[str, Requirement]:
+    result: dict[str, Requirement] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith(("-c", "-r", "-e")):
+            continue
+        requirement = Requirement(line)
+        result[canonicalize_name(requirement.name)] = requirement
+    return result
+
+
+def _load_pyproject(path: Path) -> dict[str, Requirement]:
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    dependencies: list[str] = list(data.get("project", {}).get("dependencies", []))
+    optional = data.get("project", {}).get("optional-dependencies", {})
+    for values in optional.values():
+        dependencies.extend(values)
+    result: dict[str, Requirement] = {}
+    for value in dependencies:
+        requirement = Requirement(value)
+        result[canonicalize_name(requirement.name)] = requirement
+    return result
+
+
+def main() -> int:
+    pyproject = _load_pyproject(Path("pyproject.toml"))
+    requirements = _parse_requirements(Path("requirements.txt"))
+    constraints = _parse_requirements(Path("constraints.txt"))
+
+    missing_from_requirements = sorted(
+        name for name in pyproject if name not in requirements
+    )
+    missing_from_constraints = sorted(
+        name
+        for name in pyproject
+        if name not in constraints and name not in requirements
+    )
+    orphan_requirements = sorted(
+        name
+        for name in requirements
+        if name not in pyproject and name not in constraints
+    )
+
+    if missing_from_requirements or missing_from_constraints or orphan_requirements:
+        if missing_from_requirements:
+            print("Direct pyproject dependencies missing from requirements.txt:")
+            for name in missing_from_requirements:
+                print(f"  - {name}")
+        if missing_from_constraints:
+            print(
+                "Direct pyproject dependencies missing from both requirements and constraints:"
+            )
+            for name in missing_from_constraints:
+                print(f"  - {name}")
+        if orphan_requirements:
+            print(
+                "Requirement pins with no matching direct or constrained declaration:"
+            )
+            for name in orphan_requirements:
+                print(f"  - {name}")
+        return 1
+
+    print("Active dependency surface check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repo/check_archived_dependency_snapshots.py
+++ b/scripts/repo/check_archived_dependency_snapshots.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Validate archived dependency snapshots used for provenance and recovery."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    snapshots_dir = Path("archives") / "dependency-snapshots"
+    if not snapshots_dir.is_dir():
+        print(f"Archived dependency snapshot directory is missing: {snapshots_dir}")
+        return 1
+
+    snapshot_files = sorted(snapshots_dir.glob("*.pip-snapshot"))
+    pip_check_files = sorted(snapshots_dir.glob("*pip-check*.txt"))
+
+    if not snapshot_files or not pip_check_files:
+        print("Archived dependency snapshots are incomplete.")
+        print(f"  pip snapshots: {len(snapshot_files)}")
+        print(f"  pip check reports: {len(pip_check_files)}")
+        return 1
+
+    print(
+        "Archived dependency snapshots check passed "
+        f"({len(snapshot_files)} snapshots, {len(pip_check_files)} pip-check reports)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_command_center.py
+++ b/scripts/run_command_center.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Launch the HueyOS Command Center backend."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from huey.apps.command_center.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/huey/__init__.py
+++ b/src/huey/__init__.py
@@ -12,15 +12,22 @@ from typing import Any
 
 _CORE_MODULES = (
     "api",
+    "apps",
+    "audio",
     "cli",
     "config",
     "exceptions",
     "function_registry",
+    "gui",
+    "integrations",
+    "media",
+    "runtime",
     "pdf_utils",
     "pyhuey_integration",
     "pygpt_integration",
     "run",
     "utils",
+    "v1",
     "memory",
 )
 

--- a/src/huey/apps/__init__.py
+++ b/src/huey/apps/__init__.py
@@ -1,0 +1,1 @@
+"""Application surfaces exposed by HueyOS."""

--- a/src/huey/apps/command_center/__init__.py
+++ b/src/huey/apps/command_center/__init__.py
@@ -1,0 +1,6 @@
+"""Read-only Command Center backend package."""
+
+from huey.apps.command_center.cli import main
+from huey.apps.command_center.server import create_app
+
+__all__ = ["create_app", "main"]

--- a/src/huey/apps/command_center/cli.py
+++ b/src/huey/apps/command_center/cli.py
@@ -1,0 +1,53 @@
+"""CLI launcher for the read-only Command Center backend."""
+
+from __future__ import annotations
+
+import argparse
+import threading
+import webbrowser
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse Command Center CLI arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Run the HueyOS Command Center backend"
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=1996)
+    parser.add_argument("--reload", action="store_true")
+    parser.add_argument("--open", action="store_true", dest="open_browser")
+    return parser.parse_args(argv)
+
+
+def open_browser(url: str) -> None:
+    """Open the default browser to the local Command Center URL."""
+
+    webbrowser.open(url)
+
+
+def run_server(host: str, port: int, reload: bool = False) -> None:
+    """Run uvicorn with the Command Center backend."""
+
+    import uvicorn
+
+    uvicorn.run(
+        "huey.apps.command_center.server:app",
+        host=host,
+        port=port,
+        reload=reload,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Command entry point."""
+
+    args = parse_args(argv)
+    url = f"http://{args.host}:{args.port}/command-center/meta"
+    if args.open_browser:
+        threading.Timer(1.0, open_browser, args=(url,)).start()
+    run_server(args.host, args.port, reload=args.reload)
+    return 0
+
+
+__all__ = ["main", "open_browser", "parse_args", "run_server"]

--- a/src/huey/apps/command_center/server.py
+++ b/src/huey/apps/command_center/server.py
@@ -1,0 +1,196 @@
+"""Read-only FastAPI backend for the external Command Center frontend."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    from fastapi import FastAPI, HTTPException
+except ModuleNotFoundError:
+    vendor_root = Path(__file__).resolve().parents[4] / "vendor"
+    if str(vendor_root) not in sys.path:
+        sys.path.insert(0, str(vendor_root))
+    from fastapi import FastAPI, HTTPException
+
+from huey.apps.command_center.static_config import export_frontend_config
+from huey.gui.defaults import default_migration_phases, default_operator_panel_state
+from huey.gui.models import dataclass_list_to_dicts, dataclass_to_dict
+from huey.gui.prompts import generate_next_best_task_prompt, generate_phase_prompt
+from huey.gui.safety import safety_banner
+from huey.gui.v1_runs import sample_v1_runs
+from huey.gui.validation import all_validation_commands
+from huey.integrations.command_center.adapter import (
+    get_api_status,
+    get_memory_status,
+    get_repo_status,
+    get_runtime_status,
+    get_v1_status,
+)
+
+APP_VERSION = "0.3.0"
+
+
+def get_app_metadata() -> dict[str, object]:
+    """Return metadata about the local Command Center backend."""
+
+    return {
+        "name": "HueyOS Command Center Backend",
+        "version": APP_VERSION,
+        "mode": "read-only",
+        "safety_mode": "mock-only",
+        "config": export_frontend_config(),
+    }
+
+
+def get_repositories() -> list[dict[str, object]]:
+    """Return repository status cards."""
+
+    return get_repo_status()
+
+
+def get_migration_phases() -> list[dict[str, object]]:
+    """Return migration phase data."""
+
+    return dataclass_list_to_dicts(default_migration_phases())
+
+
+def get_validation_commands() -> list[dict[str, object]]:
+    """Return copy-only validation commands."""
+
+    return dataclass_list_to_dicts(all_validation_commands())
+
+
+def get_operator_panel_state() -> dict[str, object]:
+    """Return the safe operator-panel state."""
+
+    panel = default_operator_panel_state()
+    runtime_status = get_runtime_status()
+    api_status = get_api_status()
+    services = runtime_status.get("services", {})
+    ffmpeg_service = services.get("ffmpeg", {})
+    pyhuey_service = services.get("pyhuey", {})
+    panel.health_status = "ok" if api_status.get("ready") else "degraded"
+    panel.runtime_status = "active" if runtime_status.get("started") else "standby"
+    panel.ffmpeg_status = str(ffmpeg_service.get("status", panel.ffmpeg_status))
+    panel.connector_status = str(pyhuey_service.get("status", panel.connector_status))
+    panel.v1_status = "fixture-ready" if sample_v1_runs() else "mock"
+    return dataclass_to_dict(panel)
+
+
+def get_v1_sample_runs() -> list[dict[str, object]]:
+    """Return sample V1 run records."""
+
+    return dataclass_list_to_dicts(sample_v1_runs())
+
+
+def get_safety_policy() -> dict[str, object]:
+    """Return the safety policy banner."""
+
+    return safety_banner()
+
+
+def get_state_payload() -> dict[str, object]:
+    """Return a consolidated Command Center state payload."""
+
+    return {
+        "meta": get_app_metadata(),
+        "safety": get_safety_policy(),
+        "repos": get_repositories(),
+        "phases": get_migration_phases(),
+        "validation": get_validation_commands(),
+        "operator_panel": get_operator_panel_state(),
+        "runtime": get_runtime_status(),
+        "memory": get_memory_status(),
+        "api": get_api_status(),
+        "v1": get_v1_status(),
+        "next_prompt": generate_next_best_task_prompt(default_migration_phases()),
+    }
+
+
+def register_routes(app: FastAPI) -> None:
+    """Attach all Command Center routes."""
+
+    @app.get("/command-center/meta")
+    def command_center_meta() -> dict[str, object]:
+        return get_app_metadata()
+
+    @app.get("/command-center/safety")
+    def command_center_safety() -> dict[str, object]:
+        return get_safety_policy()
+
+    @app.get("/command-center/repos")
+    def command_center_repos() -> list[dict[str, object]]:
+        return get_repositories()
+
+    @app.get("/command-center/phases")
+    def command_center_phases() -> list[dict[str, object]]:
+        return get_migration_phases()
+
+    @app.get("/command-center/validation")
+    def command_center_validation() -> list[dict[str, object]]:
+        return get_validation_commands()
+
+    @app.get("/command-center/operator-panel")
+    def command_center_operator_panel() -> dict[str, object]:
+        return get_operator_panel_state()
+
+    @app.get("/command-center/v1-runs/sample")
+    def command_center_v1_runs() -> list[dict[str, object]]:
+        return get_v1_sample_runs()
+
+    @app.get("/command-center/runtime")
+    def command_center_runtime() -> dict[str, object]:
+        return get_runtime_status()
+
+    @app.get("/command-center/memory")
+    def command_center_memory() -> dict[str, object]:
+        return get_memory_status()
+
+    @app.get("/command-center/api-status")
+    def command_center_api_status() -> dict[str, object]:
+        return get_api_status()
+
+    @app.get("/command-center/state")
+    def command_center_state() -> dict[str, object]:
+        return get_state_payload()
+
+    @app.get("/command-center/prompts/phase/{phase_id}")
+    def command_center_phase_prompt(phase_id: str) -> dict[str, str]:
+        for phase in default_migration_phases():
+            if phase.id == phase_id:
+                return {"phase_id": phase_id, "prompt": generate_phase_prompt(phase)}
+        raise HTTPException(status_code=404, detail=f"Unknown phase id: {phase_id}")
+
+
+def create_app() -> FastAPI:
+    """Create the read-only Command Center backend application."""
+
+    app = FastAPI(
+        title="HueyOS Command Center Backend",
+        version=APP_VERSION,
+        description=(
+            "Read-only local backend that unifies HueyOS runtime, memory, V1, "
+            "validation, and repository status for the separate Command Center UI."
+        ),
+    )
+    register_routes(app)
+    return app
+
+
+app = create_app()
+
+
+__all__ = [
+    "app",
+    "create_app",
+    "get_app_metadata",
+    "get_migration_phases",
+    "get_operator_panel_state",
+    "get_repositories",
+    "get_safety_policy",
+    "get_state_payload",
+    "get_v1_sample_runs",
+    "get_validation_commands",
+    "register_routes",
+]

--- a/src/huey/apps/command_center/static_config.py
+++ b/src/huey/apps/command_center/static_config.py
@@ -1,0 +1,36 @@
+"""Frontend/backend connection settings for Command Center."""
+
+from __future__ import annotations
+
+import os
+
+
+def default_backend_url() -> str:
+    """Return the default local backend URL."""
+
+    return os.environ.get("HUEY_COMMAND_CENTER_BACKEND", "http://127.0.0.1:1996")
+
+
+def command_center_frontend_url() -> str:
+    """Return the configured frontend URL or repository landing page."""
+
+    return os.environ.get(
+        "HUEY_COMMAND_CENTER_FRONTEND",
+        "https://github.com/DylanLRPollock/command-center",
+    )
+
+
+def export_frontend_config() -> dict[str, str]:
+    """Return a JSON-safe frontend configuration payload."""
+
+    return {
+        "backend_url": default_backend_url(),
+        "frontend_url": command_center_frontend_url(),
+    }
+
+
+__all__ = [
+    "command_center_frontend_url",
+    "default_backend_url",
+    "export_frontend_config",
+]

--- a/src/huey/audio/__init__.py
+++ b/src/huey/audio/__init__.py
@@ -1,0 +1,29 @@
+"""Audio analysis and transcription helpers for HueyOS."""
+
+from huey.audio.audio_analysis import (
+    bitrate,
+    channels,
+    duration,
+    peak_level,
+    rms_level,
+    sample_rate,
+    silence_map,
+)
+from huey.audio.transcription_pipeline import (
+    batch_transcribe,
+    transcribe,
+    transcription_metadata,
+)
+
+__all__ = [
+    "batch_transcribe",
+    "bitrate",
+    "channels",
+    "duration",
+    "peak_level",
+    "rms_level",
+    "sample_rate",
+    "silence_map",
+    "transcribe",
+    "transcription_metadata",
+]

--- a/src/huey/audio/audio_analysis.py
+++ b/src/huey/audio/audio_analysis.py
@@ -1,0 +1,105 @@
+"""Audio inspection helpers built on top of the FFmpeg media subsystem."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+from huey.media.ffmpeg_validator import check_ffmpeg
+from huey.media.media_manager import detect_silence, probe_media
+
+
+def _audio_stream(source: str | Path) -> dict[str, object]:
+    payload = probe_media(source)
+    for stream in payload.get("streams", []):
+        if stream.get("codec_type") == "audio":
+            return dict(stream)
+    return {}
+
+
+def duration(source: str | Path) -> float:
+    """Return audio duration in seconds."""
+
+    payload = probe_media(source)
+    return float(payload.get("format", {}).get("duration", 0.0))
+
+
+def bitrate(source: str | Path) -> int:
+    """Return audio bitrate in bits per second."""
+
+    stream = _audio_stream(source)
+    raw_value = stream.get("bit_rate") or probe_media(source).get("format", {}).get(
+        "bit_rate", 0
+    )
+    return int(float(raw_value or 0))
+
+
+def sample_rate(source: str | Path) -> int:
+    """Return audio sample rate."""
+
+    return int(float(_audio_stream(source).get("sample_rate", 0)))
+
+
+def channels(source: str | Path) -> int:
+    """Return the number of audio channels."""
+
+    return int(_audio_stream(source).get("channels", 0))
+
+
+def _volumedetect(source: str | Path) -> dict[str, float]:
+    if not check_ffmpeg():
+        raise RuntimeError("ffmpeg is not available on PATH")
+    result = subprocess.run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-i",
+            str(Path(source).expanduser().resolve()),
+            "-af",
+            "volumedetect",
+            "-f",
+            "null",
+            "-",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    mean_match = re.search(r"mean_volume:\s*(-?[0-9.]+) dB", result.stderr or "")
+    peak_match = re.search(r"max_volume:\s*(-?[0-9.]+) dB", result.stderr or "")
+    return {
+        "mean_volume": float(mean_match.group(1)) if mean_match else 0.0,
+        "max_volume": float(peak_match.group(1)) if peak_match else 0.0,
+    }
+
+
+def peak_level(source: str | Path) -> float:
+    """Return the detected peak level in dB."""
+
+    return _volumedetect(source)["max_volume"]
+
+
+def rms_level(source: str | Path) -> float:
+    """Return the mean/RMS volume in dB."""
+
+    return _volumedetect(source)["mean_volume"]
+
+
+def silence_map(source: str | Path) -> list[dict[str, float]]:
+    """Return silence segments detected in the audio."""
+
+    return detect_silence(source)
+
+
+__all__ = [
+    "bitrate",
+    "channels",
+    "duration",
+    "peak_level",
+    "rms_level",
+    "sample_rate",
+    "silence_map",
+]

--- a/src/huey/audio/transcription_pipeline.py
+++ b/src/huey/audio/transcription_pipeline.py
@@ -1,0 +1,137 @@
+"""Transcription helpers that connect FFmpeg preprocessing to speech models."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from huey.media.speech_pipeline import prepare_for_whisper
+from huey.utils.paths import ensure_subdirectory
+
+Transcriber = Callable[[str], dict[str, object] | str]
+
+
+def _default_prepared_path(source: str | Path) -> Path:
+    prepared_dir = ensure_subdirectory("AUDIO", "prepared")
+    src = Path(source).expanduser().resolve()
+    return prepared_dir / f"{src.stem}.whisper.wav"
+
+
+def transcribe(
+    source: str | Path,
+    *,
+    transcriber: Transcriber | None = None,
+    model_name: str = "small.en",
+    language: str = "en",
+    prepare_audio: bool = True,
+    mock: bool = False,
+) -> dict[str, object]:
+    """Transcribe audio through an injected or local Whisper-compatible backend."""
+
+    source_path = Path(source).expanduser().resolve()
+    if mock and transcriber is None:
+        prepared_path = source_path
+    else:
+        prepared_path = (
+            prepare_for_whisper(
+                source_path,
+                output_path=_default_prepared_path(source_path),
+            )
+            if prepare_audio
+            else source_path
+        )
+
+    if transcriber is not None:
+        result = transcriber(str(prepared_path))
+        if isinstance(result, dict):
+            payload = dict(result)
+        else:
+            payload = {"transcript": str(result)}
+        payload.setdefault("transcription_engine", "custom")
+        payload.setdefault("transcription_model", model_name)
+        payload.setdefault("language", language)
+        payload["source_file"] = str(source_path)
+        payload["prepared_file"] = str(prepared_path)
+        return payload
+
+    if mock:
+        return {
+            "source_file": str(source_path),
+            "prepared_file": str(prepared_path),
+            "transcript": f"Mock transcript for {source_path.name}",
+            "segments": [],
+            "language": language,
+            "transcription_engine": "mock-transcriber",
+            "transcription_model": model_name,
+        }
+
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError as exc:
+        raise RuntimeError(
+            "faster_whisper is not installed; pass a custom transcriber or mock=True"
+        ) from exc
+
+    model = WhisperModel(model_name, device="auto", compute_type="int8")
+    segments, info = model.transcribe(str(prepared_path), language=language)
+    collected_segments = []
+    transcript_parts: list[str] = []
+    for segment in segments:
+        segment_payload = {
+            "start": float(segment.start),
+            "end": float(segment.end),
+            "text": segment.text.strip(),
+        }
+        collected_segments.append(segment_payload)
+        transcript_parts.append(segment_payload["text"])
+    return {
+        "source_file": str(source_path),
+        "prepared_file": str(prepared_path),
+        "transcript": " ".join(part for part in transcript_parts if part),
+        "segments": collected_segments,
+        "language": getattr(info, "language", language),
+        "duration": getattr(info, "duration", None),
+        "transcription_engine": "faster-whisper",
+        "transcription_model": model_name,
+    }
+
+
+def batch_transcribe(
+    sources: list[str | Path],
+    *,
+    transcriber: Transcriber | None = None,
+    model_name: str = "small.en",
+    language: str = "en",
+    prepare_audio: bool = True,
+    mock: bool = False,
+) -> list[dict[str, object]]:
+    """Transcribe multiple audio fixtures."""
+
+    return [
+        transcribe(
+            source,
+            transcriber=transcriber,
+            model_name=model_name,
+            language=language,
+            prepare_audio=prepare_audio,
+            mock=mock,
+        )
+        for source in sources
+    ]
+
+
+def transcription_metadata(payload: dict[str, object]) -> dict[str, object]:
+    """Return a stable metadata subset for a transcription result."""
+
+    return {
+        "source_file": payload.get("source_file"),
+        "prepared_file": payload.get("prepared_file"),
+        "language": payload.get("language"),
+        "transcription_engine": payload.get("transcription_engine"),
+        "transcription_model": payload.get("transcription_model"),
+        "duration": payload.get("duration"),
+        "segment_count": len(payload.get("segments", [])),
+    }
+
+
+__all__ = ["batch_transcribe", "transcribe", "transcription_metadata"]

--- a/src/huey/cli.py
+++ b/src/huey/cli.py
@@ -8,15 +8,12 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from typing import Iterable, Optional
 
 from .memory.PY import cli as _cli
 
-# NOTE(v101.1-migration): Compatibility wrapper while canonical
-# implementation remains under ``src/huey/memory/PY``.
-main = _cli.main
-
-__all__ = ["main", "parse_arguments", "run_cli", "huey_main"]
+__all__ = ["main", "parse_arguments", "run_cli", "huey_main", "run_command_center"]
 
 
 def parse_arguments(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
@@ -44,8 +41,25 @@ def huey_main(config_file: str = "config.yaml") -> None:
     )
 
 
+def run_command_center(argv: list[str] | None = None) -> int:
+    """Delegate to the read-only Command Center backend launcher."""
+
+    from huey.apps.command_center.cli import main as command_center_main
+
+    return command_center_main(argv)
+
+
 def run_cli(argv: Optional[Iterable[str]] = None) -> None:
     """Invoke the legacy CLI with parsed arguments."""
 
     args = parse_arguments(argv)
     huey_main(config_file=args.config)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    """Route the Command Center subcommand before falling back to the main CLI."""
+
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if args and args[0] in {"command-center", "command_center", "gui"}:
+        return run_command_center(args[1:])
+    return _cli.main(args)

--- a/src/huey/connectors/pyhuey/__init__.py
+++ b/src/huey/connectors/pyhuey/__init__.py
@@ -13,7 +13,14 @@ import os
 from pathlib import Path
 from typing import Final
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "get_status",
+    "launch_pyhuey",
+    "receive_event",
+    "send_event",
+    "shutdown_pyhuey",
+]
 
 __version__ = "2.6.67"
 
@@ -54,3 +61,11 @@ def _ensure_private_nltk_data() -> None:
 
 
 _ensure_private_nltk_data()
+
+from .adapter import (
+    get_status,
+    launch_pyhuey,
+    receive_event,
+    send_event,
+    shutdown_pyhuey,
+)

--- a/src/huey/connectors/pyhuey/adapter.py
+++ b/src/huey/connectors/pyhuey/adapter.py
@@ -1,0 +1,73 @@
+"""Lightweight integration adapter for the vendored PyHuey surface."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable
+
+from huey.pygpt_integration import pyhuey_status
+
+from .app import run as run_app
+
+_EVENT_QUEUE: deque[dict[str, object]] = deque()
+_RUNNING = False
+
+
+def launch_pyhuey(*, tools: Iterable[object] | None = None) -> dict[str, object]:
+    """Launch the PyHuey surface with optional HueyOS tools."""
+
+    global _RUNNING
+    run_app(tools=tools)
+    _RUNNING = True
+    return get_status()
+
+
+def shutdown_pyhuey() -> dict[str, object]:
+    """Mark the PyHuey adapter as stopped."""
+
+    global _RUNNING
+    _RUNNING = False
+    return get_status()
+
+
+def send_event(
+    event_type: str, payload: dict[str, object] | None = None
+) -> dict[str, object]:
+    """Queue an event for the PyHuey integration surface."""
+
+    event = {"event_type": event_type, "payload": dict(payload or {})}
+    _EVENT_QUEUE.append(event)
+    return event
+
+
+def receive_event() -> dict[str, object] | None:
+    """Receive the next queued PyHuey event if one exists."""
+
+    if not _EVENT_QUEUE:
+        return None
+    return _EVENT_QUEUE.popleft()
+
+
+def get_status() -> dict[str, object]:
+    """Return adapter and discovery status for PyHuey integration."""
+
+    payload = dict(pyhuey_status())
+    payload.update(
+        {
+            "running": _RUNNING,
+            "queued_events": len(_EVENT_QUEUE),
+            "ready": bool(payload.get("prepared")),
+        }
+    )
+    if _EVENT_QUEUE:
+        payload["last_event"] = _EVENT_QUEUE[-1]
+    return payload
+
+
+__all__ = [
+    "get_status",
+    "launch_pyhuey",
+    "receive_event",
+    "send_event",
+    "shutdown_pyhuey",
+]

--- a/src/huey/gui/__init__.py
+++ b/src/huey/gui/__init__.py
@@ -1,0 +1,41 @@
+"""Canonical GUI helpers shared across HueyOS surfaces."""
+
+from huey.gui.events import Event, EventBus, EventType
+from huey.gui.models import (
+    MigrationPhase,
+    OperatorPanelState,
+    RepoStatus,
+    V1RunRecord,
+    ValidationCommand,
+)
+from huey.gui.safety import SafetyPolicy, is_dangerous_action
+from huey.gui.state import (
+    HueyState,
+    MemoryState,
+    OperatorState,
+    RepositoryState,
+    RuntimeState,
+    build_default_state,
+)
+from huey.gui.theme import HueyTheme, get_default_theme
+
+__all__ = [
+    "HueyTheme",
+    "get_default_theme",
+    "RepoStatus",
+    "MigrationPhase",
+    "ValidationCommand",
+    "V1RunRecord",
+    "OperatorPanelState",
+    "SafetyPolicy",
+    "is_dangerous_action",
+    "EventType",
+    "Event",
+    "EventBus",
+    "HueyState",
+    "OperatorState",
+    "RuntimeState",
+    "MemoryState",
+    "RepositoryState",
+    "build_default_state",
+]

--- a/src/huey/gui/defaults.py
+++ b/src/huey/gui/defaults.py
@@ -1,0 +1,163 @@
+"""Default mock and local data for GUI-oriented surfaces."""
+
+from __future__ import annotations
+
+from huey.gui.models import (
+    MigrationPhase,
+    OperatorPanelState,
+    RepoStatus,
+    ValidationCommand,
+)
+
+
+def default_repositories() -> list[RepoStatus]:
+    """Return default Monkey-Head-Project umbrella repo cards."""
+
+    return [
+        RepoStatus(
+            name="Monkey-Head-Project",
+            full_name="DylanLRPollock/Monkey-Head-Project",
+            role="runtime",
+            description="Canonical HueyOS runtime, memory, API, and tooling repository.",
+            url="https://github.com/DylanLRPollock/Monkey-Head-Project",
+            data_mode="mock",
+        ),
+        RepoStatus(
+            name="PyHuey",
+            full_name="DylanLRPollock/PyHuey",
+            role="cockpit",
+            description="Cockpit-side UI and future operator surface integration repo.",
+            url="https://github.com/DylanLRPollock/PyHuey",
+            data_mode="mock",
+        ),
+        RepoStatus(
+            name="command-center",
+            full_name="DylanLRPollock/command-center",
+            role="dashboard",
+            description="Separate frontend repo for the read-only Command Center operator UI.",
+            url="https://github.com/DylanLRPollock/command-center",
+            data_mode="mock",
+        ),
+        RepoStatus(
+            name="dlrp.ca",
+            full_name="DylanLRPollock/dlrp.ca",
+            role="website",
+            description="Website and outward-facing documentation surface for the project.",
+            url="https://github.com/DylanLRPollock/dlrp.ca",
+            data_mode="mock",
+        ),
+    ]
+
+
+def default_migration_phases() -> list[MigrationPhase]:
+    """Return canonical current migration phases."""
+
+    return [
+        MigrationPhase(
+            id="phase-1-layout",
+            title="Lock repository layout and package boundaries",
+            target_repo="DylanLRPollock/Monkey-Head-Project",
+            status="merged",
+            risk="low",
+            notes="Compatibility shims are in place and the canonical src layout is active.",
+            checklist=[
+                "Preserve the existing memory tree.",
+                "Keep legacy import bridges operational.",
+            ],
+        ),
+        MigrationPhase(
+            id="phase-2-huey-os-canonical",
+            title="Consolidate canonical HueyOS Python surfaces",
+            target_repo="DylanLRPollock/Monkey-Head-Project",
+            status="in_progress",
+            risk="high",
+            owner="Copilot",
+            checklist=[
+                "Unify GUI theme, state, and validation metadata.",
+                "Add runtime orchestration and FFmpeg media helpers.",
+                "Expose safe integration adapters for Command Center.",
+            ],
+            validation_commands=[
+                "python scripts/repo/check_dependency_sync.py",
+                "python scripts/check_command_center_contract.py",
+                "python -m pytest -q tests/test_command_center_backend.py",
+            ],
+        ),
+        MigrationPhase(
+            id="phase-2-5-pyhuey-connector",
+            title="Reconcile PyHuey connector integration",
+            target_repo="DylanLRPollock/Monkey-Head-Project",
+            status="in_progress",
+            risk="medium",
+            checklist=[
+                "Detect local/vendored PyHuey sources.",
+                "Expose adapter status and event forwarding hooks.",
+                "Keep the cockpit surface opt-in and local-only.",
+            ],
+        ),
+        MigrationPhase(
+            id="phase-3-pyhuey-rename",
+            title="Prepare PyHuey naming and repo alignment",
+            target_repo="DylanLRPollock/PyHuey",
+            status="not_started",
+            risk="high",
+            checklist=[
+                "Document compatibility boundaries before any rename.",
+                "Preserve import compatibility for shipped tooling.",
+            ],
+        ),
+        MigrationPhase(
+            id="phase-4-remove-compat-shims",
+            title="Retire temporary compatibility shims",
+            target_repo="DylanLRPollock/Monkey-Head-Project",
+            status="not_started",
+            risk="high",
+            blockers=[
+                "Wait until Command Center, runtime, and PyHuey adapters stabilize."
+            ],
+        ),
+        MigrationPhase(
+            id="phase-5-v1-run-dashboard",
+            title="Surface V1 proof-loop status in the dashboard",
+            target_repo="DylanLRPollock/command-center",
+            status="in_progress",
+            risk="medium",
+            checklist=[
+                "Normalize structured run logs.",
+                "Expose copy-only prompts and reviewer checklists.",
+                "Provide safe sample runs to the frontend.",
+            ],
+        ),
+    ]
+
+
+def default_validation_commands() -> list[ValidationCommand]:
+    """Return copy-only validation commands grouped by repo."""
+
+    from huey.gui.validation import all_validation_commands
+
+    return all_validation_commands()
+
+
+def default_operator_panel_state() -> OperatorPanelState:
+    """Return safe mock operator-panel state."""
+
+    return OperatorPanelState(
+        api_url="http://127.0.0.1:1995",
+        health_status="read-only",
+        memory_status="local",
+        governance_status="documentation-only",
+        connector_status="partial",
+        runtime_status="standby",
+        ffmpeg_status="unknown",
+        v1_status="fixture-ready",
+        mock_only=True,
+    )
+
+
+__all__ = [
+    "default_migration_phases",
+    "default_operator_panel_state",
+    "default_repositories",
+    "default_validation_commands",
+]

--- a/src/huey/gui/events.py
+++ b/src/huey/gui/events.py
@@ -1,0 +1,87 @@
+"""Small event bus used by GUI-facing Python components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Callable
+from uuid import uuid4
+
+EventCallback = Callable[["Event"], None]
+
+
+def _utc_now() -> str:
+    return datetime.now(tz=UTC).isoformat()
+
+
+class EventType(StrEnum):
+    MEMORY_UPDATED = "memory_updated"
+    TRANSCRIPTION_COMPLETE = "transcription_complete"
+    RUN_STARTED = "run_started"
+    RUN_FINISHED = "run_finished"
+    API_CONNECTED = "api_connected"
+    MODEL_CHANGED = "model_changed"
+    REPOSITORY_CHANGED = "repository_changed"
+
+
+@dataclass(frozen=True)
+class Event:
+    event_type: EventType
+    payload: dict[str, object] = field(default_factory=dict)
+    source: str = ""
+    timestamp: str = field(default_factory=_utc_now)
+    event_id: str = field(default_factory=lambda: uuid4().hex)
+
+
+class EventBus:
+    """In-process publish/subscribe event bus for GUI state sharing."""
+
+    def __init__(self) -> None:
+        self._subscribers: dict[EventType, list[EventCallback]] = {
+            event_type: [] for event_type in EventType
+        }
+        self._history: list[Event] = []
+
+    def subscribe(self, event_type: EventType | str, callback: EventCallback) -> None:
+        self._subscribers[self._normalise(event_type)].append(callback)
+
+    def unsubscribe(self, event_type: EventType | str, callback: EventCallback) -> None:
+        subscribers = self._subscribers[self._normalise(event_type)]
+        if callback in subscribers:
+            subscribers.remove(callback)
+
+    def emit(
+        self,
+        event_type: Event | EventType | str,
+        payload: dict[str, object] | None = None,
+        *,
+        source: str = "",
+    ) -> Event:
+        if isinstance(event_type, Event):
+            event = event_type
+        else:
+            event = Event(
+                event_type=self._normalise(event_type),
+                payload=dict(payload or {}),
+                source=source,
+            )
+        self._history.append(event)
+        for callback in list(self._subscribers[event.event_type]):
+            callback(event)
+        return event
+
+    def history(self, event_type: EventType | str | None = None) -> list[Event]:
+        if event_type is None:
+            return list(self._history)
+        selected = self._normalise(event_type)
+        return [event for event in self._history if event.event_type == selected]
+
+    @staticmethod
+    def _normalise(event_type: EventType | str) -> EventType:
+        if isinstance(event_type, EventType):
+            return event_type
+        return EventType(event_type.strip().lower())
+
+
+__all__ = ["Event", "EventBus", "EventType"]

--- a/src/huey/gui/github_client.py
+++ b/src/huey/gui/github_client.py
@@ -1,0 +1,147 @@
+"""Read-only GitHub API helpers for dashboard and operator surfaces."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import requests
+
+from huey.gui.models import RepoStatus
+
+
+@dataclass(frozen=True)
+class GitHubClientConfig:
+    token: str | None = None
+    timeout_seconds: float = 10.0
+    user_agent: str = "HueyOS-Command-Center"
+
+
+class GitHubReadOnlyClient:
+    """Small read-only client for repository status surfaces."""
+
+    base_url = "https://api.github.com"
+
+    def __init__(self, config: GitHubClientConfig | None = None) -> None:
+        self.config = config or GitHubClientConfig()
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Accept": "application/vnd.github+json",
+                "User-Agent": self.config.user_agent,
+            }
+        )
+        if self.config.token:
+            self.session.headers["Authorization"] = f"Bearer {self.config.token}"
+
+    def get_repo(self, full_name: str) -> dict[str, object]:
+        """Fetch public repository metadata."""
+
+        return self._request(f"/repos/{full_name}")
+
+    def list_pull_requests(
+        self, full_name: str, state: str = "open"
+    ) -> list[dict[str, object]]:
+        """Fetch PR metadata."""
+
+        payload = self._request(f"/repos/{full_name}/pulls", params={"state": state})
+        return list(payload)
+
+    def list_issues(
+        self, full_name: str, state: str = "open"
+    ) -> list[dict[str, object]]:
+        """Fetch issues excluding pull requests."""
+
+        payload = self._request(f"/repos/{full_name}/issues", params={"state": state})
+        return [
+            item
+            for item in payload
+            if isinstance(item, dict) and "pull_request" not in item
+        ]
+
+    def list_workflow_runs(
+        self, full_name: str, branch: str | None = None
+    ) -> list[dict[str, object]]:
+        """Fetch recent workflow run metadata."""
+
+        params = {"per_page": 10}
+        if branch:
+            params["branch"] = branch
+        payload = self._request(
+            f"/repos/{full_name}/actions/runs",
+            params=params,
+        )
+        return list(payload.get("workflow_runs", []))
+
+    def get_latest_commit(
+        self, full_name: str, branch: str = "main"
+    ) -> dict[str, object]:
+        """Fetch the latest commit on a branch."""
+
+        payload = self._request(
+            f"/repos/{full_name}/commits",
+            params={"sha": branch, "per_page": 1},
+        )
+        if not payload:
+            return {}
+        return dict(payload[0])
+
+    def _request(
+        self, path: str, params: dict[str, object] | None = None
+    ) -> dict[str, object] | list[dict[str, object]]:
+        response = self.session.get(
+            f"{self.base_url}{path}",
+            params=params,
+            timeout=self.config.timeout_seconds,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def client_from_env() -> GitHubReadOnlyClient:
+    """Build a client using the optional ``GITHUB_TOKEN`` environment variable."""
+
+    return GitHubReadOnlyClient(
+        GitHubClientConfig(token=os.environ.get("GITHUB_TOKEN") or None)
+    )
+
+
+def summarize_repo_status(client: GitHubReadOnlyClient, full_name: str) -> RepoStatus:
+    """Convert GitHub API data into a ``RepoStatus`` record."""
+
+    repo = client.get_repo(full_name)
+    default_branch = str(repo.get("default_branch", "main"))
+    workflows = client.list_workflow_runs(full_name, branch=default_branch)
+    commit = client.get_latest_commit(full_name, branch=default_branch)
+    repo_name = full_name.rsplit("/", 1)[-1]
+    role = {
+        "Monkey-Head-Project": "runtime",
+        "PyHuey": "cockpit",
+        "command-center": "dashboard",
+        "dlrp.ca": "website",
+    }.get(repo_name, "tooling")
+    latest_workflow = workflows[0] if workflows else {}
+    return RepoStatus(
+        name=repo_name,
+        full_name=full_name,
+        role=role,  # type: ignore[arg-type]
+        description=str(repo.get("description") or ""),
+        default_branch=default_branch,
+        url=str(repo.get("html_url") or ""),
+        open_prs=len(client.list_pull_requests(full_name)),
+        open_issues=len(client.list_issues(full_name)),
+        latest_workflow_status=str(
+            latest_workflow.get("conclusion") or latest_workflow.get("status") or ""
+        )
+        or None,
+        latest_commit=str(commit.get("sha", ""))[:7] or None,
+        data_mode="live",
+    )
+
+
+__all__ = [
+    "GitHubClientConfig",
+    "GitHubReadOnlyClient",
+    "client_from_env",
+    "summarize_repo_status",
+]

--- a/src/huey/gui/legacy_adapters.py
+++ b/src/huey/gui/legacy_adapters.py
@@ -1,0 +1,53 @@
+"""Explicit adapters for legacy Tkinter GUI modules."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from importlib.util import find_spec
+
+
+def legacy_license_gui_available() -> bool:
+    """Return ``True`` if the legacy license GUI can be imported."""
+
+    return find_spec("huey.memory.PY.license_gui") is not None
+
+
+def legacy_ai_tools_gui_available() -> bool:
+    """Return ``True`` if the legacy AI tools GUI can be imported."""
+
+    return find_spec("huey.memory.PY.ai_tools_gui") is not None
+
+
+def launch_legacy_license_gui(config_path: str | None = None) -> None:
+    """Launch the legacy Tkinter license GUI explicitly."""
+
+    module = import_module("huey.memory.PY.license_gui")
+    if config_path is None:
+        module.show_license_gui()
+        return
+    module.show_license_gui(config_path)
+
+
+def launch_legacy_ai_tools_gui() -> None:
+    """Launch the legacy AI tools GUI explicitly."""
+
+    module = import_module("huey.memory.PY.ai_tools_gui")
+    module.run_ai_tools()
+
+
+def legacy_gui_status() -> dict[str, bool]:
+    """Return availability status for legacy GUI tools."""
+
+    return {
+        "license_gui": legacy_license_gui_available(),
+        "ai_tools_gui": legacy_ai_tools_gui_available(),
+    }
+
+
+__all__ = [
+    "launch_legacy_ai_tools_gui",
+    "launch_legacy_license_gui",
+    "legacy_ai_tools_gui_available",
+    "legacy_gui_status",
+    "legacy_license_gui_available",
+]

--- a/src/huey/gui/models.py
+++ b/src/huey/gui/models.py
@@ -1,0 +1,121 @@
+"""Shared dataclasses used by GUI and command-center surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+from typing import Literal
+
+PhaseStatus = Literal[
+    "not_started",
+    "in_progress",
+    "blocked",
+    "ready_for_pr",
+    "merged",
+]
+RiskLevel = Literal["low", "medium", "high", "critical"]
+RepoRole = Literal["runtime", "cockpit", "dashboard", "website", "tooling"]
+RunStatus = Literal["passed", "failed", "pending", "skipped"]
+DataMode = Literal["mock", "live", "local"]
+
+
+@dataclass
+class RepoStatus:
+    name: str
+    full_name: str
+    role: RepoRole
+    description: str
+    default_branch: str = "main"
+    url: str = ""
+    open_prs: int | None = None
+    open_issues: int | None = None
+    latest_workflow_status: str | None = None
+    latest_commit: str | None = None
+    data_mode: DataMode = "mock"
+
+
+@dataclass
+class MigrationPhase:
+    id: str
+    title: str
+    target_repo: str
+    status: PhaseStatus
+    risk: RiskLevel
+    owner: str = ""
+    branch: str = ""
+    pr_url: str = ""
+    checklist: list[str] = field(default_factory=list)
+    validation_commands: list[str] = field(default_factory=list)
+    notes: str = ""
+    blockers: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ValidationCommand:
+    id: str
+    repo: str
+    command: str
+    purpose: str
+    expected_result: str
+    risk: RiskLevel = "low"
+    phase_id: str | None = None
+    notes: str = ""
+    copy_only: bool = True
+
+
+@dataclass
+class V1RunRecord:
+    id: str
+    fixture: str
+    status: RunStatus
+    transcription_status: str = ""
+    cognition_status: str = ""
+    response_text: str = ""
+    error: str = ""
+    raw: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class OperatorPanelState:
+    api_url: str = "http://127.0.0.1:1995"
+    health_status: str = "unknown"
+    memory_status: str = "mock"
+    governance_status: str = "mock"
+    connector_status: str = "mock"
+    runtime_status: str = "standby"
+    ffmpeg_status: str = "unknown"
+    v1_status: str = "mock"
+    mock_only: bool = True
+
+
+def dataclass_to_dict(value: object) -> dict[str, object]:
+    """Convert a GUI dataclass to a JSON-safe dict."""
+
+    if is_dataclass(value):
+        return asdict(value)
+    if isinstance(value, dict):
+        return dict(value)
+    if hasattr(value, "model_dump"):
+        return dict(value.model_dump())
+    raise TypeError(f"Unsupported value for dataclass_to_dict: {type(value)!r}")
+
+
+def dataclass_list_to_dicts(values: list[object]) -> list[dict[str, object]]:
+    """Convert a list of GUI dataclasses to JSON-safe dicts."""
+
+    return [dataclass_to_dict(value) for value in values]
+
+
+__all__ = [
+    "DataMode",
+    "MigrationPhase",
+    "OperatorPanelState",
+    "PhaseStatus",
+    "RepoRole",
+    "RepoStatus",
+    "RiskLevel",
+    "RunStatus",
+    "V1RunRecord",
+    "ValidationCommand",
+    "dataclass_list_to_dicts",
+    "dataclass_to_dict",
+]

--- a/src/huey/gui/prompts.py
+++ b/src/huey/gui/prompts.py
@@ -1,0 +1,129 @@
+"""Prompt generators for migration phases and review flows."""
+
+from __future__ import annotations
+
+from huey.gui.defaults import default_migration_phases
+from huey.gui.models import MigrationPhase
+
+_STATUS_PRIORITY = {
+    "in_progress": 0,
+    "ready_for_pr": 1,
+    "not_started": 2,
+    "blocked": 3,
+    "merged": 4,
+}
+_RISK_PRIORITY = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+
+def generate_phase_prompt(phase: MigrationPhase) -> str:
+    """Generate a Copilot/task-agent prompt for a migration phase."""
+
+    checklist = (
+        "\n".join(f"- {item}" for item in phase.checklist) or "- No checklist yet."
+    )
+    blockers = (
+        "\n".join(f"- {item}" for item in phase.blockers) or "- No blockers recorded."
+    )
+    validation = (
+        "\n".join(f"- {item}" for item in phase.validation_commands)
+        or "- No validation commands recorded."
+    )
+    return (
+        f"Work phase: {phase.title}\n"
+        f"Target repository: {phase.target_repo}\n"
+        f"Current status: {phase.status}\n"
+        f"Risk: {phase.risk}\n\n"
+        f"Checklist:\n{checklist}\n\n"
+        f"Validation commands:\n{validation}\n\n"
+        f"Blockers:\n{blockers}\n\n"
+        "Implement the phase end-to-end, preserve compatibility, and keep all new "
+        "surfaces read-only unless the phase explicitly says otherwise."
+    )
+
+
+def generate_next_best_task_prompt(phases: list[MigrationPhase]) -> str:
+    """Pick the highest-priority unblocked phase and generate its prompt."""
+
+    candidates = [
+        phase for phase in phases if phase.status not in {"merged", "blocked"}
+    ]
+    if not candidates:
+        return "All current migration phases are merged or blocked."
+    selected = min(
+        candidates,
+        key=lambda phase: (
+            _STATUS_PRIORITY.get(phase.status, 99),
+            _RISK_PRIORITY.get(phase.risk, 99),
+            phase.id,
+        ),
+    )
+    return generate_phase_prompt(selected)
+
+
+def generate_pr_body(phase: MigrationPhase) -> str:
+    """Generate a PR body draft for the phase."""
+
+    checklist = "\n".join(f"- {item}" for item in phase.checklist) or "- No checklist"
+    validation = (
+        "\n".join(f"- `{item}`" for item in phase.validation_commands)
+        or "- No validation commands recorded"
+    )
+    return (
+        f"## Summary\n\n"
+        f"- Advance **{phase.title}** for `{phase.target_repo}`.\n"
+        f"- Keep the surface compatible while moving toward canonical HueyOS layers.\n\n"
+        f"## Checklist\n\n{checklist}\n\n"
+        f"## Validation\n\n{validation}\n"
+    )
+
+
+def generate_review_checklist(phase: MigrationPhase) -> str:
+    """Generate a reviewer checklist for the phase."""
+
+    items = list(phase.checklist) or [
+        "Review the changed code paths for compatibility."
+    ]
+    lines = [f"- [ ] {item}" for item in items]
+    if phase.validation_commands:
+        lines.extend(f"- [ ] Run `{command}`" for command in phase.validation_commands)
+    return "\n".join(lines)
+
+
+def _phase_by_id(phase_id: str) -> MigrationPhase:
+    for phase in default_migration_phases():
+        if phase.id == phase_id:
+            return phase
+    raise KeyError(f"Unknown phase id: {phase_id}")
+
+
+def phase_2_5_prompt() -> str:
+    """Prompt for PyHuey connector reconciliation in the Monkey repo."""
+
+    return generate_phase_prompt(_phase_by_id("phase-2-5-pyhuey-connector"))
+
+
+def phase_3_prompt() -> str:
+    """Prompt for the later PyHuey package rename phase."""
+
+    return generate_phase_prompt(_phase_by_id("phase-3-pyhuey-rename"))
+
+
+def dependency_security_prompt() -> str:
+    """Prompt for dependency and security refresh work."""
+
+    return (
+        "Audit the active dependency surface, archived snapshots, and direct pins. "
+        "Keep requirements.txt, constraints.txt, and pyproject.toml aligned while "
+        "preserving the current HueyOS runtime contract."
+    )
+
+
+__all__ = [
+    "dependency_security_prompt",
+    "generate_next_best_task_prompt",
+    "generate_phase_prompt",
+    "generate_pr_body",
+    "generate_review_checklist",
+    "phase_2_5_prompt",
+    "phase_3_prompt",
+]

--- a/src/huey/gui/safety.py
+++ b/src/huey/gui/safety.py
@@ -1,0 +1,85 @@
+"""Safety guardrails shared by GUI and command-center surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class SafetyPolicy:
+    mock_only: bool = True
+    allow_command_execution: bool = False
+    allow_memory_mutation: bool = False
+    allow_governance_mutation: bool = False
+    allow_network_mutation: bool = False
+    allow_power_actions: bool = False
+    allow_task_execution: bool = False
+
+
+DANGEROUS_ACTIONS = {
+    "shutdown",
+    "reboot",
+    "network_change",
+    "memory_mutation",
+    "governance_emergency",
+    "task_execution",
+    "shell_command",
+}
+
+_ACTION_TO_POLICY = {
+    "shutdown": "allow_power_actions",
+    "reboot": "allow_power_actions",
+    "network_change": "allow_network_mutation",
+    "memory_mutation": "allow_memory_mutation",
+    "governance_emergency": "allow_governance_mutation",
+    "task_execution": "allow_task_execution",
+    "shell_command": "allow_command_execution",
+}
+
+
+def default_safety_policy() -> SafetyPolicy:
+    """Return the default safe/mock-only GUI policy."""
+
+    return SafetyPolicy()
+
+
+def is_dangerous_action(action: str) -> bool:
+    """Return ``True`` when the action is dangerous in operator GUI context."""
+
+    return action.strip().lower() in DANGEROUS_ACTIONS
+
+
+def assert_action_allowed(action: str, policy: SafetyPolicy | None = None) -> None:
+    """Raise ``PermissionError`` if a GUI action is not allowed."""
+
+    normalised = action.strip().lower()
+    if not is_dangerous_action(normalised):
+        return
+
+    selected = policy or default_safety_policy()
+    flag_name = _ACTION_TO_POLICY.get(normalised)
+    if flag_name is None:
+        raise PermissionError(f"Action '{action}' is blocked by GUI safety policy")
+    if not getattr(selected, flag_name):
+        raise PermissionError(f"Action '{action}' is disabled in safe GUI mode")
+
+
+def safety_banner() -> dict[str, str | bool]:
+    """Return a JSON-safe safety status banner."""
+
+    policy = default_safety_policy()
+    banner = asdict(policy)
+    banner["summary"] = (
+        "Read-only safe mode: no command, task, memory, or power mutation."
+    )
+    return banner
+
+
+__all__ = [
+    "DANGEROUS_ACTIONS",
+    "SafetyPolicy",
+    "assert_action_allowed",
+    "default_safety_policy",
+    "is_dangerous_action",
+    "safety_banner",
+]

--- a/src/huey/gui/state.py
+++ b/src/huey/gui/state.py
@@ -1,0 +1,98 @@
+"""Shared GUI state containers for HueyOS surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from huey.gui.defaults import default_repositories
+from huey.gui.events import Event, EventType
+from huey.gui.models import RepoStatus, dataclass_to_dict
+from huey.utils.paths import get_memory_path
+
+
+def _default_memory_root() -> str:
+    return str(get_memory_path(create=True))
+
+
+@dataclass
+class OperatorState:
+    active_view: str = "overview"
+    selected_phase_id: str = ""
+    selected_repository: str = "DylanLRPollock/Monkey-Head-Project"
+    mock_only: bool = True
+
+
+@dataclass
+class RuntimeState:
+    orchestration_status: str = "idle"
+    health_status: str = "unknown"
+    api_connected: bool = False
+    active_model: str = ""
+    services: dict[str, dict[str, object]] = field(default_factory=dict)
+    pipelines: dict[str, dict[str, object]] = field(default_factory=dict)
+    models: dict[str, dict[str, object]] = field(default_factory=dict)
+
+
+@dataclass
+class MemoryState:
+    root_path: str = field(default_factory=_default_memory_root)
+    data_mode: str = "local"
+    last_update: str = ""
+    indexed_documents: int = 0
+    last_query: str = ""
+
+
+@dataclass
+class RepositoryState:
+    repositories: list[RepoStatus] = field(default_factory=default_repositories)
+    active_repository: str = "DylanLRPollock/Monkey-Head-Project"
+
+
+@dataclass
+class HueyState:
+    operator: OperatorState = field(default_factory=OperatorState)
+    runtime: RuntimeState = field(default_factory=RuntimeState)
+    memory: MemoryState = field(default_factory=MemoryState)
+    repositories: RepositoryState = field(default_factory=RepositoryState)
+    recent_events: list[Event] = field(default_factory=list)
+
+    def apply_event(self, event: Event) -> None:
+        self.recent_events.append(event)
+        if event.event_type is EventType.API_CONNECTED:
+            self.runtime.api_connected = True
+            self.runtime.health_status = str(event.payload.get("status", "connected"))
+        elif event.event_type is EventType.RUN_STARTED:
+            self.runtime.orchestration_status = "running"
+        elif event.event_type is EventType.RUN_FINISHED:
+            self.runtime.orchestration_status = str(event.payload.get("status", "idle"))
+        elif event.event_type is EventType.MEMORY_UPDATED:
+            self.memory.last_update = event.timestamp
+            self.memory.indexed_documents = int(
+                event.payload.get("indexed_documents", self.memory.indexed_documents)
+            )
+        elif event.event_type is EventType.MODEL_CHANGED:
+            self.runtime.active_model = str(event.payload.get("model", ""))
+        elif event.event_type is EventType.REPOSITORY_CHANGED:
+            selected = str(event.payload.get("repository", ""))
+            if selected:
+                self.operator.selected_repository = selected
+                self.repositories.active_repository = selected
+
+    def as_dict(self) -> dict[str, object]:
+        return dataclass_to_dict(self)
+
+
+def build_default_state() -> HueyState:
+    """Return the canonical default GUI state."""
+
+    return HueyState()
+
+
+__all__ = [
+    "HueyState",
+    "MemoryState",
+    "OperatorState",
+    "RepositoryState",
+    "RuntimeState",
+    "build_default_state",
+]

--- a/src/huey/gui/storage.py
+++ b/src/huey/gui/storage.py
@@ -1,0 +1,109 @@
+"""Workspace storage helpers for GUI-facing Python surfaces."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from huey.gui.defaults import (
+    default_migration_phases,
+    default_operator_panel_state,
+    default_repositories,
+    default_validation_commands,
+)
+from huey.gui.models import dataclass_list_to_dicts, dataclass_to_dict
+from huey.utils.paths import ensure_subdirectory
+
+
+@dataclass
+class WorkspaceData:
+    repositories: list[dict[str, object]]
+    phases: list[dict[str, object]]
+    validation_commands: list[dict[str, object]]
+    operator_panel: dict[str, object]
+    notes: str = ""
+    version: str = "0.1.0"
+
+
+def _default_workspace_data() -> WorkspaceData:
+    return WorkspaceData(
+        repositories=dataclass_list_to_dicts(default_repositories()),
+        phases=dataclass_list_to_dicts(default_migration_phases()),
+        validation_commands=dataclass_list_to_dicts(default_validation_commands()),
+        operator_panel=dataclass_to_dict(default_operator_panel_state()),
+    )
+
+
+def default_workspace_path() -> Path:
+    """Return the default local workspace JSON path."""
+
+    return ensure_subdirectory("GUI") / "command-center-workspace.json"
+
+
+def load_workspace(path: Path | None = None) -> WorkspaceData:
+    """Load workspace JSON or return defaults."""
+
+    selected = path or default_workspace_path()
+    if not selected.exists():
+        return _default_workspace_data()
+    return import_workspace(selected.read_text(encoding="utf-8"))
+
+
+def save_workspace(data: WorkspaceData, path: Path | None = None) -> Path:
+    """Save workspace JSON."""
+
+    selected = path or default_workspace_path()
+    selected.parent.mkdir(parents=True, exist_ok=True)
+    selected.write_text(export_workspace(data), encoding="utf-8")
+    return selected
+
+
+def export_workspace(data: WorkspaceData) -> str:
+    """Return a pretty JSON string."""
+
+    payload = {
+        "repositories": data.repositories,
+        "phases": data.phases,
+        "validation_commands": data.validation_commands,
+        "operator_panel": data.operator_panel,
+        "notes": data.notes,
+        "version": data.version,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def import_workspace(text: str) -> WorkspaceData:
+    """Parse workspace JSON text."""
+
+    payload = json.loads(text)
+    defaults = _default_workspace_data()
+    return WorkspaceData(
+        repositories=list(payload.get("repositories", defaults.repositories)),
+        phases=list(payload.get("phases", defaults.phases)),
+        validation_commands=list(
+            payload.get("validation_commands", defaults.validation_commands)
+        ),
+        operator_panel=dict(payload.get("operator_panel", defaults.operator_panel)),
+        notes=str(payload.get("notes", "")),
+        version=str(payload.get("version", defaults.version)),
+    )
+
+
+def reset_workspace(path: Path | None = None) -> WorkspaceData:
+    """Overwrite workspace with default data."""
+
+    defaults = _default_workspace_data()
+    save_workspace(defaults, path=path)
+    return defaults
+
+
+__all__ = [
+    "WorkspaceData",
+    "default_workspace_path",
+    "export_workspace",
+    "import_workspace",
+    "load_workspace",
+    "reset_workspace",
+    "save_workspace",
+]

--- a/src/huey/gui/theme.py
+++ b/src/huey/gui/theme.py
@@ -1,0 +1,83 @@
+"""Shared theme values for every Python GUI surface."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class HueyTheme:
+    name: str
+    background: str
+    panel: str
+    panel_alt: str
+    text: str
+    muted_text: str
+    accent: str
+    accent_green: str
+    warning: str
+    danger: str
+    success: str
+    border: str
+
+
+_DEFAULT_THEME = HueyTheme(
+    name="hueyos-dark-purple",
+    background="#141019",
+    panel="#1e1726",
+    panel_alt="#261d31",
+    text="#f8f2ff",
+    muted_text="#c8b8d4",
+    accent="#7a4fa0",
+    accent_green="#00a85a",
+    warning="#d19a32",
+    danger="#d34a4a",
+    success="#00a85a",
+    border="#4f3a63",
+)
+
+
+def get_default_theme() -> HueyTheme:
+    """Return the canonical HueyOS dark-purple theme."""
+
+    return _DEFAULT_THEME
+
+
+def as_json(theme: HueyTheme | None = None) -> dict[str, str]:
+    """Return serializable theme values."""
+
+    return asdict(theme or get_default_theme())
+
+
+def as_tk_palette(theme: HueyTheme | None = None) -> dict[str, str]:
+    """Return Tkinter-friendly color aliases for legacy and modern GUIs."""
+
+    selected = theme or get_default_theme()
+    palette = as_json(selected)
+    palette.update(
+        {
+            "foreground": selected.text,
+            "dark_bg": selected.background,
+            "light_fg": selected.text,
+            "accent_purple": selected.accent,
+        }
+    )
+    return palette
+
+
+def as_css_variables(theme: HueyTheme | None = None) -> dict[str, str]:
+    """Return CSS custom-property values for web UI export."""
+
+    return {
+        f"--huey-{key.replace('_', '-')}": value
+        for key, value in as_json(theme).items()
+    }
+
+
+__all__ = [
+    "HueyTheme",
+    "as_css_variables",
+    "as_json",
+    "as_tk_palette",
+    "get_default_theme",
+]

--- a/src/huey/gui/v1_runs.py
+++ b/src/huey/gui/v1_runs.py
@@ -1,0 +1,114 @@
+"""Helpers for normalizing V1 proof-loop run records."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from huey.gui.models import V1RunRecord, dataclass_list_to_dicts
+
+
+def parse_jsonl(text: str) -> list[V1RunRecord]:
+    """Parse pasted JSONL text into ``V1RunRecord`` objects."""
+
+    records: list[V1RunRecord] = []
+    for line_number, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSONL at line {line_number}") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"JSONL line {line_number} is not a JSON object")
+        records.append(record_from_dict(payload))
+    return records
+
+
+def load_jsonl(path: Path) -> list[V1RunRecord]:
+    """Load ``V1RunRecord`` objects from a local JSONL file."""
+
+    return parse_jsonl(path.read_text(encoding="utf-8"))
+
+
+def record_from_dict(payload: dict[str, object]) -> V1RunRecord:
+    """Normalize a raw V1 run-log dictionary."""
+
+    source_file = str(payload.get("source_file", payload.get("fixture", "")))
+    status = "passed" if payload.get("exit_status") == "success" else "failed"
+    return V1RunRecord(
+        id=str(payload.get("run_id", payload.get("id", source_file or "unknown-run"))),
+        fixture=Path(source_file).name or "unknown-fixture",
+        status=status,  # type: ignore[arg-type]
+        transcription_status=("complete" if payload.get("transcript") else "missing"),
+        cognition_status=("complete" if payload.get("response") else "missing"),
+        response_text=str(payload.get("response") or ""),
+        error=str(payload.get("error_message_if_any") or ""),
+        raw=dict(payload),
+    )
+
+
+def filter_runs(
+    runs: list[V1RunRecord],
+    status: str | None = None,
+    contains: str | None = None,
+    fixture: str | None = None,
+) -> list[V1RunRecord]:
+    """Filter V1 run records for UI display."""
+
+    filtered = list(runs)
+    if status:
+        filtered = [run for run in filtered if run.status == status]
+    if fixture:
+        filtered = [run for run in filtered if run.fixture == fixture]
+    if contains:
+        needle = contains.lower()
+        filtered = [
+            run
+            for run in filtered
+            if needle in run.response_text.lower() or needle in run.error.lower()
+        ]
+    return filtered
+
+
+def export_runs_json(runs: list[V1RunRecord]) -> str:
+    """Export selected runs as pretty JSON."""
+
+    return json.dumps(dataclass_list_to_dicts(runs), indent=2, sort_keys=True)
+
+
+def sample_v1_runs() -> list[V1RunRecord]:
+    """Return mock/sample V1 proof-loop records."""
+
+    return [
+        record_from_dict(
+            {
+                "run_id": "sample-run-001",
+                "source_file": "fixtures/hello-world.mp3",
+                "transcript": "Hello Huey, run the fixture loop.",
+                "response": "Fixture loop acknowledged.",
+                "exit_status": "success",
+            }
+        ),
+        record_from_dict(
+            {
+                "run_id": "sample-run-002",
+                "source_file": "fixtures/noisy-input.mp3",
+                "transcript": "",
+                "response": "",
+                "exit_status": "error",
+                "error_message_if_any": "Transcription pipeline could not extract speech.",
+            }
+        ),
+    ]
+
+
+__all__ = [
+    "export_runs_json",
+    "filter_runs",
+    "load_jsonl",
+    "parse_jsonl",
+    "record_from_dict",
+    "sample_v1_runs",
+]

--- a/src/huey/gui/validation.py
+++ b/src/huey/gui/validation.py
@@ -1,0 +1,204 @@
+"""Copy-only validation command registry for dashboard and operator flows."""
+
+from __future__ import annotations
+
+from huey.gui.models import ValidationCommand
+
+
+def monkey_head_validation_commands() -> list[ValidationCommand]:
+    """Return Monkey-Head-Project validation commands."""
+
+    return [
+        ValidationCommand(
+            id="stale-platform-strings",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python scripts/repo/check_stale_platform_strings.py",
+            purpose="Catch stale platform labels and renamed surfaces.",
+            expected_result="Script prints a pass message and exits with code 0.",
+            risk="low",
+            phase_id="phase-2-huey-os-canonical",
+        ),
+        ValidationCommand(
+            id="repo-drift",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python scripts/repo/check_repo_drift.py",
+            purpose="Detect current-facing repository drift strings.",
+            expected_result="Script prints 'Repo drift check passed.'",
+            risk="medium",
+            phase_id="phase-2-huey-os-canonical",
+        ),
+        ValidationCommand(
+            id="legacy-hueyos-imports",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python scripts/repo/check_legacy_hueyos_imports.py",
+            purpose="Prevent new legacy namespace import regressions.",
+            expected_result="Script exits with code 0 and reports no violations.",
+            risk="medium",
+            phase_id="phase-2-huey-os-canonical",
+        ),
+        ValidationCommand(
+            id="dependency-sync",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python scripts/repo/check_dependency_sync.py",
+            purpose="Verify pyproject, requirements, and constraints stay aligned.",
+            expected_result="Dependency sync check passed.",
+            risk="high",
+            phase_id="phase-2-huey-os-canonical",
+        ),
+        ValidationCommand(
+            id="active-dependency-surface",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python scripts/repo/check_active_dependency_surface.py",
+            purpose="Report duplicate, orphaned, and inactive direct dependencies.",
+            expected_result="Script exits 0 when the active dependency surface is coherent.",
+            risk="high",
+            phase_id="phase-2-huey-os-canonical",
+        ),
+        ValidationCommand(
+            id="archived-dependency-snapshots",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python scripts/repo/check_archived_dependency_snapshots.py",
+            purpose="Validate archived dependency manifests and known-good snapshots.",
+            expected_result="Script exits 0 when archived snapshots are present and readable.",
+            risk="medium",
+            phase_id="phase-2-huey-os-canonical",
+        ),
+        ValidationCommand(
+            id="black-check",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python -m black --check src tests scripts conftest.py",
+            purpose="Verify formatting stays stable.",
+            expected_result="Black exits with code 0.",
+            risk="low",
+        ),
+        ValidationCommand(
+            id="isort-check",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python -m isort --check-only src tests scripts conftest.py",
+            purpose="Verify import ordering stays stable.",
+            expected_result="isort exits with code 0.",
+            risk="low",
+        ),
+        ValidationCommand(
+            id="ruff-check",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python -m ruff check src tests scripts conftest.py",
+            purpose="Run the primary Python lint surface.",
+            expected_result="ruff exits with code 0.",
+            risk="medium",
+        ),
+        ValidationCommand(
+            id="flake8-check",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command=(
+                "python -m flake8 --exclude=src/huey/connectors/pyhuey "
+                "src tests scripts conftest.py"
+            ),
+            purpose="Run legacy style checks that still guard parts of the tree.",
+            expected_result="flake8 exits with code 0.",
+            risk="medium",
+        ),
+        ValidationCommand(
+            id="pytest-all",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python -m pytest -q",
+            purpose="Run the repository test suite.",
+            expected_result="pytest exits with code 0.",
+            risk="high",
+        ),
+    ]
+
+
+def pyhuey_validation_commands() -> list[ValidationCommand]:
+    """Return PyHuey validation commands."""
+
+    return [
+        ValidationCommand(
+            id="pyhuey-status",
+            repo="DylanLRPollock/PyHuey",
+            command="python -m huey.pyhuey_integration",
+            purpose="Inspect PyHuey discovery and source resolution status.",
+            expected_result="Command prints source candidates without mutating anything.",
+            risk="low",
+            phase_id="phase-2-5-pyhuey-connector",
+        ),
+    ]
+
+
+def command_center_validation_commands() -> list[ValidationCommand]:
+    """Return Command Center validation commands."""
+
+    return [
+        ValidationCommand(
+            id="command-center-contract",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command="python scripts/check_command_center_contract.py",
+            purpose="Verify the read-only backend exposes the expected API contract.",
+            expected_result="Script exits 0 and confirms route and safety guarantees.",
+            risk="high",
+            phase_id="phase-5-v1-run-dashboard",
+        ),
+        ValidationCommand(
+            id="command-center-seed",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command=(
+                "python scripts/export_command_center_seed.py "
+                "--output docs/tools/command-center-seed.json"
+            ),
+            purpose="Export canonical seed data for the separate frontend app.",
+            expected_result="Script writes a seed JSON file without mutating runtime state.",
+            risk="low",
+            phase_id="phase-5-v1-run-dashboard",
+        ),
+        ValidationCommand(
+            id="command-center-backend-tests",
+            repo="DylanLRPollock/Monkey-Head-Project",
+            command=(
+                "python -m pytest -q tests/test_command_center_backend.py "
+                "tests/test_legacy_gui_adapters.py"
+            ),
+            purpose="Exercise the read-only backend and legacy GUI bridges.",
+            expected_result="pytest exits with code 0.",
+            risk="medium",
+            phase_id="phase-5-v1-run-dashboard",
+        ),
+    ]
+
+
+def all_validation_commands() -> list[ValidationCommand]:
+    """Return every registered validation command."""
+
+    commands = (
+        monkey_head_validation_commands()
+        + pyhuey_validation_commands()
+        + command_center_validation_commands()
+    )
+    return commands
+
+
+def commands_by_repo() -> dict[str, list[ValidationCommand]]:
+    """Group validation commands by repository."""
+
+    grouped: dict[str, list[ValidationCommand]] = {}
+    for command in all_validation_commands():
+        grouped.setdefault(command.repo, []).append(command)
+    return grouped
+
+
+def get_command(command_id: str) -> ValidationCommand:
+    """Lookup a validation command by its identifier."""
+
+    for command in all_validation_commands():
+        if command.id == command_id:
+            return command
+    raise KeyError(f"Unknown validation command: {command_id}")
+
+
+__all__ = [
+    "all_validation_commands",
+    "command_center_validation_commands",
+    "commands_by_repo",
+    "get_command",
+    "monkey_head_validation_commands",
+    "pyhuey_validation_commands",
+]

--- a/src/huey/integrations/__init__.py
+++ b/src/huey/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integration adapters that connect HueyOS to external operator surfaces."""

--- a/src/huey/integrations/command_center/__init__.py
+++ b/src/huey/integrations/command_center/__init__.py
@@ -1,0 +1,17 @@
+"""Command Center integration adapters and serializers."""
+
+from huey.integrations.command_center.adapter import (
+    get_api_status,
+    get_memory_status,
+    get_repo_status,
+    get_runtime_status,
+    get_v1_status,
+)
+
+__all__ = [
+    "get_api_status",
+    "get_memory_status",
+    "get_repo_status",
+    "get_runtime_status",
+    "get_v1_status",
+]

--- a/src/huey/integrations/command_center/adapter.py
+++ b/src/huey/integrations/command_center/adapter.py
@@ -1,0 +1,106 @@
+"""Read-only adapters that prepare HueyOS state for Command Center."""
+
+from __future__ import annotations
+
+import os
+
+from huey.gui.defaults import default_migration_phases, default_repositories
+from huey.gui.github_client import client_from_env, summarize_repo_status
+from huey.gui.models import dataclass_list_to_dicts, dataclass_to_dict
+from huey.gui.v1_runs import sample_v1_runs
+from huey.integrations.command_center.serializers import memory_to_json, state_to_json
+from huey.memory.pipeline.indexing import default_index_path
+from huey.runtime.orchestrator import RuntimeOrchestrator
+from huey.utils.paths import get_memory_path
+from huey.v1.fixture_registry import list_fixtures
+
+
+def get_repo_status(*, live: bool | None = None) -> list[dict[str, object]]:
+    """Return repository status cards from mock or live sources."""
+
+    use_live = live
+    if use_live is None:
+        use_live = os.environ.get("HUEY_COMMAND_CENTER_LIVE_REPOS", "").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+    if not use_live:
+        return dataclass_list_to_dicts(default_repositories())
+
+    client = client_from_env()
+    statuses = []
+    for repo in default_repositories():
+        try:
+            statuses.append(
+                dataclass_to_dict(summarize_repo_status(client, repo.full_name))
+            )
+        except Exception as exc:
+            fallback = dataclass_to_dict(repo)
+            fallback["data_mode"] = "mock"
+            fallback["live_error"] = str(exc)
+            statuses.append(fallback)
+    return statuses
+
+
+def get_runtime_status() -> dict[str, object]:
+    """Return orchestrator-driven runtime status."""
+
+    orchestrator = RuntimeOrchestrator()
+    orchestrator.health_check()
+    return state_to_json(orchestrator.status())
+
+
+def get_v1_status() -> dict[str, object]:
+    """Return V1 proof-loop status and sample data."""
+
+    fixtures = list_fixtures()
+    runs = sample_v1_runs()
+    return {
+        "fixtures_registered": len(fixtures),
+        "fixtures": fixtures,
+        "sample_runs": dataclass_list_to_dicts(runs),
+        "phases": dataclass_list_to_dicts(default_migration_phases()),
+    }
+
+
+def get_memory_status() -> dict[str, object]:
+    """Return memory root and index status."""
+
+    memory_root = get_memory_path(create=True)
+    index_path = default_index_path()
+    indexed_entries = 0
+    if index_path.exists():
+        indexed_entries = len(
+            __import__("json").loads(index_path.read_text(encoding="utf-8"))
+        )
+    payload = {
+        "root_path": str(memory_root),
+        "exists": memory_root.exists(),
+        "index_path": str(index_path),
+        "indexed_entries": indexed_entries,
+        "subdirectories": sorted(
+            entry.name for entry in memory_root.iterdir() if entry.is_dir()
+        ),
+    }
+    return memory_to_json(payload)
+
+
+def get_api_status() -> dict[str, object]:
+    """Return local API health information."""
+
+    from huey.os.api.routers.system import healthz
+
+    payload = dict(healthz())
+    payload["ready"] = payload.get("status") == "ok"
+    return payload
+
+
+__all__ = [
+    "get_api_status",
+    "get_memory_status",
+    "get_repo_status",
+    "get_runtime_status",
+    "get_v1_status",
+]

--- a/src/huey/integrations/command_center/serializers.py
+++ b/src/huey/integrations/command_center/serializers.py
@@ -1,0 +1,45 @@
+"""Serializers for Command Center payloads."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+
+
+def _normalise(value: object) -> object:
+    if is_dataclass(value):
+        return {_key: _normalise(_value) for _key, _value in asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(key): _normalise(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_normalise(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def repo_to_json(repo: object) -> dict[str, object]:
+    """Serialize a repository status object."""
+
+    return dict(_normalise(repo))
+
+
+def run_to_json(run_record: object) -> dict[str, object]:
+    """Serialize a V1 run record."""
+
+    return dict(_normalise(run_record))
+
+
+def memory_to_json(memory_state: object) -> dict[str, object]:
+    """Serialize a memory or indexing payload."""
+
+    return dict(_normalise(memory_state))
+
+
+def state_to_json(state: object) -> dict[str, object]:
+    """Serialize a nested state payload."""
+
+    return dict(_normalise(state))
+
+
+__all__ = ["memory_to_json", "repo_to_json", "run_to_json", "state_to_json"]

--- a/src/huey/media/__init__.py
+++ b/src/huey/media/__init__.py
@@ -1,0 +1,47 @@
+"""Canonical media and FFmpeg helpers for HueyOS."""
+
+from huey.media.ffmpeg_validator import (
+    check_ffmpeg,
+    check_ffprobe,
+    get_ffmpeg_version,
+    validate_media_environment,
+)
+from huey.media.media_manager import (
+    compress_audio,
+    compress_video,
+    convert_audio,
+    detect_silence,
+    extract_audio,
+    extract_frames,
+    generate_spectrogram,
+    generate_waveform,
+    normalize_audio,
+    probe_media,
+    remove_silence,
+    resample_audio,
+    split_audio_chunks,
+    transcode_video,
+    trim_audio,
+)
+
+__all__ = [
+    "check_ffmpeg",
+    "check_ffprobe",
+    "compress_audio",
+    "compress_video",
+    "convert_audio",
+    "detect_silence",
+    "extract_audio",
+    "extract_frames",
+    "generate_spectrogram",
+    "generate_waveform",
+    "get_ffmpeg_version",
+    "normalize_audio",
+    "probe_media",
+    "remove_silence",
+    "resample_audio",
+    "split_audio_chunks",
+    "transcode_video",
+    "trim_audio",
+    "validate_media_environment",
+]

--- a/src/huey/media/ffmpeg_validator.py
+++ b/src/huey/media/ffmpeg_validator.py
@@ -1,0 +1,55 @@
+"""Startup validation helpers for FFmpeg-dependent features."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+
+def check_ffmpeg() -> bool:
+    """Return ``True`` when ``ffmpeg`` is visible on ``PATH``."""
+
+    return shutil.which("ffmpeg") is not None
+
+
+def check_ffprobe() -> bool:
+    """Return ``True`` when ``ffprobe`` is visible on ``PATH``."""
+
+    return shutil.which("ffprobe") is not None
+
+
+def get_ffmpeg_version() -> str | None:
+    """Return the installed FFmpeg version string if available."""
+
+    if not check_ffmpeg():
+        return None
+    result = subprocess.run(
+        ["ffmpeg", "-version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout:
+        return None
+    return result.stdout.splitlines()[0].strip()
+
+
+def validate_media_environment() -> dict[str, object]:
+    """Return a snapshot of FFmpeg/ffprobe readiness."""
+
+    ffmpeg_ready = check_ffmpeg()
+    ffprobe_ready = check_ffprobe()
+    return {
+        "ffmpeg": ffmpeg_ready,
+        "ffprobe": ffprobe_ready,
+        "ffmpeg_version": get_ffmpeg_version(),
+        "ready": ffmpeg_ready and ffprobe_ready,
+    }
+
+
+__all__ = [
+    "check_ffmpeg",
+    "check_ffprobe",
+    "get_ffmpeg_version",
+    "validate_media_environment",
+]

--- a/src/huey/media/media_manager.py
+++ b/src/huey/media/media_manager.py
@@ -1,0 +1,393 @@
+"""Central FFmpeg wrapper used by audio, video, and ingestion pipelines."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+from huey.media.ffmpeg_validator import validate_media_environment
+
+SilenceRange = dict[str, float]
+
+
+def _coerce_path(value: str | Path) -> Path:
+    return Path(value).expanduser().resolve()
+
+
+def _ensure_source(value: str | Path) -> Path:
+    path = _coerce_path(value)
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    return path
+
+
+def _prepare_output(value: str | Path) -> Path:
+    path = _coerce_path(value)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _run_process(command: list[str]) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return result
+
+
+def _run_ffmpeg(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    environment = validate_media_environment()
+    if not environment["ffmpeg"]:
+        raise RuntimeError("ffmpeg is not available on PATH")
+    return _run_process(["ffmpeg", "-hide_banner", "-y", *arguments])
+
+
+def _run_ffprobe(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    environment = validate_media_environment()
+    if not environment["ffprobe"]:
+        raise RuntimeError("ffprobe is not available on PATH")
+    return _run_process(["ffprobe", "-v", "error", *arguments])
+
+
+def probe_media(path: str | Path) -> dict[str, object]:
+    """Return stream and format metadata for a media file."""
+
+    source = _ensure_source(path)
+    result = _run_ffprobe(
+        [
+            "-print_format",
+            "json",
+            "-show_format",
+            "-show_streams",
+            str(source),
+        ]
+    )
+    return json.loads(result.stdout or "{}")
+
+
+def convert_audio(
+    source: str | Path,
+    target: str | Path,
+    *,
+    bitrate: str = "192k",
+    codec: str | None = None,
+) -> Path:
+    """Convert audio to a new target format."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(target)
+    command = ["-i", str(src), "-vn"]
+    if codec:
+        command.extend(["-c:a", codec])
+    command.extend(["-b:a", bitrate, str(dst)])
+    _run_ffmpeg(command)
+    return dst
+
+
+def extract_audio(
+    source: str | Path,
+    target: str | Path,
+    *,
+    codec: str | None = None,
+) -> Path:
+    """Extract the audio stream from a video file."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(target)
+    command = ["-i", str(src), "-vn"]
+    if codec:
+        command.extend(["-c:a", codec])
+    else:
+        command.extend(["-c:a", "copy"])
+    command.append(str(dst))
+    _run_ffmpeg(command)
+    return dst
+
+
+def normalize_audio(
+    source: str | Path,
+    target: str | Path,
+    *,
+    integrated_lufs: int = -16,
+    true_peak: float = -1.5,
+    loudness_range: int = 11,
+) -> Path:
+    """Normalize audio loudness using FFmpeg loudnorm."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(target)
+    filter_value = f"loudnorm=I={integrated_lufs}:TP={true_peak}:LRA={loudness_range}"
+    _run_ffmpeg(["-i", str(src), "-af", filter_value, str(dst)])
+    return dst
+
+
+def trim_audio(
+    source: str | Path,
+    target: str | Path,
+    *,
+    start: float | None = None,
+    end: float | None = None,
+    duration: float | None = None,
+) -> Path:
+    """Trim audio to a requested time window."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(target)
+    command: list[str] = []
+    if start is not None:
+        command.extend(["-ss", str(start)])
+    command.extend(["-i", str(src)])
+    if end is not None:
+        command.extend(["-to", str(end)])
+    if duration is not None:
+        command.extend(["-t", str(duration)])
+    command.append(str(dst))
+    _run_ffmpeg(command)
+    return dst
+
+
+def resample_audio(
+    source: str | Path,
+    target: str | Path,
+    *,
+    sample_rate: int = 16000,
+    channels: int = 1,
+) -> Path:
+    """Resample audio for speech and analysis pipelines."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(target)
+    _run_ffmpeg(
+        [
+            "-i",
+            str(src),
+            "-ar",
+            str(sample_rate),
+            "-ac",
+            str(channels),
+            str(dst),
+        ]
+    )
+    return dst
+
+
+def transcode_video(
+    source: str | Path,
+    target: str | Path,
+    *,
+    video_codec: str = "libx264",
+    audio_codec: str = "aac",
+    crf: int = 23,
+    preset: str = "medium",
+) -> Path:
+    """Transcode video to a portable distribution format."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(target)
+    _run_ffmpeg(
+        [
+            "-i",
+            str(src),
+            "-c:v",
+            video_codec,
+            "-preset",
+            preset,
+            "-crf",
+            str(crf),
+            "-c:a",
+            audio_codec,
+            "-movflags",
+            "+faststart",
+            str(dst),
+        ]
+    )
+    return dst
+
+
+def extract_frames(
+    source: str | Path,
+    output_pattern: str | Path,
+    *,
+    fps: float = 1.0,
+) -> Path:
+    """Extract video frames to an image sequence."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(output_pattern)
+    _run_ffmpeg(["-i", str(src), "-vf", f"fps={fps}", str(dst)])
+    return dst
+
+
+def generate_waveform(
+    source: str | Path,
+    target: str | Path,
+    *,
+    width: int = 1280,
+    height: int = 320,
+    color: str = "0x7a4fa0",
+) -> Path:
+    """Generate a waveform image for an audio file."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(target)
+    filter_value = f"showwavespic=s={width}x{height}:colors={color}"
+    _run_ffmpeg(["-i", str(src), "-lavfi", filter_value, "-frames:v", "1", str(dst)])
+    return dst
+
+
+def generate_spectrogram(
+    source: str | Path,
+    target: str | Path,
+    *,
+    width: int = 1280,
+    height: int = 720,
+) -> Path:
+    """Generate a spectrogram image for an audio file."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(target)
+    filter_value = f"showspectrumpic=s={width}x{height}"
+    _run_ffmpeg(["-i", str(src), "-lavfi", filter_value, "-frames:v", "1", str(dst)])
+    return dst
+
+
+def compress_audio(
+    source: str | Path,
+    target: str | Path,
+    *,
+    bitrate: str = "128k",
+) -> Path:
+    """Create a smaller audio derivative."""
+
+    return convert_audio(source, target, bitrate=bitrate)
+
+
+def compress_video(
+    source: str | Path,
+    target: str | Path,
+    *,
+    crf: int = 28,
+    preset: str = "slow",
+) -> Path:
+    """Create a smaller video derivative."""
+
+    return transcode_video(source, target, crf=crf, preset=preset)
+
+
+def detect_silence(
+    source: str | Path,
+    *,
+    noise: str = "-30dB",
+    duration: float = 0.5,
+) -> list[SilenceRange]:
+    """Return detected silence spans from an audio file."""
+
+    src = _ensure_source(source)
+    result = _run_process(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-i",
+            str(src),
+            "-af",
+            f"silencedetect=noise={noise}:d={duration}",
+            "-f",
+            "null",
+            "-",
+        ]
+    )
+    silence_start = re.compile(r"silence_start: (?P<start>[0-9.]+)")
+    silence_end = re.compile(
+        r"silence_end: (?P<end>[0-9.]+) \| silence_duration: (?P<duration>[0-9.]+)"
+    )
+    starts: list[float] = []
+    ranges: list[SilenceRange] = []
+    for line in (result.stderr or "").splitlines():
+        start_match = silence_start.search(line)
+        if start_match:
+            starts.append(float(start_match.group("start")))
+            continue
+        end_match = silence_end.search(line)
+        if end_match and starts:
+            start = starts.pop(0)
+            ranges.append(
+                {
+                    "start": start,
+                    "end": float(end_match.group("end")),
+                    "duration": float(end_match.group("duration")),
+                }
+            )
+    return ranges
+
+
+def remove_silence(
+    source: str | Path,
+    target: str | Path,
+    *,
+    threshold: str = "-30dB",
+    min_silence_duration: float = 0.5,
+) -> Path:
+    """Remove leading, trailing, and internal silence using FFmpeg filters."""
+
+    src = _ensure_source(source)
+    dst = _prepare_output(target)
+    filter_value = (
+        "silenceremove="
+        f"start_periods=1:start_duration={min_silence_duration}:"
+        f"start_threshold={threshold}:"
+        f"stop_periods=-1:stop_duration={min_silence_duration}:"
+        f"stop_threshold={threshold}"
+    )
+    _run_ffmpeg(["-i", str(src), "-af", filter_value, str(dst)])
+    return dst
+
+
+def split_audio_chunks(
+    source: str | Path,
+    output_dir: str | Path,
+    *,
+    chunk_seconds: float = 30.0,
+    prefix: str = "chunk",
+    extension: str = ".wav",
+) -> list[Path]:
+    """Split an audio file into evenly-sized chunks."""
+
+    src = _ensure_source(source)
+    directory = _coerce_path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    suffix = extension if extension.startswith(".") else f".{extension}"
+    pattern = directory / f"{prefix}-%03d{suffix}"
+    _run_ffmpeg(
+        [
+            "-i",
+            str(src),
+            "-f",
+            "segment",
+            "-segment_time",
+            str(chunk_seconds),
+            "-c",
+            "copy",
+            str(pattern),
+        ]
+    )
+    return sorted(directory.glob(f"{prefix}-*{suffix}"))
+
+
+__all__ = [
+    "compress_audio",
+    "compress_video",
+    "convert_audio",
+    "detect_silence",
+    "extract_audio",
+    "extract_frames",
+    "generate_spectrogram",
+    "generate_waveform",
+    "normalize_audio",
+    "probe_media",
+    "remove_silence",
+    "resample_audio",
+    "split_audio_chunks",
+    "transcode_video",
+    "trim_audio",
+]

--- a/src/huey/media/speech_pipeline.py
+++ b/src/huey/media/speech_pipeline.py
@@ -1,0 +1,114 @@
+"""Pre-transcription audio preparation for Whisper-style pipelines."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from huey.media.media_manager import (
+    _coerce_path,
+    _ensure_source,
+    _run_ffmpeg,
+)
+from huey.media.media_manager import normalize_audio as _normalize_audio
+from huey.media.media_manager import remove_silence as _remove_silence
+from huey.media.media_manager import resample_audio as _resample_audio
+from huey.utils.paths import ensure_subdirectory
+
+
+def normalize_volume(source: str | Path, target: str | Path) -> Path:
+    """Normalize audio loudness before transcription."""
+
+    return _normalize_audio(source, target)
+
+
+def denoise_audio(
+    source: str | Path,
+    target: str | Path,
+    *,
+    noise_reduction_filter: str = "afftdn=nf=-25",
+) -> Path:
+    """Apply a light denoise filter suitable for speech."""
+
+    src = _ensure_source(source)
+    dst = _coerce_path(target)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _run_ffmpeg(["-i", str(src), "-af", noise_reduction_filter, str(dst)])
+    return dst
+
+
+def convert_to_mono(source: str | Path, target: str | Path) -> Path:
+    """Downmix audio to a single speech channel."""
+
+    return _resample_audio(source, target, channels=1, sample_rate=44100)
+
+
+def convert_to_16khz(source: str | Path, target: str | Path) -> Path:
+    """Resample audio to 16kHz for Whisper-style models."""
+
+    return _resample_audio(source, target, channels=1, sample_rate=16000)
+
+
+def remove_silence(
+    source: str | Path,
+    target: str | Path,
+    *,
+    threshold: str = "-30dB",
+    min_silence_duration: float = 0.5,
+) -> Path:
+    """Remove silence regions from a speech file."""
+
+    return _remove_silence(
+        source,
+        target,
+        threshold=threshold,
+        min_silence_duration=min_silence_duration,
+    )
+
+
+def _default_output_path(source: str | Path, suffix: str) -> Path:
+    prepared_dir = ensure_subdirectory("AUDIO", "prepared")
+    src = _ensure_source(source)
+    return prepared_dir / f"{src.stem}.{suffix}.wav"
+
+
+def generate_transcription_ready_file(
+    source: str | Path,
+    *,
+    output_path: str | Path | None = None,
+) -> Path:
+    """Run the full pre-transcription audio pipeline."""
+
+    src = _ensure_source(source)
+    normalized = _default_output_path(src, "normalized")
+    trimmed = _default_output_path(src, "nosilence")
+    mono = _default_output_path(src, "mono")
+    final_path = (
+        _coerce_path(output_path) if output_path else _default_output_path(src, "ready")
+    )
+
+    normalize_volume(src, normalized)
+    remove_silence(normalized, trimmed)
+    convert_to_mono(trimmed, mono)
+    convert_to_16khz(mono, final_path)
+    return final_path
+
+
+def prepare_for_whisper(
+    source: str | Path,
+    *,
+    output_path: str | Path | None = None,
+) -> Path:
+    """Prepare an audio file for Whisper ingestion."""
+
+    return generate_transcription_ready_file(source, output_path=output_path)
+
+
+__all__ = [
+    "convert_to_16khz",
+    "convert_to_mono",
+    "denoise_audio",
+    "generate_transcription_ready_file",
+    "normalize_volume",
+    "prepare_for_whisper",
+    "remove_silence",
+]

--- a/src/huey/media/video_pipeline.py
+++ b/src/huey/media/video_pipeline.py
@@ -1,0 +1,134 @@
+"""Video helpers that build on the central FFmpeg media manager."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from huey.media.media_manager import (
+    _coerce_path,
+    _ensure_source,
+    _run_ffmpeg,
+)
+from huey.media.media_manager import extract_frames as _extract_frames
+from huey.media.media_manager import (
+    probe_media,
+)
+
+
+def extract_frames(
+    source: str | Path,
+    output_pattern: str | Path,
+    *,
+    fps: float = 1.0,
+) -> Path:
+    """Extract video frames to a numbered image sequence."""
+
+    return _extract_frames(source, output_pattern, fps=fps)
+
+
+def extract_keyframes(
+    source: str | Path,
+    output_pattern: str | Path,
+) -> Path:
+    """Extract I-frames from a video."""
+
+    src = _ensure_source(source)
+    dst = _coerce_path(output_pattern)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _run_ffmpeg(
+        [
+            "-i",
+            str(src),
+            "-vf",
+            "select='eq(pict_type,I)'",
+            "-vsync",
+            "vfr",
+            str(dst),
+        ]
+    )
+    return dst
+
+
+def extract_thumbnail(
+    source: str | Path,
+    target: str | Path,
+    *,
+    timestamp: float = 1.0,
+) -> Path:
+    """Extract a single thumbnail frame."""
+
+    src = _ensure_source(source)
+    dst = _coerce_path(target)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    _run_ffmpeg(["-ss", str(timestamp), "-i", str(src), "-frames:v", "1", str(dst)])
+    return dst
+
+
+def split_video(
+    source: str | Path,
+    output_dir: str | Path,
+    *,
+    chunk_seconds: float = 30.0,
+    prefix: str = "segment",
+) -> list[Path]:
+    """Split a video into fixed-duration segments."""
+
+    src = _ensure_source(source)
+    directory = _coerce_path(output_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    pattern = directory / f"{prefix}-%03d.mp4"
+    _run_ffmpeg(
+        [
+            "-i",
+            str(src),
+            "-c",
+            "copy",
+            "-map",
+            "0",
+            "-f",
+            "segment",
+            "-segment_time",
+            str(chunk_seconds),
+            str(pattern),
+        ]
+    )
+    return sorted(directory.glob(f"{prefix}-*.mp4"))
+
+
+def video_metadata(source: str | Path) -> dict[str, object]:
+    """Return full ffprobe metadata for a video file."""
+
+    return probe_media(source)
+
+
+def video_duration(source: str | Path) -> float:
+    """Return video duration in seconds."""
+
+    payload = video_metadata(source)
+    return float(payload.get("format", {}).get("duration", 0.0))
+
+
+def video_fps(source: str | Path) -> float:
+    """Return the primary video stream frames-per-second value."""
+
+    payload = video_metadata(source)
+    for stream in payload.get("streams", []):
+        if stream.get("codec_type") != "video":
+            continue
+        raw_value = str(stream.get("r_frame_rate") or "0/1")
+        numerator, _, denominator = raw_value.partition("/")
+        if denominator and float(denominator) != 0:
+            return float(numerator) / float(denominator)
+        return float(numerator)
+    return 0.0
+
+
+__all__ = [
+    "extract_frames",
+    "extract_keyframes",
+    "extract_thumbnail",
+    "split_video",
+    "video_duration",
+    "video_fps",
+    "video_metadata",
+]

--- a/src/huey/memory/PY/ai_tools_gui.py
+++ b/src/huey/memory/PY/ai_tools_gui.py
@@ -29,8 +29,9 @@ except Exception:  # pragma: no cover - can't import GUI libs
     scrolledtext = None
     ttk = None
 
+from huey.gui.theme import as_tk_palette
+
 from .gui_scaling import apply_scaling
-from .license_gui import ACCENT_PURPLE, DARK_BG, LIGHT_FG
 
 try:  # pragma: no cover - psutil optional dependency
     import psutil  # type: ignore
@@ -50,6 +51,11 @@ from huey.utils.paths import ensure_subdirectory, get_memory_path
 from .config_manager import ConfigManager
 
 logger = logging.getLogger(__name__)
+
+_PALETTE = as_tk_palette()
+DARK_BG = _PALETTE["background"]
+LIGHT_FG = _PALETTE["text"]
+ACCENT_PURPLE = _PALETTE["accent"]
 
 
 def _format_bytes(size: float | int | None) -> str:

--- a/src/huey/memory/PY/license_gui.py
+++ b/src/huey/memory/PY/license_gui.py
@@ -25,13 +25,15 @@ except Exception:  # pragma: no cover - can't import GUI libs
     messagebox = None
     scrolledtext = None
 
+from huey.gui.theme import as_tk_palette
+
 from .config_manager import ConfigManager
 from .gui_scaling import apply_scaling
 
-# Shared theme colors
-DARK_BG = "#000000"  # black background
-LIGHT_FG = "#00ff00"  # green text
-ACCENT_PURPLE = "#2d2b57"  # dark purple accent
+_PALETTE = as_tk_palette()
+DARK_BG = _PALETTE["background"]
+LIGHT_FG = _PALETTE["text"]
+ACCENT_PURPLE = _PALETTE["accent"]
 
 
 def accept_license(config_path: str | Path, license_hash: str | None = None) -> None:

--- a/src/huey/memory/PY/media_conversion.py
+++ b/src/huey/memory/PY/media_conversion.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 from pathlib import Path
+
+from huey.media.media_manager import convert_audio as _convert_audio
+from huey.media.media_manager import extract_audio as _extract_audio
+from huey.media.media_manager import transcode_video as _transcode_video
 
 __all__ = [
     "convert_audio",
@@ -29,26 +32,18 @@ __all__ = [
 ]
 
 
-def _run_ffmpeg(args: list[str]) -> None:
-    """Run an ffmpeg command and raise if it fails."""
-    cmd = ["ffmpeg", "-y"] + args
-    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    if result.returncode != 0:
-        raise RuntimeError(result.stderr.decode("utf-8", "ignore"))
-
-
 def convert_audio(src: str, dst: str, bitrate: str = "192k") -> None:
     """Convert an audio file to a new format using ffmpeg."""
     if not os.path.exists(src):
         raise FileNotFoundError(src)
-    _run_ffmpeg(["-i", src, "-b:a", bitrate, dst])
+    _convert_audio(src, dst, bitrate=bitrate)
 
 
 def convert_video(src: str, dst: str, codec: str = "libx264") -> None:
     """Convert a video file to a new format using ffmpeg."""
     if not os.path.exists(src):
         raise FileNotFoundError(src)
-    _run_ffmpeg(["-i", src, "-vcodec", codec, dst])
+    _transcode_video(src, dst, video_codec=codec)
 
 
 def convert_file(src: str, dst: str) -> None:
@@ -63,10 +58,8 @@ def extract_audio(src: str, dst: str) -> None:
     if not os.path.exists(src):
         raise FileNotFoundError(src)
     ext = Path(dst).suffix.lower()
-    if ext == ".mp3":
-        _run_ffmpeg(["-i", src, "-vn", "-acodec", "libmp3lame", dst])
-    else:
-        _run_ffmpeg(["-i", src, "-vn", "-acodec", "copy", dst])
+    codec = "libmp3lame" if ext == ".mp3" else None
+    _extract_audio(src, dst, codec=codec)
 
 
 AUDIO_EXTENSIONS = {".wav", ".mp3", ".flac", ".m4a", ".aac", ".ogg"}

--- a/src/huey/memory/pipeline/__init__.py
+++ b/src/huey/memory/pipeline/__init__.py
@@ -1,0 +1,39 @@
+"""Memory ingestion, metadata, and indexing helpers."""
+
+from huey.memory.pipeline.indexing import (
+    build_index,
+    rebuild_index,
+    search_index,
+    update_index,
+)
+from huey.memory.pipeline.ingestion import (
+    ingest_audio,
+    ingest_json,
+    ingest_md,
+    ingest_pdf,
+    ingest_txt,
+    ingest_video,
+)
+from huey.memory.pipeline.metadata import (
+    file_hash,
+    file_stats,
+    file_summary,
+    generate_metadata,
+)
+
+__all__ = [
+    "build_index",
+    "file_hash",
+    "file_stats",
+    "file_summary",
+    "generate_metadata",
+    "ingest_audio",
+    "ingest_json",
+    "ingest_md",
+    "ingest_pdf",
+    "ingest_txt",
+    "ingest_video",
+    "rebuild_index",
+    "search_index",
+    "update_index",
+]

--- a/src/huey/memory/pipeline/indexing.py
+++ b/src/huey/memory/pipeline/indexing.py
@@ -1,0 +1,136 @@
+"""Simple JSON indexing helpers for the shared memory pipeline."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from huey.memory.pipeline.ingestion import (
+    ingest_audio,
+    ingest_json,
+    ingest_md,
+    ingest_pdf,
+    ingest_txt,
+    ingest_video,
+)
+from huey.utils.paths import ensure_subdirectory, get_memory_path
+
+SUPPORTED_EXTENSIONS = {
+    ".txt": ingest_txt,
+    ".md": ingest_md,
+    ".json": ingest_json,
+    ".pdf": ingest_pdf,
+    ".mp3": ingest_audio,
+    ".wav": ingest_audio,
+    ".flac": ingest_audio,
+    ".m4a": ingest_audio,
+    ".mp4": ingest_video,
+    ".mov": ingest_video,
+    ".mkv": ingest_video,
+}
+
+
+def default_index_path() -> Path:
+    """Return the default JSON index path."""
+
+    return ensure_subdirectory("INDEX") / "memory-index.json"
+
+
+def _load_index(path: Path | None = None) -> list[dict[str, object]]:
+    selected = path or default_index_path()
+    if not selected.exists():
+        return []
+    return json.loads(selected.read_text(encoding="utf-8"))
+
+
+def _save_index(records: list[dict[str, object]], path: Path | None = None) -> Path:
+    selected = path or default_index_path()
+    selected.parent.mkdir(parents=True, exist_ok=True)
+    selected.write_text(json.dumps(records, indent=2, sort_keys=True), encoding="utf-8")
+    return selected
+
+
+def _ingest_path(path: Path) -> dict[str, object] | None:
+    handler = SUPPORTED_EXTENSIONS.get(path.suffix.lower())
+    if handler is None:
+        return None
+    return handler(path, store_copy=False)
+
+
+def build_index(
+    paths: list[str | Path],
+    *,
+    index_path: Path | None = None,
+) -> list[dict[str, object]]:
+    """Build an index from explicit file paths."""
+
+    records = []
+    for value in paths:
+        record = _ingest_path(Path(value).expanduser().resolve())
+        if record is not None:
+            records.append(record)
+    _save_index(records, index_path)
+    return records
+
+
+def rebuild_index(
+    root: str | Path | None = None,
+    *,
+    index_path: Path | None = None,
+) -> list[dict[str, object]]:
+    """Rebuild the index by walking a memory root."""
+
+    base = Path(root).expanduser().resolve() if root else get_memory_path(create=True)
+    paths = [
+        path
+        for path in base.rglob("*")
+        if path.is_file() and path.suffix.lower() in SUPPORTED_EXTENSIONS
+    ]
+    return build_index(paths, index_path=index_path)
+
+
+def update_index(
+    record: dict[str, object],
+    *,
+    index_path: Path | None = None,
+) -> list[dict[str, object]]:
+    """Insert or replace a single record in the JSON index."""
+
+    records = _load_index(index_path)
+    path_value = str(record.get("path"))
+    updated = [item for item in records if str(item.get("path")) != path_value]
+    updated.append(record)
+    _save_index(updated, index_path)
+    return updated
+
+
+def search_index(
+    query: str,
+    *,
+    index_path: Path | None = None,
+) -> list[dict[str, object]]:
+    """Search the index for a query string across paths, summaries, and content."""
+
+    needle = query.strip().lower()
+    if not needle:
+        return []
+    matches = []
+    for record in _load_index(index_path):
+        haystacks = [
+            str(record.get("path", "")),
+            str(record.get("kind", "")),
+            str(record.get("content", "")),
+            str(record.get("metadata", {}).get("summary", "")),
+        ]
+        if any(needle in haystack.lower() for haystack in haystacks):
+            matches.append(record)
+    return matches
+
+
+__all__ = [
+    "build_index",
+    "default_index_path",
+    "rebuild_index",
+    "search_index",
+    "update_index",
+]

--- a/src/huey/memory/pipeline/ingestion.py
+++ b/src/huey/memory/pipeline/ingestion.py
@@ -1,0 +1,124 @@
+"""Unified ingestion helpers for common memory inputs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from shutil import copy2
+
+from huey.media.media_manager import probe_media
+from huey.memory.pipeline.metadata import generate_metadata
+from huey.utils.paths import ensure_subdirectory
+
+
+def _store_copy(source: Path, category: str) -> Path:
+    target_dir = ensure_subdirectory("INGESTED", category.upper())
+    target_path = target_dir / source.name
+    copy2(source, target_path)
+    return target_path
+
+
+def ingest_txt(path: str | Path, *, store_copy: bool = True) -> dict[str, object]:
+    """Ingest a plain-text file into the memory pipeline."""
+
+    source = Path(path).expanduser().resolve()
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    stored_path = _store_copy(source, "txt") if store_copy else source
+    return {
+        "kind": "txt",
+        "path": str(stored_path),
+        "content": stored_path.read_text(encoding="utf-8", errors="replace"),
+        "metadata": generate_metadata(stored_path),
+    }
+
+
+def ingest_md(path: str | Path, *, store_copy: bool = True) -> dict[str, object]:
+    """Ingest a Markdown file."""
+
+    payload = ingest_txt(path, store_copy=store_copy)
+    payload["kind"] = "md"
+    return payload
+
+
+def ingest_json(path: str | Path, *, store_copy: bool = True) -> dict[str, object]:
+    """Ingest a JSON file."""
+
+    source = Path(path).expanduser().resolve()
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    stored_path = _store_copy(source, "json") if store_copy else source
+    data = json.loads(stored_path.read_text(encoding="utf-8"))
+    return {
+        "kind": "json",
+        "path": str(stored_path),
+        "content": data,
+        "metadata": generate_metadata(stored_path),
+    }
+
+
+def ingest_pdf(path: str | Path, *, store_copy: bool = True) -> dict[str, object]:
+    """Ingest a PDF document, extracting text when a parser is available."""
+
+    source = Path(path).expanduser().resolve()
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    stored_path = _store_copy(source, "pdf") if store_copy else source
+    pages: list[str] = []
+    parser = "unavailable"
+    try:
+        from pypdf import PdfReader
+
+        reader = PdfReader(str(stored_path))
+        pages = [(page.extract_text() or "").strip() for page in reader.pages]
+        parser = "pypdf"
+    except ImportError:
+        pages = []
+    return {
+        "kind": "pdf",
+        "path": str(stored_path),
+        "content": "\n\n".join(page for page in pages if page),
+        "page_count": len(pages),
+        "parser": parser,
+        "metadata": generate_metadata(stored_path),
+    }
+
+
+def ingest_audio(path: str | Path, *, store_copy: bool = True) -> dict[str, object]:
+    """Ingest an audio file and capture probe metadata."""
+
+    source = Path(path).expanduser().resolve()
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    stored_path = _store_copy(source, "audio") if store_copy else source
+    return {
+        "kind": "audio",
+        "path": str(stored_path),
+        "probe": probe_media(stored_path),
+        "metadata": generate_metadata(stored_path),
+    }
+
+
+def ingest_video(path: str | Path, *, store_copy: bool = True) -> dict[str, object]:
+    """Ingest a video file and capture probe metadata."""
+
+    source = Path(path).expanduser().resolve()
+    if not source.is_file():
+        raise FileNotFoundError(source)
+    stored_path = _store_copy(source, "video") if store_copy else source
+    return {
+        "kind": "video",
+        "path": str(stored_path),
+        "probe": probe_media(stored_path),
+        "metadata": generate_metadata(stored_path),
+    }
+
+
+__all__ = [
+    "ingest_audio",
+    "ingest_json",
+    "ingest_md",
+    "ingest_pdf",
+    "ingest_txt",
+    "ingest_video",
+]

--- a/src/huey/memory/pipeline/metadata.py
+++ b/src/huey/memory/pipeline/metadata.py
@@ -1,0 +1,76 @@
+"""Metadata helpers for files entering HueyOS memory."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from huey.media.media_manager import probe_media
+
+
+def file_hash(path: str | Path, *, algorithm: str = "sha256") -> str:
+    """Return the file hash for a path."""
+
+    target = Path(path).expanduser().resolve()
+    if not target.is_file():
+        raise FileNotFoundError(target)
+    hasher = hashlib.new(algorithm)
+    with target.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def file_stats(path: str | Path) -> dict[str, object]:
+    """Return filesystem metadata for a file."""
+
+    target = Path(path).expanduser().resolve()
+    if not target.is_file():
+        raise FileNotFoundError(target)
+    stat = target.stat()
+    return {
+        "path": str(target),
+        "name": target.name,
+        "suffix": target.suffix.lower(),
+        "size_bytes": stat.st_size,
+        "modified_at": datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
+    }
+
+
+def file_summary(path: str | Path, *, max_chars: int = 240) -> str:
+    """Return a short summary of a file."""
+
+    target = Path(path).expanduser().resolve()
+    suffix = target.suffix.lower()
+    if suffix in {".txt", ".md", ".py", ".json", ".yaml", ".yml"}:
+        content = target.read_text(encoding="utf-8", errors="replace").strip()
+        if suffix == ".json":
+            try:
+                parsed = json.loads(content)
+            except json.JSONDecodeError:
+                return content[:max_chars]
+            return json.dumps(parsed, sort_keys=True)[:max_chars]
+        return content[:max_chars]
+    if suffix in {".mp3", ".wav", ".flac", ".m4a", ".mp4", ".mov", ".mkv"}:
+        try:
+            metadata = probe_media(target)
+        except (OSError, RuntimeError, ValueError):
+            return f"Media file: {target.name}"
+        duration = metadata.get("format", {}).get("duration", "unknown")
+        return f"Media file ({target.name}) duration={duration}"
+    return f"Binary file: {target.name}"
+
+
+def generate_metadata(path: str | Path) -> dict[str, object]:
+    """Generate a combined metadata payload for a file."""
+
+    target = Path(path).expanduser().resolve()
+    payload = file_stats(target)
+    payload["sha256"] = file_hash(target)
+    payload["summary"] = file_summary(target)
+    return payload
+
+
+__all__ = ["file_hash", "file_stats", "file_summary", "generate_metadata"]

--- a/src/huey/runtime/__init__.py
+++ b/src/huey/runtime/__init__.py
@@ -1,0 +1,12 @@
+"""Runtime orchestration primitives for HueyOS."""
+
+from huey.runtime.dependency_graph import DependencyGraph
+from huey.runtime.orchestrator import RuntimeOrchestrator
+from huey.runtime.service_registry import ServiceRecord, ServiceRegistry
+
+__all__ = [
+    "DependencyGraph",
+    "RuntimeOrchestrator",
+    "ServiceRecord",
+    "ServiceRegistry",
+]

--- a/src/huey/runtime/dependency_graph.py
+++ b/src/huey/runtime/dependency_graph.py
@@ -1,0 +1,58 @@
+"""Dependency tracking for runtime startup and health ordering."""
+
+from __future__ import annotations
+
+
+class DependencyGraph:
+    """Track service dependencies and compute safe startup order."""
+
+    def __init__(self) -> None:
+        self._dependencies: dict[str, set[str]] = {}
+
+    def register(
+        self, service: str, depends_on: list[str] | tuple[str, ...] = ()
+    ) -> None:
+        self._dependencies.setdefault(service, set()).update(depends_on)
+        for dependency in depends_on:
+            self._dependencies.setdefault(dependency, set())
+
+    def add_dependency(self, service: str, dependency: str) -> None:
+        self.register(service, (dependency,))
+
+    def dependencies_for(self, service: str) -> list[str]:
+        return sorted(self._dependencies.get(service, set()))
+
+    def dependents_for(self, service: str) -> list[str]:
+        return sorted(
+            name
+            for name, dependencies in self._dependencies.items()
+            if service in dependencies
+        )
+
+    def startup_order(self) -> list[str]:
+        dependencies = {
+            name: set(values) for name, values in self._dependencies.items()
+        }
+        order: list[str] = []
+        ready = sorted(name for name, values in dependencies.items() if not values)
+        while ready:
+            current = ready.pop(0)
+            order.append(current)
+            for dependent in self.dependents_for(current):
+                remaining = dependencies[dependent]
+                remaining.discard(current)
+                if not remaining and dependent not in order and dependent not in ready:
+                    ready.append(dependent)
+                    ready.sort()
+        unresolved = {name: values for name, values in dependencies.items() if values}
+        if unresolved:
+            raise ValueError(f"Dependency cycle detected: {unresolved}")
+        return order
+
+    def as_dict(self) -> dict[str, list[str]]:
+        return {
+            name: sorted(values) for name, values in sorted(self._dependencies.items())
+        }
+
+
+__all__ = ["DependencyGraph"]

--- a/src/huey/runtime/orchestrator.py
+++ b/src/huey/runtime/orchestrator.py
@@ -1,0 +1,248 @@
+"""Master runtime coordinator for HueyOS subsystem integration."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Callable
+
+from huey.media.ffmpeg_validator import validate_media_environment
+from huey.runtime.dependency_graph import DependencyGraph
+from huey.runtime.service_registry import ServiceRecord, ServiceRegistry
+from huey.utils.paths import get_memory_path
+
+HealthPayload = dict[str, object] | bool | str | None
+
+
+class RuntimeOrchestrator:
+    """Coordinate subsystem registration, dependency order, and health state."""
+
+    def __init__(self, *, bootstrap_defaults: bool = True) -> None:
+        self.registry = ServiceRegistry()
+        self.dependency_graph = DependencyGraph()
+        self.pipelines: dict[str, dict[str, object]] = {}
+        self.models: dict[str, dict[str, object]] = {}
+        self._started = False
+        if bootstrap_defaults:
+            self._bootstrap_defaults()
+
+    def register_service(
+        self,
+        name: str,
+        description: str,
+        *,
+        dependencies: list[str] | tuple[str, ...] = (),
+        status: str = "unknown",
+        metadata: dict[str, object] | None = None,
+        healthcheck: Callable[[], HealthPayload] | None = None,
+    ) -> ServiceRecord:
+        record = self.registry.register_service(
+            name,
+            description,
+            dependencies=dependencies,
+            status=status,
+            metadata=metadata,
+            healthcheck=healthcheck,
+        )
+        self.dependency_graph.register(name, list(dependencies))
+        return record
+
+    def register_pipeline(
+        self,
+        name: str,
+        *,
+        description: str,
+        steps: list[str],
+        metadata: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        payload = {
+            "name": name,
+            "description": description,
+            "steps": list(steps),
+            "metadata": dict(metadata or {}),
+        }
+        self.pipelines[name] = payload
+        return payload
+
+    def register_model(
+        self,
+        name: str,
+        *,
+        provider: str,
+        metadata: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        payload = {
+            "name": name,
+            "provider": provider,
+            "metadata": dict(metadata or {}),
+        }
+        self.models[name] = payload
+        return payload
+
+    def start(self) -> dict[str, object]:
+        """Mark the orchestrator active and return the planned startup order."""
+
+        self._started = True
+        order = self.dependency_graph.startup_order()
+        for service_name in order:
+            record = self.registry.get(service_name)
+            if record.status in {"unknown", "stopped"}:
+                record.status = "ready"
+        return {"started": True, "startup_order": order}
+
+    def stop(self) -> dict[str, object]:
+        """Mark the orchestrator stopped."""
+
+        self._started = False
+        for record in self.registry.all():
+            if record.status != "blocked":
+                record.status = "stopped"
+        return {"started": False}
+
+    def restart(self) -> dict[str, object]:
+        """Restart orchestration state."""
+
+        self.stop()
+        return self.start()
+
+    def health_check(self) -> dict[str, dict[str, object]]:
+        """Run service health checks and update registry state."""
+
+        results: dict[str, dict[str, object]] = {}
+        for record in self.registry.all():
+            payload = self._run_healthcheck(record)
+            results[record.name] = payload
+        return results
+
+    def status(self) -> dict[str, object]:
+        """Return a serializable runtime status snapshot."""
+
+        return {
+            "started": self._started,
+            "startup_order": self.dependency_graph.startup_order(),
+            "services": self.registry.as_dict(),
+            "pipelines": dict(self.pipelines),
+            "models": dict(self.models),
+            "dependencies": self.dependency_graph.as_dict(),
+        }
+
+    def _bootstrap_defaults(self) -> None:
+        self.register_service(
+            "memory",
+            "Shared memory workspace and ingestable storage tree.",
+            healthcheck=lambda: {
+                "ready": get_memory_path(create=True).exists(),
+                "path": str(get_memory_path(create=True)),
+            },
+        )
+        self.register_service(
+            "ffmpeg",
+            "FFmpeg and ffprobe media processing toolchain.",
+            healthcheck=validate_media_environment,
+        )
+        self.register_service(
+            "transcription",
+            "Speech pipeline and Whisper-compatible transcription stack.",
+            dependencies=("ffmpeg",),
+            healthcheck=lambda: {
+                "ready": importlib.util.find_spec("faster_whisper") is not None,
+                "module": "faster_whisper",
+            },
+        )
+        self.register_service(
+            "api",
+            "HueyOS API health surface.",
+            dependencies=("memory",),
+            healthcheck=self._check_api,
+        )
+        self.register_service(
+            "command_center",
+            "Read-only local backend for the external Command Center frontend.",
+            dependencies=("api",),
+            healthcheck=self._check_command_center,
+        )
+        self.register_service(
+            "pyhuey",
+            "PyHuey cockpit integration adapter.",
+            dependencies=("api",),
+            healthcheck=self._check_pyhuey,
+        )
+        self.register_service(
+            "ollama",
+            "Optional local model provider.",
+            healthcheck=lambda: {
+                "ready": importlib.util.find_spec("ollama") is not None,
+                "module": "ollama",
+            },
+        )
+        self.register_pipeline(
+            "v1-proof-loop",
+            description="Controlled MP3 fixture -> transcription -> cognition -> structured log.",
+            steps=[
+                "prepare-media",
+                "transcribe-fixture",
+                "generate-response",
+                "write-run-record",
+            ],
+        )
+        self.register_model(
+            "default-ollama",
+            provider="ollama",
+            metadata={"available": importlib.util.find_spec("ollama") is not None},
+        )
+
+    @staticmethod
+    def _check_api() -> dict[str, object]:
+        from huey.os.api.routers.system import healthz
+
+        payload = healthz()
+        return {
+            "ready": payload.get("status") == "ok",
+            "payload": payload,
+        }
+
+    @staticmethod
+    def _check_command_center() -> dict[str, object]:
+        from huey.apps.command_center.server import create_app
+
+        app = create_app()
+        paths = {route.path for route in app.routes}
+        return {
+            "ready": "/command-center/meta" in paths,
+            "route_count": len(paths),
+        }
+
+    @staticmethod
+    def _check_pyhuey() -> dict[str, object]:
+        from huey.connectors.pyhuey.adapter import get_status
+
+        return get_status()
+
+    def _run_healthcheck(self, record: ServiceRecord) -> dict[str, object]:
+        if record.healthcheck is None:
+            payload = {"ready": record.status == "ready"}
+        else:
+            try:
+                raw = record.healthcheck()
+            except (ImportError, OSError, RuntimeError, ValueError) as exc:
+                raw = {"ready": False, "error": str(exc)}
+            payload = self._normalise_health_payload(raw)
+
+        record.status = "ready" if payload.get("ready") else "blocked"
+        record.metadata.update(payload)
+        return payload
+
+    @staticmethod
+    def _normalise_health_payload(raw: HealthPayload) -> dict[str, object]:
+        if raw is None:
+            return {"ready": False}
+        if isinstance(raw, bool):
+            return {"ready": raw}
+        if isinstance(raw, str):
+            return {"ready": bool(raw), "status": raw}
+        payload = dict(raw)
+        if "ready" not in payload:
+            payload["ready"] = payload.get("status") == "ok"
+        return payload
+
+
+__all__ = ["RuntimeOrchestrator"]

--- a/src/huey/runtime/service_registry.py
+++ b/src/huey/runtime/service_registry.py
@@ -1,0 +1,93 @@
+"""Registry of runtime services, dependencies, and health metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+ServiceHealthcheck = Callable[[], dict[str, object] | bool | str | None]
+
+
+@dataclass
+class ServiceRecord:
+    name: str
+    description: str
+    dependencies: list[str] = field(default_factory=list)
+    status: str = "unknown"
+    kind: str = "service"
+    metadata: dict[str, object] = field(default_factory=dict)
+    healthcheck: ServiceHealthcheck | None = field(
+        default=None, repr=False, compare=False
+    )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "dependencies": list(self.dependencies),
+            "status": self.status,
+            "kind": self.kind,
+            "metadata": dict(self.metadata),
+        }
+
+
+class ServiceRegistry:
+    """Track runtime services and expose serializable summaries."""
+
+    def __init__(self) -> None:
+        self._services: dict[str, ServiceRecord] = {}
+
+    def register(self, record: ServiceRecord) -> ServiceRecord:
+        self._services[record.name] = record
+        return record
+
+    def register_service(
+        self,
+        name: str,
+        description: str,
+        *,
+        dependencies: list[str] | tuple[str, ...] = (),
+        status: str = "unknown",
+        kind: str = "service",
+        metadata: dict[str, object] | None = None,
+        healthcheck: ServiceHealthcheck | None = None,
+    ) -> ServiceRecord:
+        return self.register(
+            ServiceRecord(
+                name=name,
+                description=description,
+                dependencies=list(dependencies),
+                status=status,
+                kind=kind,
+                metadata=dict(metadata or {}),
+                healthcheck=healthcheck,
+            )
+        )
+
+    def get(self, name: str) -> ServiceRecord:
+        return self._services[name]
+
+    def update_status(
+        self,
+        name: str,
+        status: str,
+        *,
+        metadata: dict[str, object] | None = None,
+    ) -> ServiceRecord:
+        record = self.get(name)
+        record.status = status
+        if metadata:
+            record.metadata.update(metadata)
+        return record
+
+    def all(self) -> list[ServiceRecord]:
+        return [self._services[name] for name in sorted(self._services)]
+
+    def ready_services(self) -> list[ServiceRecord]:
+        return [record for record in self.all() if record.status == "ready"]
+
+    def as_dict(self) -> dict[str, dict[str, object]]:
+        return {record.name: record.as_dict() for record in self.all()}
+
+
+__all__ = ["ServiceRecord", "ServiceRegistry"]

--- a/src/huey/v1/__init__.py
+++ b/src/huey/v1/__init__.py
@@ -1,0 +1,27 @@
+"""Dedicated V1 proof-loop helpers."""
+
+from huey.v1.fixture_registry import list_fixtures, load_fixture, register_fixture
+from huey.v1.proof_loop import (
+    generate_report,
+    run_all_fixtures,
+    run_fixture,
+    validate_result,
+)
+from huey.v1.report_generator import (
+    generate_html_report,
+    generate_json_report,
+    generate_markdown_report,
+)
+
+__all__ = [
+    "generate_html_report",
+    "generate_json_report",
+    "generate_markdown_report",
+    "generate_report",
+    "list_fixtures",
+    "load_fixture",
+    "register_fixture",
+    "run_all_fixtures",
+    "run_fixture",
+    "validate_result",
+]

--- a/src/huey/v1/fixture_registry.py
+++ b/src/huey/v1/fixture_registry.py
@@ -1,0 +1,84 @@
+"""Registry helpers for V1 proof-loop fixtures."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from shutil import copy2
+
+from huey.memory.pipeline.metadata import generate_metadata
+from huey.utils.paths import ensure_subdirectory
+
+
+def _registry_path(path: Path | None = None) -> Path:
+    return path or (ensure_subdirectory("V1", "fixtures") / "registry.json")
+
+
+def _read_registry(path: Path | None = None) -> dict[str, dict[str, object]]:
+    registry_path = _registry_path(path)
+    if not registry_path.exists():
+        return {}
+    return json.loads(registry_path.read_text(encoding="utf-8"))
+
+
+def _write_registry(
+    payload: dict[str, dict[str, object]], path: Path | None = None
+) -> Path:
+    registry_path = _registry_path(path)
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    return registry_path
+
+
+def register_fixture(
+    source: str | Path,
+    *,
+    fixture_id: str | None = None,
+    description: str = "",
+    copy_to_registry: bool = False,
+    registry_path: Path | None = None,
+) -> dict[str, object]:
+    """Register a fixture path in the V1 registry."""
+
+    source_path = Path(source).expanduser().resolve()
+    if not source_path.is_file():
+        raise FileNotFoundError(source_path)
+    target_path = source_path
+    if copy_to_registry:
+        fixtures_dir = ensure_subdirectory("V1", "fixtures")
+        target_path = fixtures_dir / source_path.name
+        copy2(source_path, target_path)
+    key = fixture_id or source_path.stem
+    entry = {
+        "id": key,
+        "path": str(target_path),
+        "description": description or f"Fixture for {source_path.name}",
+        "metadata": generate_metadata(target_path),
+    }
+    payload = _read_registry(registry_path)
+    payload[key] = entry
+    _write_registry(payload, registry_path)
+    return entry
+
+
+def load_fixture(
+    fixture_id: str, *, registry_path: Path | None = None
+) -> dict[str, object]:
+    """Return fixture metadata from the registry."""
+
+    payload = _read_registry(registry_path)
+    if fixture_id not in payload:
+        raise KeyError(f"Unknown fixture id: {fixture_id}")
+    return payload[fixture_id]
+
+
+def list_fixtures(*, registry_path: Path | None = None) -> list[dict[str, object]]:
+    """List every registered V1 fixture."""
+
+    payload = _read_registry(registry_path)
+    return [payload[key] for key in sorted(payload)]
+
+
+__all__ = ["list_fixtures", "load_fixture", "register_fixture"]

--- a/src/huey/v1/proof_loop.py
+++ b/src/huey/v1/proof_loop.py
@@ -1,0 +1,120 @@
+"""Higher-level V1 fixture orchestration built on the CI-safe runtime loop."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+from huey.audio.transcription_pipeline import transcribe
+from huey.os.runtime.v1_loop import run_v1_loop
+from huey.utils.paths import ensure_subdirectory
+from huey.v1.fixture_registry import list_fixtures, load_fixture
+
+CognitionFunc = Callable[[str], dict[str, str] | str]
+TranscribeFunc = Callable[[str], dict[str, object] | str]
+
+
+def _default_cognition(transcript: str | None) -> dict[str, str]:
+    summary = (transcript or "").strip()[:160]
+    return {
+        "cognition_provider": "offline-stub",
+        "cognition_model": "rule-based-summary",
+        "response": f"Processed fixture transcript: {summary or 'no transcript available'}",
+    }
+
+
+def _default_log_dir(path: Path | None = None) -> Path:
+    selected = path or ensure_subdirectory("V1", "runs")
+    selected.mkdir(parents=True, exist_ok=True)
+    return selected
+
+
+def run_fixture(
+    fixture: str | Path | dict[str, object],
+    *,
+    transcribe_func: TranscribeFunc | None = None,
+    cognition_func: CognitionFunc | None = None,
+    log_dir: str | Path | None = None,
+    mock: bool = True,
+) -> dict[str, object]:
+    """Run the V1 fixture loop for a single source file."""
+
+    if isinstance(fixture, dict):
+        source_file = str(fixture["path"])
+    else:
+        source_file = str(Path(fixture).expanduser().resolve())
+    selected_log_dir = _default_log_dir(Path(log_dir) if log_dir else None)
+    jsonl_path = selected_log_dir / "v1-runs.jsonl"
+
+    def _transcribe(source_path: str) -> dict[str, object] | str:
+        if transcribe_func is not None:
+            return transcribe_func(source_path)
+        return transcribe(source_path, mock=mock)
+
+    def _cognition(transcript_value: str | None) -> dict[str, str] | str:
+        if cognition_func is not None:
+            return cognition_func(transcript_value or "")
+        return _default_cognition(transcript_value)
+
+    def _log_writer(record: dict[str, object]) -> None:
+        record_path = selected_log_dir / f"{record['run_id']}.json"
+        record_path.write_text(
+            json.dumps(record, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        with jsonl_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True))
+            handle.write("\n")
+
+    return run_v1_loop(source_file, _transcribe, _cognition, _log_writer)
+
+
+def run_all_fixtures(
+    fixtures: list[str | Path] | None = None,
+    *,
+    fixture_ids: list[str] | None = None,
+    log_dir: str | Path | None = None,
+    mock: bool = True,
+) -> list[dict[str, object]]:
+    """Run the V1 loop across explicit or registered fixtures."""
+
+    work_items: list[str | Path | dict[str, object]]
+    if fixtures is not None:
+        work_items = fixtures
+    elif fixture_ids:
+        work_items = [load_fixture(fixture_id) for fixture_id in fixture_ids]
+    else:
+        work_items = list_fixtures()
+    return [run_fixture(item, log_dir=log_dir, mock=mock) for item in work_items]
+
+
+def validate_result(run_record: dict[str, object]) -> bool:
+    """Return ``True`` when a run record satisfies the V1 proof-loop contract."""
+
+    return bool(
+        run_record.get("exit_status") == "success"
+        and run_record.get("transcript")
+        and run_record.get("response")
+    )
+
+
+def generate_report(run_records: list[dict[str, object]]) -> dict[str, object]:
+    """Return an aggregate summary for a batch of V1 runs."""
+
+    total = len(run_records)
+    successful = sum(1 for record in run_records if validate_result(record))
+    failed = total - successful
+    return {
+        "total": total,
+        "successful": successful,
+        "failed": failed,
+        "success_rate": (successful / total) if total else 0.0,
+        "failed_runs": [
+            record.get("run_id")
+            for record in run_records
+            if not validate_result(record)
+        ],
+    }
+
+
+__all__ = ["generate_report", "run_all_fixtures", "run_fixture", "validate_result"]

--- a/src/huey/v1/report_generator.py
+++ b/src/huey/v1/report_generator.py
@@ -1,0 +1,76 @@
+"""Report generation helpers for V1 fixture runs."""
+
+from __future__ import annotations
+
+import json
+
+from huey.v1.proof_loop import generate_report
+
+
+def generate_json_report(run_records: list[dict[str, object]]) -> str:
+    """Return a JSON report for V1 runs."""
+
+    payload = {
+        "summary": generate_report(run_records),
+        "runs": run_records,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def generate_markdown_report(run_records: list[dict[str, object]]) -> str:
+    """Return a Markdown report for V1 runs."""
+
+    summary = generate_report(run_records)
+    lines = [
+        "# V1 Proof Loop Report",
+        "",
+        f"- Total runs: {summary['total']}",
+        f"- Successful: {summary['successful']}",
+        f"- Failed: {summary['failed']}",
+        f"- Success rate: {summary['success_rate']:.2%}",
+        "",
+        "| Run ID | Status | Transcript | Response |",
+        "| --- | --- | --- | --- |",
+    ]
+    for record in run_records:
+        status = "success" if record.get("exit_status") == "success" else "failed"
+        transcript = str(record.get("transcript") or "").replace("\n", " ")[:60]
+        response = str(record.get("response") or "").replace("\n", " ")[:60]
+        lines.append(
+            f"| {record.get('run_id')} | {status} | {transcript} | {response} |"
+        )
+    return "\n".join(lines)
+
+
+def generate_html_report(run_records: list[dict[str, object]]) -> str:
+    """Return a lightweight HTML report for V1 runs."""
+
+    summary = generate_report(run_records)
+    rows = []
+    for record in run_records:
+        status = "success" if record.get("exit_status") == "success" else "failed"
+        rows.append(
+            "<tr>"
+            f"<td>{record.get('run_id')}</td>"
+            f"<td>{status}</td>"
+            f"<td>{record.get('transcript', '')}</td>"
+            f"<td>{record.get('response', '')}</td>"
+            "</tr>"
+        )
+    return (
+        "<html><body>"
+        "<h1>V1 Proof Loop Report</h1>"
+        f"<p>Total: {summary['total']} | Successful: {summary['successful']} | "
+        f"Failed: {summary['failed']}</p>"
+        "<table border='1'><thead><tr><th>Run ID</th><th>Status</th>"
+        "<th>Transcript</th><th>Response</th></tr></thead><tbody>"
+        f"{''.join(rows)}"
+        "</tbody></table></body></html>"
+    )
+
+
+__all__ = [
+    "generate_html_report",
+    "generate_json_report",
+    "generate_markdown_report",
+]

--- a/tests/test_command_center_backend.py
+++ b/tests/test_command_center_backend.py
@@ -1,0 +1,48 @@
+"""Tests for the read-only Command Center backend."""
+
+from __future__ import annotations
+
+from huey.apps.command_center.server import (
+    create_app,
+    get_app_metadata,
+    get_safety_policy,
+    get_validation_commands,
+)
+
+
+def test_create_app_exposes_meta_route():
+    app = create_app()
+    paths = {route.path for route in app.routes}
+
+    assert "/command-center/meta" in paths
+    assert get_app_metadata()["mode"] == "read-only"
+
+
+def test_create_app_exposes_safety_route():
+    app = create_app()
+    paths = {route.path for route in app.routes}
+
+    assert "/command-center/safety" in paths
+    assert get_safety_policy()["mock_only"] is True
+
+
+def test_create_app_exposes_validation_route():
+    app = create_app()
+    paths = {route.path for route in app.routes}
+    commands = get_validation_commands()
+
+    assert "/command-center/validation" in paths
+    assert commands
+    assert all(command["copy_only"] for command in commands)
+
+
+def test_backend_does_not_expose_command_execution_route():
+    app = create_app()
+    paths = {route.path: route.methods for route in app.routes}
+
+    assert "/command-center/execute" not in paths
+    assert all(
+        "POST" not in (methods or set())
+        for path, methods in paths.items()
+        if path.startswith("/command-center/")
+    )

--- a/tests/test_gui_models.py
+++ b/tests/test_gui_models.py
@@ -1,0 +1,30 @@
+"""Tests for canonical GUI defaults and validation metadata."""
+
+from huey.gui.defaults import (
+    default_migration_phases,
+    default_repositories,
+    default_validation_commands,
+)
+
+
+def test_default_repositories_include_umbrella_repos():
+    full_names = {repo.full_name for repo in default_repositories()}
+
+    assert "DylanLRPollock/Monkey-Head-Project" in full_names
+    assert "DylanLRPollock/PyHuey" in full_names
+    assert "DylanLRPollock/command-center" in full_names
+    assert "DylanLRPollock/dlrp.ca" in full_names
+
+
+def test_default_phases_include_phase_2_5_and_phase_3():
+    phase_ids = {phase.id for phase in default_migration_phases()}
+
+    assert "phase-2-5-pyhuey-connector" in phase_ids
+    assert "phase-3-pyhuey-rename" in phase_ids
+
+
+def test_validation_commands_are_copy_only():
+    commands = default_validation_commands()
+
+    assert commands
+    assert all(command.copy_only for command in commands)

--- a/tests/test_gui_theme.py
+++ b/tests/test_gui_theme.py
@@ -1,0 +1,30 @@
+"""Tests for the canonical GUI theme helpers."""
+
+from huey.gui.theme import as_css_variables, as_tk_palette, get_default_theme
+
+
+def test_default_theme_has_required_colors():
+    theme = get_default_theme()
+
+    assert theme.background.startswith("#")
+    assert theme.panel.startswith("#")
+    assert theme.text.startswith("#")
+    assert theme.accent.startswith("#")
+
+
+def test_tk_palette_contains_legacy_keys():
+    palette = as_tk_palette()
+
+    assert palette["background"]
+    assert palette["text"]
+    assert palette["accent"]
+    assert palette["dark_bg"] == palette["background"]
+    assert palette["light_fg"] == palette["text"]
+    assert palette["accent_purple"] == palette["accent"]
+
+
+def test_css_variables_are_prefixed():
+    css_variables = as_css_variables()
+
+    assert css_variables
+    assert all(key.startswith("--huey-") for key in css_variables)

--- a/tests/test_legacy_gui_adapters.py
+++ b/tests/test_legacy_gui_adapters.py
@@ -1,0 +1,36 @@
+"""Tests for legacy GUI availability adapters."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from huey.gui.legacy_adapters import (
+    legacy_ai_tools_gui_available,
+    legacy_gui_status,
+    legacy_license_gui_available,
+)
+
+
+def test_legacy_gui_status_returns_booleans():
+    status = legacy_gui_status()
+
+    assert isinstance(status["license_gui"], bool)
+    assert isinstance(status["ai_tools_gui"], bool)
+
+
+def test_legacy_license_gui_import_check_does_not_launch():
+    with (
+        patch("huey.gui.legacy_adapters.find_spec", return_value=object()),
+        patch("huey.gui.legacy_adapters.import_module") as import_module,
+    ):
+        assert legacy_license_gui_available() is True
+        import_module.assert_not_called()
+
+
+def test_legacy_ai_tools_gui_import_check_does_not_launch():
+    with (
+        patch("huey.gui.legacy_adapters.find_spec", return_value=object()),
+        patch("huey.gui.legacy_adapters.import_module") as import_module,
+    ):
+        assert legacy_ai_tools_gui_available() is True
+        import_module.assert_not_called()

--- a/tests/test_media_stack.py
+++ b/tests/test_media_stack.py
@@ -1,0 +1,33 @@
+"""Tests for the FFmpeg media wrapper layer."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from huey.media.ffmpeg_validator import validate_media_environment
+from huey.media.media_manager import probe_media
+
+
+def test_validate_media_environment_reports_missing_tools():
+    with patch("huey.media.ffmpeg_validator.shutil.which", return_value=None):
+        payload = validate_media_environment()
+
+    assert payload["ready"] is False
+    assert payload["ffmpeg"] is False
+    assert payload["ffprobe"] is False
+
+
+def test_probe_media_parses_ffprobe_json(tmp_path):
+    media_file = tmp_path / "fixture.wav"
+    media_file.write_bytes(b"data")
+
+    with patch(
+        "huey.media.media_manager._run_ffprobe",
+        return_value=SimpleNamespace(
+            stdout='{"format": {"duration": "1.23"}, "streams": []}'
+        ),
+    ):
+        payload = probe_media(media_file)
+
+    assert payload["format"]["duration"] == "1.23"

--- a/tests/test_runtime_orchestrator.py
+++ b/tests/test_runtime_orchestrator.py
@@ -1,0 +1,27 @@
+"""Tests for the runtime orchestrator."""
+
+from huey.runtime.orchestrator import RuntimeOrchestrator
+
+
+def test_orchestrator_registers_default_services():
+    orchestrator = RuntimeOrchestrator()
+    status = orchestrator.status()
+
+    assert "ffmpeg" in status["services"]
+    assert "command_center" in status["services"]
+    assert "transcription" in status["dependencies"]
+    assert "ffmpeg" in status["dependencies"]["transcription"]
+
+
+def test_orchestrator_health_check_updates_service_status():
+    orchestrator = RuntimeOrchestrator(bootstrap_defaults=False)
+    orchestrator.register_service(
+        "memory",
+        "Memory subsystem",
+        healthcheck=lambda: {"ready": True, "path": "memory"},
+    )
+
+    results = orchestrator.health_check()
+
+    assert results["memory"]["ready"] is True
+    assert orchestrator.registry.get("memory").status == "ready"

--- a/tests/test_v1_proof_loop.py
+++ b/tests/test_v1_proof_loop.py
@@ -1,0 +1,30 @@
+"""Tests for the higher-level V1 proof loop helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from huey.v1.proof_loop import run_fixture, validate_result
+
+
+def test_run_fixture_generates_successful_record(tmp_path):
+    fixture = tmp_path / "fixture.mp3"
+    fixture.write_bytes(b"not-real-audio")
+
+    record = run_fixture(
+        fixture,
+        transcribe_func=lambda source: {
+            "transcription_engine": "test",
+            "transcription_model": "mock",
+            "transcript": f"transcribed {Path(source).name}",
+        },
+        cognition_func=lambda transcript: {
+            "cognition_provider": "test",
+            "cognition_model": "mock",
+            "response": transcript.upper(),
+        },
+        log_dir=tmp_path / "runs",
+    )
+
+    assert validate_result(record) is True
+    assert (tmp_path / "runs" / "v1-runs.jsonl").exists()

--- a/tests/test_v1_run_parser.py
+++ b/tests/test_v1_run_parser.py
@@ -1,0 +1,107 @@
+"""Tests for V1 run parsing helpers."""
+
+from __future__ import annotations
+
+import json
+
+from huey.gui.v1_runs import export_runs_json, filter_runs, parse_jsonl
+
+
+def test_parse_jsonl_handles_valid_records():
+    text = "\n".join(
+        [
+            json.dumps(
+                {
+                    "run_id": "run-1",
+                    "source_file": "fixtures/one.mp3",
+                    "transcript": "hello",
+                    "response": "hi",
+                    "exit_status": "success",
+                }
+            ),
+            json.dumps(
+                {
+                    "run_id": "run-2",
+                    "source_file": "fixtures/two.mp3",
+                    "transcript": "",
+                    "response": "",
+                    "exit_status": "error",
+                    "error_message_if_any": "boom",
+                }
+            ),
+        ]
+    )
+
+    records = parse_jsonl(text)
+
+    assert len(records) == 2
+    assert records[0].status == "passed"
+    assert records[1].status == "failed"
+
+
+def test_parse_jsonl_skips_blank_lines():
+    records = parse_jsonl(
+        json.dumps(
+            {
+                "run_id": "run-1",
+                "source_file": "fixtures/one.mp3",
+                "transcript": "hello",
+                "response": "hi",
+                "exit_status": "success",
+            }
+        )
+        + "\n\n"
+    )
+
+    assert len(records) == 1
+
+
+def test_filter_runs_by_status():
+    records = parse_jsonl(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "run_id": "run-1",
+                        "source_file": "fixtures/one.mp3",
+                        "transcript": "hello",
+                        "response": "hi",
+                        "exit_status": "success",
+                    }
+                ),
+                json.dumps(
+                    {
+                        "run_id": "run-2",
+                        "source_file": "fixtures/two.mp3",
+                        "transcript": "",
+                        "response": "",
+                        "exit_status": "error",
+                    }
+                ),
+            ]
+        )
+    )
+
+    filtered = filter_runs(records, status="failed")
+
+    assert len(filtered) == 1
+    assert filtered[0].fixture == "two.mp3"
+
+
+def test_export_runs_json_roundtrip():
+    records = parse_jsonl(
+        json.dumps(
+            {
+                "run_id": "run-1",
+                "source_file": "fixtures/one.mp3",
+                "transcript": "hello",
+                "response": "hi",
+                "exit_status": "success",
+            }
+        )
+    )
+
+    payload = json.loads(export_runs_json(records))
+
+    assert payload[0]["fixture"] == "one.mp3"
+    assert payload[0]["status"] == "passed"


### PR DESCRIPTION
## Summary
- Add canonical Python integration packages for GUI, FFmpeg/media, audio, runtime orchestration, V1 proof-loop management, memory ingestion/indexing, and Command Center adapters.
- Wire a read-only Command Center backend and CLI into the repo, and route legacy GUI/theme/media entry points through the shared layer.
- Add focused tests and operator scripts for contract checks, seed export, repo mapping, and dependency/API audits.

## Why
- The repo already had runtime, GUI, memory, FFmpeg, PyHuey, and dashboard pieces, but no single Python orchestration layer tied them together.
- This change consolidates those surfaces into reusable packages so Command Center, legacy tools, and future PyHuey integration can consume one safe source of truth instead of isolated helpers.

## Scope
- In scope:
  - Canonical `huey.gui`, `huey.media`, `huey.audio`, `huey.runtime`, `huey.v1`, `huey.memory.pipeline`, and `huey.integrations.command_center` packages.
  - Read-only FastAPI Command Center backend, CLI entrypoints, and packaging/Makefile wiring.
  - Legacy Tkinter theme/media bridging, PyHuey adapter hooks, and focused regression coverage.
- Out of scope:
  - Rewriting the separate Command Center frontend repo.
  - Adding write/mutation endpoints or activating live mic, Huey Body, or HIMS runtime control.
  - Repo-wide cleanup of pre-existing `tests/test_api_routes.py` client mismatches and unrelated legacy formatting debt.

## Tests run
- [x] `python scripts/check_command_center_contract.py`
- [x] `python -m pytest -q tests/test_gui_theme.py tests/test_gui_models.py tests/test_command_center_backend.py tests/test_v1_run_parser.py tests/test_legacy_gui_adapters.py tests/test_runtime_orchestrator.py tests/test_media_stack.py tests/test_v1_proof_loop.py tests/test_license_gui.py tests/test_huey_compat_imports.py`
- [x] Scoped `python -m black --check ...`, `python -m isort --check-only ...`, `python -m ruff check ...`, and `python -m flake8 ...` across the changed Python surfaces.
- [ ] `python -m pytest -q` (4 pre-existing failures remain in `tests/test_api_routes.py` under the current FastAPI/httpx stack.)

## Screenshots/logs if UI
- N/A

## Security considerations
- Command Center stays read-only and defaults to mock/safe mode.
- Validation commands remain copy-only text; no command execution, task execution, memory mutation, governance mutation, power actions, or network mutation were added.

## Docs updated
- [ ] Yes
- [x] No (code/test/script surfaces only; generator/export scripts were added but no docs pages were committed.)

## Dependency changes
- [x] None
- [ ] Yes (list package, version change, and reason)

## Boundary check
- [x] Does this keep PyHuey as cockpit/tooling?
- [x] Does this keep Huey Brain V1 on Legion Go?
- [x] Does this avoid implying Huey Body/HIMS/live mic are active?