### PR TITLE
chore: standardize legacy root wrappers

### DIFF
--- a/docs/development/legacy-root-wrapper-cleanup.md
+++ b/docs/development/legacy-root-wrapper-cleanup.md
@@ -1,0 +1,42 @@
+# Legacy root wrapper cleanup
+
+This note records the first layout-standardization cleanup after the generated-artifact and salvage branches were merged.
+
+## Decision
+
+The repository should keep importable Python source under `src/huey` and avoid maintaining duplicate root-level package wrappers such as `huey/...` and `hueyos/...`.
+
+The following root wrappers were removed because each only re-exported the canonical implementation already present under `src/huey/memory/PY`:
+
+- `huey/memory/PY/error_handler.py`
+- `hueyos/convert_mkv_to_mp4.py`
+- `hueyos/convert_pdf_to_text.py`
+- `hueyos/convert_video_to_gif.py`
+- `hueyos/media_conversion.py`
+
+## Canonical locations
+
+Use these source modules instead:
+
+- `src/huey/memory/PY/error_handler.py`
+- `src/huey/memory/PY/convert_mkv_to_mp4.py`
+- `src/huey/memory/PY/convert_pdf_to_text.py`
+- `src/huey/memory/PY/convert_video_to_gif.py`
+- `src/huey/memory/PY/media_conversion.py`
+
+## Rationale
+
+Keeping duplicate root wrappers makes the checkout harder to reason about and risks shadowing the editable `src` package layout. The standardized project layout is:
+
+```text
+src/huey/                 canonical Huey source
+src/huey/os/              HueyOS layer
+src/huey/connectors/      external and companion integrations
+src/huey/media/           media and FFmpeg pipeline code
+src/huey/memory/          memory system code
+scripts/                  operator/developer entry points
+integrations/             companion applications and dashboards
+docs/                     project and developer documentation
+```
+
+Compatibility should be added intentionally through documented adapters or console entry points, not through duplicate root package files.

--- a/huey/memory/PY/error_handler.py
+++ b/huey/memory/PY/error_handler.py
@@ -1,3 +1,0 @@
-"""Filesystem compatibility wrapper for legacy test loaders."""
-
-from huey.memory.PY.error_handler import *  # noqa: F401,F403

--- a/hueyos/convert_mkv_to_mp4.py
+++ b/hueyos/convert_mkv_to_mp4.py
@@ -1,3 +1,0 @@
-"""Filesystem compatibility wrapper for legacy test loaders."""
-
-from huey.memory.PY.convert_mkv_to_mp4 import *  # noqa: F401,F403

--- a/hueyos/convert_pdf_to_text.py
+++ b/hueyos/convert_pdf_to_text.py
@@ -1,3 +1,0 @@
-"""Filesystem compatibility wrapper for legacy test loaders."""
-
-from huey.memory.PY.convert_pdf_to_text import *  # noqa: F401,F403

--- a/hueyos/convert_video_to_gif.py
+++ b/hueyos/convert_video_to_gif.py
@@ -1,3 +1,0 @@
-"""Filesystem compatibility wrapper for legacy test loaders."""
-
-from huey.memory.PY.convert_video_to_gif import *  # noqa: F401,F403

--- a/hueyos/media_conversion.py
+++ b/hueyos/media_conversion.py
@@ -1,3 +1,0 @@
-"""Filesystem compatibility wrapper for legacy test loaders."""
-
-from huey.memory.PY.media_conversion import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary
- Removes duplicate root-level compatibility wrappers under `huey/` and `hueyos/`.
- Keeps the canonical implementations under `src/huey/memory/PY`.
- Adds developer documentation explaining the cleanup and the standardized source layout.

## Why
The project should use the `src/huey` package layout as the source of truth. Duplicate root wrappers make the checkout harder to reason about and can shadow the editable package layout.

## Removed wrappers
- `huey/memory/PY/error_handler.py`
- `hueyos/convert_mkv_to_mp4.py`
- `hueyos/convert_pdf_to_text.py`
- `hueyos/convert_video_to_gif.py`
- `hueyos/media_conversion.py`

## Canonical locations
- `src/huey/memory/PY/error_handler.py`
- `src/huey/memory/PY/convert_mkv_to_mp4.py`
- `src/huey/memory/PY/convert_pdf_to_text.py`
- `src/huey/memory/PY/convert_video_to_gif.py`
- `src/huey/memory/PY/media_conversion.py`

## Safety
- No canonical implementation code was moved or changed.
- No memory implementation files were edited.
- This is a layout cleanup only.
- The PR should be reviewed for any lingering legacy imports before merging.