### PR TITLE
refactor: consolidate media tools under huey.media

### DIFF
--- a/docs/development/media-tool-consolidation.md
+++ b/docs/development/media-tool-consolidation.md
@@ -1,0 +1,39 @@
+# Media tool consolidation
+
+This note records the consolidation of media helpers under the canonical `huey.media` package.
+
+## Decision
+
+Media and FFmpeg-oriented helpers should live under:
+
+```text
+src/huey/media/
+```
+
+The `huey.audio` package may keep compatibility adapters for existing imports, but implementation should be centralized under `huey.media` when the helper is part of the shared media pipeline.
+
+## Canonical media modules
+
+Use these modules for media operations:
+
+- `huey.media.media_manager`
+- `huey.media.ffmpeg_validator`
+- `huey.media.audio_analysis`
+- `huey.media.speech_pipeline`
+- `huey.media.video_pipeline`
+- `huey.media.media_conversion`
+- `huey.media.convert_mkv_to_mp4`
+- `huey.media.convert_png_to_jpeg`
+- `huey.media.convert_video_to_gif`
+
+## Compatibility adapters
+
+The following compatibility adapter remains intentionally:
+
+- `huey.audio.audio_analysis`
+
+It re-exports the canonical `huey.media.audio_analysis` public API so older imports keep working while the project transitions to the standardized media package.
+
+## Rationale
+
+The project previously had overlapping media helper locations across memory, audio, and root-level bridge modules. Consolidating implementation under `huey.media` makes the package layout easier to maintain and aligns FFmpeg, audio analysis, speech preparation, and video preprocessing under one domain boundary.

--- a/src/huey/audio/audio_analysis.py
+++ b/src/huey/audio/audio_analysis.py
@@ -1,99 +1,25 @@
-"""Audio inspection helpers built on top of the FFmpeg media subsystem."""
+"""Compatibility wrapper for canonical audio analysis helpers.
 
-from __future__ import annotations
+The canonical implementation lives in :mod:`huey.media.audio_analysis`.
+This module is retained so existing imports from :mod:`huey.audio.audio_analysis`
+continue to work during the media-tools consolidation.
+"""
 
-import re
-import subprocess
-from pathlib import Path
-
-from huey.media.ffmpeg_validator import check_ffmpeg
-from huey.media.media_manager import detect_silence, probe_media
-
-
-def _audio_stream(source: str | Path) -> dict[str, object]:
-    payload = probe_media(source)
-    for stream in payload.streams:
-        if stream.get("codec_type") == "audio":
-            return dict(stream)
-    return {}
-
-
-def duration(source: str | Path) -> float:
-    """Return audio duration in seconds."""
-
-    payload = probe_media(source)
-    return float(payload.duration_seconds or 0.0)
-
-
-def bitrate(source: str | Path) -> int:
-    """Return audio bitrate in bits per second."""
-
-    payload = probe_media(source)
-    stream = _audio_stream(source)
-    raw_value = stream.get("bit_rate") or payload.bit_rate or 0
-    return int(float(raw_value or 0))
-
-
-def sample_rate(source: str | Path) -> int:
-    """Return audio sample rate."""
-
-    return int(float(_audio_stream(source).get("sample_rate", 0)))
-
-
-def channels(source: str | Path) -> int:
-    """Return the number of audio channels."""
-
-    return int(_audio_stream(source).get("channels", 0))
-
-
-def _volumedetect(source: str | Path) -> dict[str, float]:
-    if not check_ffmpeg():
-        raise RuntimeError("ffmpeg is not available on PATH")
-    result = subprocess.run(
-        [
-            "ffmpeg",
-            "-hide_banner",
-            "-i",
-            str(Path(source).expanduser().resolve()),
-            "-af",
-            "volumedetect",
-            "-f",
-            "null",
-            "-",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
-    mean_match = re.search(r"mean_volume:\s*(-?[0-9.]+) dB", result.stderr or "")
-    peak_match = re.search(r"max_volume:\s*(-?[0-9.]+) dB", result.stderr or "")
-    return {
-        "mean_volume": float(mean_match.group(1)) if mean_match else 0.0,
-        "max_volume": float(peak_match.group(1)) if peak_match else 0.0,
-    }
-
-
-def peak_level(source: str | Path) -> float:
-    """Return the detected peak level in dB."""
-
-    return _volumedetect(source)["max_volume"]
-
-
-def rms_level(source: str | Path) -> float:
-    """Return the mean/RMS volume in dB."""
-
-    return _volumedetect(source)["mean_volume"]
-
-
-def silence_map(source: str | Path) -> list[dict[str, float]]:
-    """Return silence segments detected in the audio."""
-
-    return detect_silence(source)
-
+from huey.media.audio_analysis import (
+    AudioAnalysis,
+    analyze_audio,
+    bitrate,
+    channels,
+    duration,
+    peak_level,
+    rms_level,
+    sample_rate,
+    silence_map,
+)
 
 __all__ = [
+    "AudioAnalysis",
+    "analyze_audio",
     "bitrate",
     "channels",
     "duration",

--- a/src/huey/media/audio_analysis.py
+++ b/src/huey/media/audio_analysis.py
@@ -94,6 +94,48 @@ def analyze_audio(
     )
 
 
+def duration(source: str | Path) -> float:
+    """Return audio duration in seconds."""
+
+    return float(analyze_audio(source).duration_seconds or 0.0)
+
+
+def bitrate(source: str | Path) -> int:
+    """Return audio bitrate in bits per second."""
+
+    return int(analyze_audio(source).bit_rate or 0)
+
+
+def sample_rate(source: str | Path) -> int:
+    """Return audio sample rate in hertz."""
+
+    return int(analyze_audio(source).sample_rate_hz or 0)
+
+
+def channels(source: str | Path) -> int:
+    """Return the number of audio channels."""
+
+    return int(analyze_audio(source).channels or 0)
+
+
+def peak_level(source: str | Path) -> float:
+    """Return the detected peak level in dB."""
+
+    return float(analyze_audio(source).max_volume_db or 0.0)
+
+
+def rms_level(source: str | Path) -> float:
+    """Return the mean/RMS volume in dB."""
+
+    return float(analyze_audio(source).mean_volume_db or 0.0)
+
+
+def silence_map(source: str | Path) -> list[dict[str, float | None]]:
+    """Return silence segments detected in the audio."""
+
+    return analyze_audio(source).silence_regions
+
+
 def _match_float(pattern: re.Pattern[str], text: str) -> float | None:
     match = pattern.search(text)
     return float(match.group("value")) if match else None
@@ -106,4 +148,14 @@ def _optional_int(value: object) -> int | None:
         return None
 
 
-__all__ = ["AudioAnalysis", "analyze_audio"]
+__all__ = [
+    "AudioAnalysis",
+    "analyze_audio",
+    "bitrate",
+    "channels",
+    "duration",
+    "peak_level",
+    "rms_level",
+    "sample_rate",
+    "silence_map",
+]


### PR DESCRIPTION
## Summary
- Centralizes audio-analysis helper functions in `huey.media.audio_analysis`.
- Converts `huey.audio.audio_analysis` into a compatibility adapter over the canonical media module.
- Adds developer documentation for the media-tool consolidation boundary.

## Why
Media and FFmpeg-related functionality should live under `src/huey/media/` so the project has one practical domain boundary for audio inspection, speech preparation, video preprocessing, and media conversion.

## Notes
- Existing imports from `huey.audio.audio_analysis` are preserved through an adapter.
- The canonical public API now includes `duration`, `bitrate`, `sample_rate`, `channels`, `peak_level`, `rms_level`, and `silence_map` from `huey.media.audio_analysis`.
- I did not change memory implementation files in this PR.

## Safety
- No destructive media conversion behavior was changed.
- No memory implementation files were edited.
- This is intentionally a small consolidation PR before larger script/layout moves.