### PR TITLE
v120.2 cleanup: establish asset audit and repair canon guardrails

### DIFF
--- a/docs/audits/v120.2-asset-reacquisition-register.md
+++ b/docs/audits/v120.2-asset-reacquisition-register.md
@@ -1,0 +1,259 @@
+# Monkey-Head-Project v120.2 Asset Reacquisition and Cleanup Register
+
+**Status:** Initial project-wide discovery pass  
+**Standard:** Master Plan / README v120.2  
+**Date:** 2026-07-11  
+**Purpose:** Align, update, integrate, archive, or remove every project asset through evidence-backed and reviewable cleanup work.
+
+## 1. Governing rule
+
+Every asset must have one deliberate state:
+
+| State | Meaning | Required action |
+|---|---|---|
+| **Aligned** | Fits v120.2 role, terminology, location, dependency, and authority boundaries | Retain and test |
+| **Update required** | Useful active asset with stale implementation or canon | Update in place or migrate |
+| **Reusable component** | Valuable code, script, prompt, configuration, or design fragment without a current supported home | Adapt into a named v120.2 domain |
+| **Archive-only** | Preserves lineage but no longer represents active architecture | Keep in an explicit archive with provenance |
+| **Duplicate / superseded** | Repeats a canonical implementation or older version | Remove from the active surface after reference checks |
+| **Generated / release payload** | Reproducible output rather than maintained source | Move to releases or generated storage; retain source and checksums |
+| **Unsafe / unsupported** | Creates security, dependency, execution, or authority risk | Isolate, document, and remove or replace through a focused PR |
+
+The active tree is not a general museum. Historical value is preserved through explicit archives; active code and documentation must reflect v120.2.
+
+## 2. Sources covered in the initial pass
+
+- `DylanLRPollock/Monkey-Head-Project`
+- `DylanLRPollock/PyHuey`
+- `DylanLRPollock/command-center`
+- v120.0, v120.1, and v120.2 master-plan / README artifacts available in the working set
+- existing repository inventories, restructuring records, and audit documents
+- discoverable Python, PowerShell, batch, shell, installer, packaging, media, messaging, GUI, and integration surfaces
+
+Saved artifacts that are not currently enumerable must enter the same register when supplied or resolved by name. Their absence from this first report is not a classification decision.
+
+## 3. Baseline observations
+
+The repository’s existing pass-01 inventory records **1,511 paths**. It is a historical snapshot rather than a current authoritative tree, but it reveals the major cleanup surfaces.
+
+| Surface | Snapshot count | Initial interpretation |
+|---|---:|---|
+| `platform/` | 647 | Dominated by boot, installer, and package payloads; source and generated artifacts require separation |
+| `src/` | 597 | Contains active source, compatibility namespaces, embedded upstream material, memory, prompts, and archived assets |
+| `src/huey/memory/` | 343 | Valuable lineage mixed into an importable source package |
+| `platform/boot/` | 312 | Large GRUB/EFI/module tree that should be treated as a generated or release surface unless an active build contract proves otherwise |
+| Python files | 392 | Includes active code, wrappers, duplicated upstream trees, tests, archived utilities, and compatibility code |
+| GRUB modules (`.mod`) | 269 | Generated boot payload candidates |
+| Debian installer packages (`.udeb`) | 232 | Generated/package-repository payload candidates |
+| PDFs | 116 | Mix of canonical source material, rendered pages, prompts, and archival documents |
+| Tests | 79 | Valuable coverage, but some tests intentionally preserve legacy surfaces that v120.2 may retire |
+| `integrations/pygpt/` | 70 | Older embedded/upstream integration surface competing with the separate PyHuey repository |
+| `src/huey/pygpt_net/` | 64 | Embedded full PyGPT-derived surface that conflicts with the v120.2 connector boundary |
+| `src/huey/prompts/` | 69 | Current, legacy, source, rendered, and page-level assets need clearer provenance and ownership |
+
+## 4. High-priority findings
+
+### 4.1 PyHuey exists in too many forms
+
+Observed surfaces include:
+
+- separate `DylanLRPollock/PyHuey` repository,
+- `integrations/pygpt/py-gpt/`,
+- `integrations/pygpt/pygpt-mhp/`,
+- `src/huey/pygpt_net/`,
+- `src/huey/connectors/pyhuey/`,
+- legacy memory scripts and launchers using PyGPT names.
+
+**v120.2 direction:**
+
+- The separate PyHuey repository is the canonical standalone cockpit.
+- `src/huey/connectors/pyhuey/` is the canonical embedded connector boundary.
+- Full embedded upstream copies require provenance comparison, salvage review, and removal from the active Monkey-Head-Project tree.
+- Launchers and documentation should use PyHuey naming except where upstream compatibility is explicitly required.
+
+### 4.2 PyHuey’s own metadata is stale
+
+The active PyHuey README still describes the v101.1 Legion Go architecture. Its `pyproject.toml` still identifies the package, homepage, repository, and issue tracker as upstream `pygpt-net` / PyGPT.
+
+**Classification:** Update required.
+
+**Required result:** Preserve upstream attribution and package compatibility while clearly defining the fork’s project identity, supported runtime, repository, entry points, and v120.2 role.
+
+### 4.3 Legacy scripts are mirrored into active wrapper surfaces
+
+`tests/test_script_layout.py` requires all preserved shell, batch, and PowerShell memory scripts to have active wrappers under `scripts/automation/`. This turns preservation into implied support.
+
+**v120.2 direction:**
+
+- Replace blanket mirroring with an explicit supported-script manifest.
+- Keep historical scripts in memory/archive without automatic active wrappers.
+- Require each supported wrapper to declare its target, platform, risk class, and replacement status.
+- Retire launchers that expose Kubernetes, old PyGPT paths, obsolete device roles, or unsafe update/install behavior unless an active use case is accepted.
+
+### 4.4 Canonical and compatibility Python surfaces overlap
+
+The snapshot shows multiple implementations or wrappers for areas such as:
+
+- `system_checks.py`,
+- hardware managers,
+- run entry points,
+- auto-sort utilities,
+- configuration,
+- media conversion,
+- PyGPT agent/provider code,
+- `src/huey/` and `src/hueyos/` namespaces.
+
+**v120.2 direction:** One canonical implementation per maintained capability. Compatibility modules must be small, documented adapters with deprecation tests and a removal trigger.
+
+### 4.5 Archive material sits inside the importable package
+
+The `src/huey/memory/` tree contains code, documents, images, audio, video, archives, installers, configuration, and historical reports. This preserves lineage but also makes archive material appear close to runtime source.
+
+**v120.2 direction:**
+
+- Preserve lineage.
+- Separate archival identity from importable runtime identity.
+- Maintain a manifest that identifies canonical memory, historical reference, generated render, media fixture, and unsupported executable material.
+- Package only the memory assets explicitly required at runtime.
+
+### 4.6 Generated boot and package payloads dominate the repository
+
+Tracked GRUB modules, EFI images, Debian packages, installer packages, release binaries, and generated indexes create repository weight and obscure maintained source.
+
+**v120.2 direction:**
+
+- Keep build recipes, manifests, checksums, release notes, and minimal test fixtures in source control.
+- Publish reproducible binary outputs through GitHub Releases or an artifact store.
+- Retain binary payloads in Git only when an accepted offline-build or preservation requirement is documented and cannot be satisfied elsewhere.
+
+### 4.7 Command Center remains a sandbox
+
+Command Center contains useful visual concepts but retains mock-first behavior, stale metadata, placeholder links, token-handling concerns, and limited verification.
+
+**v120.2 direction:** Keep the repository separate, label it experimental, salvage individual interface ideas deliberately, and keep credentials and Huey control outside it.
+
+### 4.8 Existing audits are useful but version-bound
+
+The repository contains restructuring recommendations, v101.1 stabilization records, Docker/Kubernetes findings, duplicate reports, and pass-01 inventories.
+
+**v120.2 direction:** Preserve them as evidence, refresh their actionable findings against current main, and stop treating old recommendation files as current task lists.
+
+## 5. Immediate candidate review list
+
+These items require focused inspection before alteration:
+
+| Candidate | Reason for review | Likely outcome |
+|---|---|---|
+| `.editorconfig` and `editorconfig` | Duplicate configuration naming | Retain canonical dotfile; remove or archive duplicate after content comparison |
+| root `huey` launcher/file | Ambiguous relationship to package and CLI entry points | Replace with supported entry point or document executable role |
+| `scripts/check_*.py` plus `scripts/repo/check_*.py` | Flat compatibility wrappers duplicate structured scripts | Keep thin adapters temporarily, then retire through deprecation plan |
+| `src/huey/pygpt_net/` | Full embedded upstream-derived tree conflicts with connector boundary | Salvage Huey-specific changes; remove embedded full copy |
+| `integrations/pygpt/` copies | Multiple upstream/fork snapshots | Compare against separate PyHuey; archive provenance or remove duplicates |
+| `src/hueyos/` | Compatibility namespace may still carry real implementations | Move maintained logic to `src/huey`; reduce to adapters |
+| `vendor/fastapi`, `vendor/httpx`, `vendor/pydantic` | May shadow real dependencies or preserve incomplete stubs | Verify use; remove if unnecessary |
+| `tools/loadlin.exe` | Legacy executable in active tools surface | Move to explicit legacy archive or release payload |
+| `infra/secrets/huey-key-example*` | Key-like material requires placeholder verification | Retain only demonstrably non-sensitive examples with clear generation instructions |
+| `platform/boot/` and package indexes | Large generated payload surface | Move outputs to releases/artifacts; keep source recipes and manifests |
+| rendered prompt PDFs and page PDFs | Derived copies of source text | Keep selected archival releases; remove active duplication |
+| master plans v120.0/v120.1/v120.2 | Legitimate version lineage at repository root | Retain versioned history and establish a single current pointer/index |
+
+## 6. Cleanup batches
+
+### Batch 0 — Baseline and CI
+
+- Confirm v120.2 is merged and canonical.
+- Refresh the tracked-file inventory from current `main`.
+- Restore green lint and tests so later cleanup has a trustworthy signal.
+- Record repository size, file counts, binary weight, and current submodule state.
+
+### Batch 1 — Inventory and classification tooling
+
+- Add a reproducible asset-audit command.
+- Generate machine-readable and Markdown reports.
+- Detect exact-content duplicates separately from repeated basenames.
+- Classify active, archive, generated, vendored, release, fixture, and compatibility paths.
+- Add allowlists for intentional exceptions.
+
+### Batch 2 — Script support surface
+
+- Replace automatic wrapper parity with a supported-script manifest.
+- Review Python, shell, batch, and PowerShell entry points.
+- Update PyGPT names to PyHuey where compatibility does not require the old name.
+- Retire obsolete Docker/Kubernetes, device-specific, and installer wrappers through tests.
+
+### Batch 3 — Python namespace consolidation
+
+- Establish `src/huey` as the maintained implementation surface.
+- Reduce `src/hueyos` to documented compatibility adapters.
+- Consolidate duplicated system checks, hardware management, configuration, run paths, and utilities.
+- Add deprecation and import-boundary tests.
+
+### Batch 4 — PyHuey reconciliation
+
+- Update the separate PyHuey repository to v120.2.
+- Correct fork metadata while preserving upstream attribution.
+- Extract Huey-specific changes from embedded copies.
+- Retain only the connector under `src/huey/connectors/pyhuey` in the main repository.
+- Update launchers, tests, docs, and package boundaries.
+
+### Batch 5 — Archive and memory separation
+
+- Build an archive manifest with provenance and status.
+- Separate runtime-required memory from historical records.
+- Remove automatic execution paths into archive scripts.
+- Deduplicate derived documents and renders while preserving canonical source and selected releases.
+
+### Batch 6 — Boot, packaging, and binary artifacts
+
+- Identify reproducible outputs.
+- Move release binaries and generated repositories to Releases/artifact storage.
+- Keep build recipes, manifests, checksums, and minimal fixtures.
+- Verify offline-preservation requirements before removing tracked binaries.
+
+### Batch 7 — Documentation and canon
+
+- Align active docs to v120.2 roles and terminology.
+- Label version-bound audits as historical snapshots.
+- Add a current master-plan index.
+- Separate website, README, master plan, runbooks, governance, and archive responsibilities.
+
+### Batch 8 — Companion repository cleanup
+
+- Keep Command Center experimental and isolated.
+- Salvage unique interface components only after review.
+- Define whether the repository remains a sandbox, is frozen, or is retired after useful material is extracted.
+
+### Batch 9 — Final reconciliation
+
+- Run full tests, lint, security scans, packaging smoke, and canon checks.
+- Produce retained / changed / archived / removed manifests.
+- Verify that no active entry point depends on removed files.
+- Record remaining funded, hardware-dependent, or intentionally deferred work.
+
+## 7. Deletion standard
+
+Removal from the active tree requires at least one of the following:
+
+- exact duplicate of a retained canonical asset,
+- generated output reproducible from retained source,
+- superseded compatibility path with verified replacement,
+- unsupported launcher or installer with no accepted v120.2 use case,
+- vendored or embedded upstream material replaced by a maintained dependency or separate canonical repository,
+- binary payload moved to an accepted release/artifact location,
+- unsafe or misleading content whose historical value is preserved through an archive record.
+
+Every removal PR must identify the replacement, archive location, or reason no replacement is required.
+
+## 8. Current recommendation
+
+Begin with **Batch 0 and Batch 1**. The repository already contains valuable inventory and drift-checking work, but it needs a current, reproducible asset register before broad deletion begins.
+
+The first cleanup PR should therefore:
+
+1. refresh current-main inventory,
+2. add a v120.2 asset classification report,
+3. add exact-duplicate and generated-artifact detection,
+4. preserve existing tests and runtime behavior,
+5. identify the first safe deletion/migration set without performing high-risk bulk removal.
+
+This creates a reliable foundation for the larger cleanup while keeping every subsequent PR focused and auditable.

--- a/scripts/repo/audit_v120_assets.py
+++ b/scripts/repo/audit_v120_assets.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Inventory repository assets against the v120.2 alignment policy.
+
+This is intentionally a classification tool, not a deletion tool. It creates a
+repeatable view of the repository so cleanup decisions can be reviewed before
+files are moved or removed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import PurePosixPath
+from typing import Iterable, Sequence
+
+POLICY_VERSION = "120.2"
+REQUIRED_CANONICAL_FILES = ("README.md", "master-plan-v120.2.json")
+
+
+@dataclass(frozen=True)
+class ClassificationRule:
+    category: str
+    prefixes: tuple[str, ...]
+    reason: str
+
+
+RULES: tuple[ClassificationRule, ...] = (
+    ClassificationRule(
+        "archive_only",
+        (
+            ".migration/",
+            "archive/",
+            "archives/",
+            "docs/archive/",
+            "docs/archives/",
+            "src/huey/memory/",
+            "src/huey/prompts/OLD/",
+        ),
+        "Historical evidence; not an active implementation or authority surface.",
+    ),
+    ClassificationRule(
+        "generated_or_release_payload",
+        (".disk/", "docs/_build/", "platform/boot/"),
+        "Generated, packaged, or release-derived material; regenerate from source.",
+    ),
+    ClassificationRule(
+        "vendored",
+        ("vendor/",),
+        "Third-party or upstream-derived code; preserve attribution and avoid direct edits.",
+    ),
+    ClassificationRule(
+        "experimental",
+        (
+            "apps/huey-gui/",
+            "src/huey/apps/command_center/",
+            "src/huey/platform/windows/huey/",
+        ),
+        "Experimental GUI/Command Center surface; mock-first and non-operational.",
+    ),
+    ClassificationRule(
+        "review_required",
+        (
+            "integrations/pygpt/",
+            "src/huey/connectors/pyhuey/",
+            "src/huey/pygpt_net/",
+            "src/hueyos/",
+            "scripts/automation/",
+        ),
+        "Known overlap, compatibility, or support-boundary area requiring reconciliation.",
+    ),
+)
+
+_MASTER_PLAN_VERSION = re.compile(
+    r"(?:master[-_]plan|master-plan)[^/]*?v(?P<version>\d+(?:\.\d+)?)",
+    re.IGNORECASE,
+)
+
+
+def tracked_paths() -> list[str]:
+    """Return NUL-safe tracked paths from the current Git worktree."""
+    output = subprocess.check_output(["git", "ls-files", "-z"])
+    return sorted(path for path in output.decode("utf-8").split("\0") if path)
+
+
+def read_inventory(path: str) -> list[str]:
+    """Read a newline-delimited inventory snapshot."""
+    with open(path, encoding="utf-8") as handle:
+        return sorted(line.strip().strip('"') for line in handle if line.strip())
+
+
+def classify_path(path: str) -> tuple[str, str]:
+    """Classify one repository-relative path using first-match policy order."""
+    normalized = path.replace("\\", "/")
+    if normalized.startswith("./"):
+        normalized = normalized[2:]
+    for rule in RULES:
+        if any(normalized.startswith(prefix) for prefix in rule.prefixes):
+            return rule.category, rule.reason
+    return (
+        "active",
+        "Current-facing source, configuration, test, documentation, or repository tooling.",
+    )
+
+
+def find_version_drift(paths: Iterable[str]) -> list[str]:
+    """Find current-facing master plans whose filename is not the canonical version."""
+    findings: list[str] = []
+    for path in paths:
+        category, _ = classify_path(path)
+        if category in {"archive_only", "generated_or_release_payload", "vendored"}:
+            continue
+        match = _MASTER_PLAN_VERSION.search(path)
+        if match and match.group("version") != POLICY_VERSION:
+            findings.append(path)
+    return sorted(findings)
+
+
+def duplicate_basenames(paths: Iterable[str]) -> dict[str, list[str]]:
+    """Return duplicate basenames across active and review-required surfaces."""
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for path in paths:
+        category, _ = classify_path(path)
+        if category not in {"active", "review_required", "experimental"}:
+            continue
+        grouped[PurePosixPath(path).name].append(path)
+    return {
+        name: sorted(locations)
+        for name, locations in sorted(grouped.items())
+        if len(locations) > 1
+    }
+
+
+def build_report(paths: Sequence[str]) -> dict[str, object]:
+    """Build a deterministic, JSON-serializable v120.2 repository report."""
+    categories = Counter(classify_path(path)[0] for path in paths)
+    missing = [path for path in REQUIRED_CANONICAL_FILES if path not in paths]
+    duplicates = duplicate_basenames(paths)
+    return {
+        "policy_version": POLICY_VERSION,
+        "tracked_path_count": len(paths),
+        "category_counts": dict(sorted(categories.items())),
+        "missing_canonical_files": missing,
+        "current_facing_master_plan_version_drift": find_version_drift(paths),
+        "duplicate_basename_groups": duplicates,
+        "duplicate_basename_group_count": len(duplicates),
+        "rules": [asdict(rule) for rule in RULES],
+    }
+
+
+def render_markdown(report: dict[str, object]) -> str:
+    """Render the report as a reviewable Markdown artifact."""
+    lines = [
+        f"# v{report['policy_version']} Repository Asset Audit",
+        "",
+        f"Tracked paths: **{report['tracked_path_count']}**",
+        "",
+        "## Classification counts",
+        "",
+        "| Classification | Paths |",
+        "|---|---:|",
+    ]
+    counts = report["category_counts"]
+    assert isinstance(counts, dict)
+    lines.extend(f"| `{name}` | {count} |" for name, count in counts.items())
+
+    lines.extend(["", "## Canonical file check", ""])
+    missing = report["missing_canonical_files"]
+    assert isinstance(missing, list)
+    lines.append(
+        "All required v120.2 files are present."
+        if not missing
+        else "Missing: " + ", ".join(f"`{path}`" for path in missing)
+    )
+
+    lines.extend(["", "## Current-facing master-plan filename drift", ""])
+    drift = report["current_facing_master_plan_version_drift"]
+    assert isinstance(drift, list)
+    lines.extend(["None detected."] if not drift else [f"- `{path}`" for path in drift])
+
+    lines.extend(["", "## Duplicate basenames", ""])
+    lines.append(
+        "Duplicate names are review candidates, not automatic deletion candidates."
+    )
+    duplicates = report["duplicate_basename_groups"]
+    assert isinstance(duplicates, dict)
+    for name, locations in duplicates.items():
+        lines.extend(["", f"### `{name}`", ""])
+        lines.extend(f"- `{path}`" for path in locations)
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--inventory",
+        help="Read paths from an existing newline-delimited inventory instead of Git.",
+    )
+    parser.add_argument(
+        "--format", choices=("json", "markdown"), default="markdown"
+    )
+    parser.add_argument(
+        "--fail-on-canon-drift",
+        action="store_true",
+        help="Return non-zero when required files are missing or old active plans remain.",
+    )
+    args = parser.parse_args()
+
+    paths = read_inventory(args.inventory) if args.inventory else tracked_paths()
+    report = build_report(paths)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_markdown(report), end="")
+
+    has_drift = bool(report["missing_canonical_files"]) or bool(
+        report["current_facing_master_plan_version_drift"]
+    )
+    return 1 if args.fail_on_canon_drift and has_drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/repo/check_canon_terms.py
+++ b/scripts/repo/check_canon_terms.py
@@ -48,7 +48,7 @@ def _compile_rules() -> tuple[Rule, ...]:
     return (
         Rule(
             "huey-core-active",
-            re.compile(r"\\bHuey Core\\b"),
+            re.compile(r"\bHuey Core\b"),
             (
                 "'Huey Core' appears as a current-facing term; use Huey Body "
                 "only in historical/provenance context."
@@ -56,27 +56,40 @@ def _compile_rules() -> tuple[Rule, ...]:
         ),
         Rule(
             "windows-hueybody-path",
-            re.compile(r"\\bplatform/windows/hueybody\\b", re.IGNORECASE),
+            re.compile(r"\bplatform/windows/hueybody\b", re.IGNORECASE),
             "Use src/huey/platform/windows/huey for cockpit/build path references.",
         ),
         Rule(
             "live-microphone-v1",
-            re.compile(r"\\blive\\s+microphone\\b", re.IGNORECASE),
+            re.compile(r"\blive\s+microphone\b", re.IGNORECASE),
             "Do not present live microphone as active V1 feature.",
         ),
         Rule(
             "huey-body-v1-runtime",
             re.compile(
-                r"\\bHuey Body\\b.*\\b(V1|runtime|compute|cognition|node)\\b|"
-                r"\\b(V1|runtime|compute|cognition|node)\\b.*\\bHuey Body\\b",
+                r"\bHuey Body\b.*\b(V1|runtime|compute|cognition|node)\b|"
+                r"\b(V1|runtime|compute|cognition|node)\b.*\bHuey Body\b",
                 re.IGNORECASE,
             ),
             "Do not present Huey Body as V1 compute/cognition/runtime node.",
         ),
         Rule(
             "hims-active-runtime",
-            re.compile(r"\\bHIMS\\b", re.IGNORECASE),
+            re.compile(r"\bHIMS\b", re.IGNORECASE),
             "Do not present HIMS as an active runtime.",
+        ),
+        Rule(
+            "glab-nonexistent-system",
+            re.compile(r"\bGlab\b", re.IGNORECASE),
+            "Remove 'Glab'; no system or project component has this name.",
+        ),
+        Rule(
+            "vague-hueybrain-node-label",
+            re.compile(r"\bactive Huey\s*Brain V1 execution node\b", re.IGNORECASE),
+            (
+                "Replace the vague node label with the concrete v120.2 role: "
+                "primary operator workstation and prototype Huey Brain platform."
+            ),
         ),
     )
 
@@ -122,9 +135,9 @@ def _has_provenance_marker(line: str) -> bool:
 
 
 def _should_flag_pygpt(line: str) -> bool:
-    if not re.search(r"\\bPyGPT\\b", line):
+    if not re.search(r"\bPyGPT\b", line):
         return False
-    if re.search(r"\\bPyHuey\\b", line):
+    if re.search(r"\bPyHuey\b", line):
         return False
     if _has_provenance_marker(line):
         return False

--- a/tests/test_v120_asset_audit.py
+++ b/tests/test_v120_asset_audit.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from scripts.repo.audit_v120_assets import (
+    build_report,
+    classify_path,
+    find_version_drift,
+    render_markdown,
+)
+from scripts.repo.check_canon_terms import _compile_rules
+
+
+def test_classification_keeps_archive_out_of_active_surface() -> None:
+    assert classify_path("src/huey/memory/PY/main.py")[0] == "archive_only"
+    assert classify_path(".migration/inventory/files.txt")[0] == "archive_only"
+    assert classify_path("platform/boot/pool/example.udeb")[0] == (
+        "generated_or_release_payload"
+    )
+    assert classify_path("src/huey/connectors/pyhuey/app.py")[0] == "review_required"
+    assert classify_path("src/huey/api.py")[0] == "active"
+
+
+def test_old_active_master_plans_are_drift_but_archived_plans_are_not() -> None:
+    paths = [
+        "master-plan-v120.2.json",
+        "master-plan-v120.1.json",
+        "archives/master-plan-v101.1.json",
+        "src/huey/memory/JSON/master-plan-v5.json",
+    ]
+    assert find_version_drift(paths) == ["master-plan-v120.1.json"]
+
+
+def test_report_requires_the_v120_2_pair_and_lists_duplicates() -> None:
+    report = build_report(
+        [
+            "README.md",
+            "src/huey/api.py",
+            "src/huey/services/api.py",
+        ]
+    )
+    assert report["missing_canonical_files"] == ["master-plan-v120.2.json"]
+    assert report["duplicate_basename_groups"] == {
+        "api.py": ["src/huey/api.py", "src/huey/services/api.py"]
+    }
+    markdown = render_markdown(report)
+    assert "v120.2 Repository Asset Audit" in markdown
+    assert "`master-plan-v120.2.json`" in markdown
+
+
+def test_canon_regexes_match_real_terms_not_literal_backslashes() -> None:
+    rules = {rule.name: rule.pattern for rule in _compile_rules()}
+    assert rules["huey-core-active"].search("Huey Core")
+    assert rules["live-microphone-v1"].search("live microphone")
+    assert rules["glab-nonexistent-system"].search("Glab")
+    assert rules["vague-hueybrain-node-label"].search(
+        "active Huey Brain V1 execution node"
+    )


### PR DESCRIPTION
## Outcome

Establishes Batch 0/1 of the v120.2 project-wide cleanup: a reproducible repository asset inventory, explicit classification boundaries, and functioning canon-term checks.

## Changes

- adds `scripts/repo/audit_v120_assets.py` with Markdown/JSON output
- distinguishes active, review-required, experimental, archive-only, generated/release, and vendored surfaces
- detects missing canonical v120.2 files, active old master-plan filenames, and duplicate basenames
- repairs over-escaped canon regular expressions that previously matched literal backslashes instead of project terms
- blocks the nonexistent `Glab` label and the vague `active Huey Brain V1 execution node` wording
- adds focused tests and the full v120.2 cleanup register

## Validation

- Python compilation passed for all changed Python files
- four focused tests passed locally by direct invocation
- full repository CI is left to GitHub Actions

## Scope

This PR classifies and measures; it does not broadly delete assets. Subsequent batches can use its output to reconcile script wrappers, Python namespaces, PyHuey copies, archives, and generated payloads with reviewable evidence.