### PR TITLE
v120.2 audit: close Batch 0/1 gaps and restore green CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lint:
 	$(PYTHON) scripts/check_command_center_contract.py
 	$(PYTHON) scripts/repo/check_dependency_sync.py
 	black --check src tests scripts conftest.py
-	isort --check-only src tests scripts conftest.py
+	isort --check-only --diff src tests scripts conftest.py
 	ruff check src tests scripts conftest.py
 	flake8 src tests scripts conftest.py
 

--- a/docs/audits/v120.2-asset-reacquisition-register.md
+++ b/docs/audits/v120.2-asset-reacquisition-register.md
@@ -155,7 +155,7 @@ These items require focused inspection before alteration:
 | `infra/secrets/huey-key-example*` | Key-like material requires placeholder verification | Retain only demonstrably non-sensitive examples with clear generation instructions |
 | `platform/boot/` and package indexes | Large generated payload surface | Move outputs to releases/artifacts; keep source recipes and manifests |
 | rendered prompt PDFs and page PDFs | Derived copies of source text | Keep selected archival releases; remove active duplication |
-| master plans v120.0/v120.1/v120.2 | Legitimate version lineage at repository root | Retain versioned history and establish a single current pointer/index |
+| master plans v120.0/v120.1/v120.2 | Legitimate lineage currently mixed into the active root surface | Keep only the current v120.2 plan at root; move superseded plans to `docs/archive/master-plans/` with provenance |
 
 ## 6. Cleanup batches
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,8 +197,11 @@ where = ["src"]
 target-version = ["py313"]
 line-length = 88
 extend-exclude = '''
-/src/huey/connectors/pyhuey/
-/src/huey/memory/PY/
+^/src/huey/
+(
+  connectors/pyhuey
+  | memory/PY
+)/
 '''
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,17 +198,24 @@ target-version = ["py313"]
 line-length = 88
 extend-exclude = '''
 /src/huey/connectors/pyhuey/
+/src/huey/memory/PY/
 '''
 
 [tool.isort]
 profile = "black"
 line_length = 88
-skip_glob = ["src/huey/connectors/pyhuey/**"]
+skip_glob = [
+  "src/huey/connectors/pyhuey/**",
+  "src/huey/memory/PY/**",
+]
 
 [tool.ruff]
 target-version = "py313"
 line-length = 88
-extend-exclude = ["src/huey/connectors/pyhuey"]
+extend-exclude = [
+  "src/huey/connectors/pyhuey",
+  "src/huey/memory/PY",
+]
 
 [tool.ruff.lint]
 ignore = ["E402"]

--- a/scripts/prepare_audio_for_transcription.py
+++ b/scripts/prepare_audio_for_transcription.py
@@ -71,9 +71,7 @@ def _resolve_output_path(
         if value
     ]
     if len(selected) > 1:
-        raise ValueError(
-            "Choose only one of destination, --output, or --output-dir."
-        )
+        raise ValueError("Choose only one of destination, --output, or --output-dir.")
     if output:
         return Path(output).expanduser().resolve()
     if output_dir:

--- a/scripts/repo/audit_v120_assets.py
+++ b/scripts/repo/audit_v120_assets.py
@@ -229,9 +229,7 @@ def main() -> int:
         "--inventory",
         help="Read paths from an existing newline-delimited inventory instead of Git.",
     )
-    parser.add_argument(
-        "--format", choices=("json", "markdown"), default="markdown"
-    )
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
     parser.add_argument(
         "--fail-on-canon-drift",
         action="store_true",

--- a/scripts/repo/audit_v120_assets.py
+++ b/scripts/repo/audit_v120_assets.py
@@ -83,21 +83,43 @@ _MASTER_PLAN_VERSION = re.compile(
 
 def tracked_paths() -> list[str]:
     """Return NUL-safe tracked paths from the current Git worktree."""
-    output = subprocess.check_output(["git", "ls-files", "-z"])
-    return sorted(path for path in output.decode("utf-8").split("\0") if path)
+    output = subprocess.check_output(
+        ["git", "ls-files", "-z"],
+        text=True,
+        encoding="utf-8",
+        errors="surrogateescape",
+    )
+    return sorted(path for path in output.split("\0") if path)
 
 
 def read_inventory(path: str) -> list[str]:
     """Read a newline-delimited inventory snapshot."""
-    with open(path, encoding="utf-8") as handle:
+    with open(path, encoding="utf-8", errors="surrogateescape") as handle:
         return sorted(line.strip().strip('"') for line in handle if line.strip())
+
+
+def normalize_repository_path(path: str) -> str:
+    """Return one stable POSIX-style representation of a repository path."""
+    normalized = path.replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def normalize_repository_paths(paths: Iterable[str]) -> list[str]:
+    """Normalize and deduplicate paths while preserving deterministic order."""
+    return sorted(
+        {
+            normalized
+            for path in paths
+            if (normalized := normalize_repository_path(path))
+        }
+    )
 
 
 def classify_path(path: str) -> tuple[str, str]:
     """Classify one repository-relative path using first-match policy order."""
-    normalized = path.replace("\\", "/")
-    if normalized.startswith("./"):
-        normalized = normalized[2:]
+    normalized = normalize_repository_path(path)
     for rule in RULES:
         if any(normalized.startswith(prefix) for prefix in rule.prefixes):
             return rule.category, rule.reason
@@ -110,7 +132,7 @@ def classify_path(path: str) -> tuple[str, str]:
 def find_version_drift(paths: Iterable[str]) -> list[str]:
     """Find current-facing master plans whose filename is not the canonical version."""
     findings: list[str] = []
-    for path in paths:
+    for path in normalize_repository_paths(paths):
         category, _ = classify_path(path)
         if category in {"archive_only", "generated_or_release_payload", "vendored"}:
             continue
@@ -123,7 +145,7 @@ def find_version_drift(paths: Iterable[str]) -> list[str]:
 def duplicate_basenames(paths: Iterable[str]) -> dict[str, list[str]]:
     """Return duplicate basenames across active and review-required surfaces."""
     grouped: dict[str, list[str]] = defaultdict(list)
-    for path in paths:
+    for path in normalize_repository_paths(paths):
         category, _ = classify_path(path)
         if category not in {"active", "review_required", "experimental"}:
             continue
@@ -137,15 +159,20 @@ def duplicate_basenames(paths: Iterable[str]) -> dict[str, list[str]]:
 
 def build_report(paths: Sequence[str]) -> dict[str, object]:
     """Build a deterministic, JSON-serializable v120.2 repository report."""
-    categories = Counter(classify_path(path)[0] for path in paths)
-    missing = [path for path in REQUIRED_CANONICAL_FILES if path not in paths]
-    duplicates = duplicate_basenames(paths)
+    normalized_paths = normalize_repository_paths(paths)
+    categories = Counter(classify_path(path)[0] for path in normalized_paths)
+    missing = [
+        path for path in REQUIRED_CANONICAL_FILES if path not in normalized_paths
+    ]
+    duplicates = duplicate_basenames(normalized_paths)
     return {
         "policy_version": POLICY_VERSION,
-        "tracked_path_count": len(paths),
+        "tracked_path_count": len(normalized_paths),
         "category_counts": dict(sorted(categories.items())),
         "missing_canonical_files": missing,
-        "current_facing_master_plan_version_drift": find_version_drift(paths),
+        "current_facing_master_plan_version_drift": find_version_drift(
+            normalized_paths
+        ),
         "duplicate_basename_groups": duplicates,
         "duplicate_basename_group_count": len(duplicates),
         "rules": [asdict(rule) for rule in RULES],

--- a/scripts/repo/check_legacy_hueyos_imports.py
+++ b/scripts/repo/check_legacy_hueyos_imports.py
@@ -26,6 +26,7 @@ ALLOWED_PATHS: set[str] = {
     "src/huey/hardware/plugins.py",
     "tests/test_hueyos_namespace.py",
     "tests/test_layout_canonicalization.py",
+    "tests/test_v120_asset_audit.py",
     "scripts/repo/check_legacy_hueyos_imports.py",
     "docs/architecture/huey-layout.md",
 }

--- a/scripts/repo/check_legacy_hueyos_imports.py
+++ b/scripts/repo/check_legacy_hueyos_imports.py
@@ -30,6 +30,12 @@ ALLOWED_PATHS: set[str] = {
     "docs/architecture/huey-layout.md",
 }
 
+# Audit policy must be able to name the compatibility namespace it measures.
+# Keep this exact-line allowance narrower than exempting the whole audit file.
+ALLOWED_TEXT_REFERENCES: set[tuple[str, str]] = {
+    ("scripts/repo/audit_v120_assets.py", '"src/hueyos/",'),
+}
+
 ACTIVE_PATH_PREFIXES: tuple[str, ...] = (
     "src/",
     "tests/",
@@ -91,6 +97,11 @@ def should_scan(path: Path) -> bool:
     }
 
 
+def is_allowed_text_reference(path: Path, line: str) -> bool:
+    """Return whether one exact policy reference is intentionally allowed."""
+    return (path.as_posix(), line.strip()) in ALLOWED_TEXT_REFERENCES
+
+
 def main() -> int:
     violations: list[str] = []
 
@@ -106,6 +117,8 @@ def main() -> int:
             continue
 
         for line_number, line in enumerate(text.splitlines(), start=1):
+            if is_allowed_text_reference(path, line):
+                continue
             for pattern in PATTERNS:
                 if pattern.search(line):
                     violations.append(

--- a/scripts/repo/check_repo_drift.py
+++ b/scripts/repo/check_repo_drift.py
@@ -50,6 +50,15 @@ NON_CURRENT_FACING_NAMES: tuple[str, ...] = (
     "scripts/repo/check_repo_drift.py",
 )
 
+# Policy and audit tools must be able to name the legacy paths they detect.
+# Keep these exemptions rule-specific so the files remain subject to all other
+# current-facing drift checks.
+RULE_REFERENCE_ALLOWLIST: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("scripts/repo/audit_v120_assets.py", "integrations-pygpt-path"),
+    }
+)
+
 
 def _is_pyhuey_canonical() -> bool:
     return os.path.isdir("src/huey/connectors/pyhuey")
@@ -145,6 +154,8 @@ def is_current_facing(path: str) -> bool:
 
 def should_check_rule(path: str, rule: DriftRule) -> bool:
     if not is_current_facing(path):
+        return False
+    if (path, rule.name) in RULE_REFERENCE_ALLOWLIST:
         return False
     if rule.name == "docker-primary-pygpt":
         return os.path.basename(path) == "Dockerfile"

--- a/src/huey/gui/__init__.py
+++ b/src/huey/gui/__init__.py
@@ -17,15 +17,6 @@ from huey.gui.state import (
     RuntimeState,
     build_default_state,
 )
-from huey.gui.theme import HueyTheme, as_qt_stylesheet, as_tk_palette, get_default_theme
-from huey.gui.tk import (
-    apply_root_chrome,
-    apply_ttk_chrome,
-    listbox_kwargs,
-    primary_button_kwargs,
-    text_surface_kwargs,
-    tk_palette,
-)
 from huey.gui.surfaces import (
     GuiAction,
     GuiActionSection,
@@ -35,6 +26,15 @@ from huey.gui.surfaces import (
     default_gui_surfaces,
     search_gui_actions,
     section_actions,
+)
+from huey.gui.theme import HueyTheme, as_qt_stylesheet, as_tk_palette, get_default_theme
+from huey.gui.tk import (
+    apply_root_chrome,
+    apply_ttk_chrome,
+    listbox_kwargs,
+    primary_button_kwargs,
+    text_surface_kwargs,
+    tk_palette,
 )
 
 __all__ = [

--- a/src/huey/hims/schema.py
+++ b/src/huey/hims/schema.py
@@ -146,7 +146,9 @@ class HIMSMessage:
                 else None
             ),
             reply_to=(
-                str(payload["reply_to"]) if payload.get("reply_to") is not None else None
+                str(payload["reply_to"])
+                if payload.get("reply_to") is not None
+                else None
             ),
         )
 

--- a/src/huey/hims/shadow.py
+++ b/src/huey/hims/shadow.py
@@ -106,11 +106,17 @@ class ShadowHIMS:
             "message_count": len(messages),
             "message_ids": [str(record["message_id"]) for record in messages],
             "statuses": dict(
-                sorted(Counter(str(record.get("status", "")) for record in messages).items())
+                sorted(
+                    Counter(
+                        str(record.get("status", "")) for record in messages
+                    ).items()
+                )
             ),
             "intent_types": dict(
                 sorted(
-                    Counter(str(record.get("intent_type", "")) for record in messages).items()
+                    Counter(
+                        str(record.get("intent_type", "")) for record in messages
+                    ).items()
                 )
             ),
             "ledger_entries": ledger_entries,
@@ -163,7 +169,10 @@ class ShadowHIMS:
             if intent_value and intent_value not in lineage_summary["intent_types"]:
                 lineage_summary["intent_types"].append(intent_value)
             status_value = str(record.get("status", "")).strip()
-            if status_value and status_value not in lineage_summary["terminal_statuses"]:
+            if (
+                status_value
+                and status_value not in lineage_summary["terminal_statuses"]
+            ):
                 lineage_summary["terminal_statuses"].append(status_value)
             updated_at = str(record.get("updated_at", ""))
             if updated_at >= str(lineage_summary["last_updated_at"]):
@@ -314,7 +323,10 @@ class ShadowHIMS:
         )
         packet_snapshot = self.mail.post(
             packet,
-            metadata={"shadow_mode": True, "lineage_stage": "external_interface_packet"},
+            metadata={
+                "shadow_mode": True,
+                "lineage_stage": "external_interface_packet",
+            },
         )
         self.mail.transition(
             packet.message_id,

--- a/src/huey/hims/validation.py
+++ b/src/huey/hims/validation.py
@@ -109,7 +109,9 @@ def validate_hims_transition(previous: HIMSMessage, current: HIMSMessage) -> Non
     if previous.status == current.status:
         raise ValueError("transition must change the message status")
 
-    allowed = _ALLOWED_TRANSITIONS.get(previous.intent_type, {}).get(previous.status, set())
+    allowed = _ALLOWED_TRANSITIONS.get(previous.intent_type, {}).get(
+        previous.status, set()
+    )
     if current.status not in allowed:
         raise ValueError(
             f"invalid transition for {previous.intent_type}: "

--- a/src/huey/messaging/hims.py
+++ b/src/huey/messaging/hims.py
@@ -219,7 +219,9 @@ class HIMSStore:
     def list_messages(self) -> list[HIMSMessage]:
         """Return every message in append order."""
 
-        return [HIMSMessage.from_dict(row) for row in self._read_jsonl(self.messages_path)]
+        return [
+            HIMSMessage.from_dict(row) for row in self._read_jsonl(self.messages_path)
+        ]
 
     def get_message(self, message_id: str) -> HIMSMessage | None:
         """Return one message by id, or ``None`` when absent."""
@@ -229,13 +231,19 @@ class HIMSStore:
                 return message
         return None
 
-    def inbox(self, recipient: str, *, include_archived: bool = False) -> list[HIMSMessage]:
+    def inbox(
+        self, recipient: str, *, include_archived: bool = False
+    ) -> list[HIMSMessage]:
         """Return messages addressed to ``recipient``."""
 
         messages = [m for m in self.list_messages() if m.recipient == recipient]
         if include_archived:
             return messages
-        return [m for m in messages if self.status_for(m.message_id) != MessageStatus.ARCHIVED]
+        return [
+            m
+            for m in messages
+            if self.status_for(m.message_id) != MessageStatus.ARCHIVED
+        ]
 
     def outbox(self, sender: str) -> list[HIMSMessage]:
         """Return messages sent by ``sender``."""

--- a/src/huey/network/manager.py
+++ b/src/huey/network/manager.py
@@ -24,7 +24,6 @@ except Exception:  # pragma: no cover - degrade gracefully
 
 from huey.os.core.platform_support import detect_host_platform
 
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -355,7 +354,9 @@ class NetworkManager:
                 capture_output=True,
             )
         except Exception:  # pragma: no cover
-            LOGGER.exception("Failed to invoke networksetup for interface %s", interface)
+            LOGGER.exception(
+                "Failed to invoke networksetup for interface %s", interface
+            )
 
     def _bring_up_windows_interface(self, interface: str) -> None:
         powershell = shutil.which("pwsh") or shutil.which("powershell")
@@ -381,7 +382,14 @@ class NetworkManager:
         if shutil.which("netsh"):
             try:
                 subprocess.run(
-                    ["netsh", "interface", "set", "interface", f"name={interface}", "admin=enabled"],
+                    [
+                        "netsh",
+                        "interface",
+                        "set",
+                        "interface",
+                        f"name={interface}",
+                        "admin=enabled",
+                    ],
                     check=False,
                     capture_output=True,
                 )

--- a/src/huey/os/cli/__init__.py
+++ b/src/huey/os/cli/__init__.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections.abc import Iterable
 from importlib import import_module
 
-from huey.os.core.platform_support import split_command_line
 from huey.os.config_manager import ConfigManager
+from huey.os.core.platform_support import split_command_line
 
 from .main import build_parser
 

--- a/src/huey/os/core/platform_support.py
+++ b/src/huey/os/core/platform_support.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import os
 import platform
 import re
 import shlex
 import shutil
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Sequence
 

--- a/src/huey/os/core/platform_support.py
+++ b/src/huey/os/core/platform_support.py
@@ -342,7 +342,11 @@ def resolve_platform_script_paths(
     """Resolve installer, updater, uninstaller, and run-script paths by platform."""
 
     root = find_project_root(project_root)
-    host = _host_platform_from_target(target) if target is not None else detect_host_platform()
+    host = (
+        _host_platform_from_target(target)
+        if target is not None
+        else detect_host_platform()
+    )
 
     installers_root = root / "src" / "huey" / "platform" / "installers"
     memory_root = root / "src" / "huey" / "memory"
@@ -410,7 +414,14 @@ def build_platform_script_command(
         batch_fallback = script_path.with_suffix(".bat")
         if batch_fallback.exists():
             return ["cmd", "/c", str(batch_fallback), *extra_args]
-        return ["powershell", "-ExecutionPolicy", "Bypass", "-File", str(script_path), *extra_args]
+        return [
+            "powershell",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script_path),
+            *extra_args,
+        ]
     if suffix == ".bat":
         return ["cmd", "/c", str(script_path), *extra_args]
     if suffix == ".sh":

--- a/src/huey/power/management.py
+++ b/src/huey/power/management.py
@@ -25,7 +25,6 @@ except ImportError:  # pragma: no cover - degrade gracefully
 
 from huey.os.core.platform_support import detect_host_platform
 
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -356,7 +355,9 @@ class BatteryMonitor:
             return self._darwin_command(action)
         if host.is_linux:
             return self._linux_command(action)
-        LOGGER.warning("No power action implementation is available for %s", host.system)
+        LOGGER.warning(
+            "No power action implementation is available for %s", host.system
+        )
         return None
 
     def _linux_command(self, action: str) -> Optional[List[str]]:

--- a/src/huey/system_checks.py
+++ b/src/huey/system_checks.py
@@ -15,9 +15,11 @@ import sys
 from typing import Any
 
 from huey.os.core.platform_support import (
-    detect_host_platform,
     HostPlatform,
-    distro as platform_distro,
+    detect_host_platform,
+)
+from huey.os.core.platform_support import distro as platform_distro
+from huey.os.core.platform_support import (
     require_admin_privileges,
 )
 

--- a/src/huey/system_checks.py
+++ b/src/huey/system_checks.py
@@ -16,8 +16,8 @@ from typing import Any
 
 from huey.os.core.platform_support import (
     detect_host_platform,
-    distro as platform_distro,
     HostPlatform,
+    distro as platform_distro,
     require_admin_privileges,
 )
 

--- a/src/huey/system_checks.py
+++ b/src/huey/system_checks.py
@@ -21,7 +21,6 @@ from huey.os.core.platform_support import (
     require_admin_privileges,
 )
 
-
 logger = logging.getLogger(__name__)
 distro = platform_distro
 
@@ -144,7 +143,9 @@ def _leading_version_number(value: str) -> int | None:
 
 def _check_windows_support(host: HostPlatform) -> bool:
     release = host.release or host.version
-    major = _leading_version_number(host.release) or _leading_version_number(host.version)
+    major = _leading_version_number(host.release) or _leading_version_number(
+        host.version
+    )
     if major is None or major < MIN_WINDOWS_RELEASE:
         logger.warning(
             "Unsupported Windows version detected: %s. HueyOS requires Windows %s or newer.",
@@ -179,7 +180,9 @@ def check_os_support(host: HostPlatform | None = None) -> bool:
         return _check_macos_support(host)
 
     if not host.is_linux:
-        logger.warning("Unsupported operating system detected: %s", host.system or "unknown")
+        logger.warning(
+            "Unsupported operating system detected: %s", host.system or "unknown"
+        )
         return False
 
     dist_id, codename = _detect_linux_distribution(host)

--- a/src/huey/system_checks.py
+++ b/src/huey/system_checks.py
@@ -15,9 +15,9 @@ import sys
 from typing import Any
 
 from huey.os.core.platform_support import (
-    HostPlatform,
     detect_host_platform,
     distro as platform_distro,
+    HostPlatform,
     require_admin_privileges,
 )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -296,7 +296,9 @@ def test_v1_run_queue_mock_processes_sorted_and_handles_failures(
     assert run_records[1]["exit_status"] == "success"
     assert run_records[2]["exit_status"] == "error"
     assert run_records[2]["error_message_if_any"] == "mock fixture failure"
-    shadow_records = sorted((Path(output["hims_shadow_dir"]) / "records").glob("*.json"))
+    shadow_records = sorted(
+        (Path(output["hims_shadow_dir"]) / "records").glob("*.json")
+    )
     assert len(shadow_records) == 12
 
 
@@ -306,9 +308,7 @@ def test_hims_summary_command_reports_shadow_state(tmp_path: Path, capsys):
     shadow = ShadowHIMS(tmp_path / "hims-shadow")
     shadow.emit_run_record(_build_shadow_run_record(fixture))
 
-    exit_code = cli.main(
-        ["hims-summary", "--shadow-root", str(shadow.root), "--json"]
-    )
+    exit_code = cli.main(["hims-summary", "--shadow-root", str(shadow.root), "--json"])
 
     assert exit_code == 0
     payload = json.loads(capsys.readouterr().out)

--- a/tests/test_platform_runtime_support.py
+++ b/tests/test_platform_runtime_support.py
@@ -85,9 +85,11 @@ def test_network_manager_windows_uses_powershell(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         "huey.network.manager.shutil.which",
-        lambda tool: "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
-        if tool == "powershell"
-        else None,
+        lambda tool: (
+            "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+            if tool == "powershell"
+            else None
+        ),
     )
     monkeypatch.setattr(
         "huey.network.manager.subprocess.run",

--- a/tests/test_platform_support.py
+++ b/tests/test_platform_support.py
@@ -55,7 +55,8 @@ def test_normalize_platform_family_recognizes_common_aliases(
     expected: str,
 ) -> None:
     assert (
-        platform_support.normalize_platform_family(system, sys_platform_name) == expected
+        platform_support.normalize_platform_family(system, sys_platform_name)
+        == expected
     )
 
 
@@ -136,9 +137,9 @@ def test_build_platform_script_command_prefers_powershell(monkeypatch) -> None:
     monkeypatch.setattr(
         platform_support.shutil,
         "which",
-        lambda tool: "C:/Program Files/PowerShell/7/pwsh.exe"
-        if tool == "pwsh"
-        else None,
+        lambda tool: (
+            "C:/Program Files/PowerShell/7/pwsh.exe" if tool == "pwsh" else None
+        ),
     )
 
     command = platform_support.build_platform_script_command(

--- a/tests/test_pyhuey_manager.py
+++ b/tests/test_pyhuey_manager.py
@@ -54,7 +54,12 @@ def test_manager_gui_payload_groups_actions_and_paths():
 
     assert payload["title"] == "Monkey Manager"
     assert payload["paths"]["project_root"].endswith("Monkey-Head-Project")
-    assert payload["paths"]["installer_target"] in {"windows", "macos", "debian", "linux"}
+    assert payload["paths"]["installer_target"] in {
+        "windows",
+        "macos",
+        "debian",
+        "linux",
+    }
     assert payload["paths"]["install"]["exists"] is True
     assert payload["paths"]["update"]["exists"] is True
     assert payload["paths"]["run"]["exists"] is True
@@ -90,7 +95,9 @@ def test_adapter_status_includes_gui_state():
         status = launch_pyhuey(tools=[MonkeyManager()])
         assert status["running"] is True
         assert status["gui_state"]["tool_count"] == 1
-        assert status["gui_state"]["tools"][0]["gui_payload"]["title"] == "Monkey Manager"
+        assert (
+            status["gui_state"]["tools"][0]["gui_payload"]["title"] == "Monkey Manager"
+        )
     finally:
         shutdown_pyhuey()
 

--- a/tests/test_speech_pipeline.py
+++ b/tests/test_speech_pipeline.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from huey.media.media_manifest import MediaProbe
 from huey.media.media_manager import CommandResult
+from huey.media.media_manifest import MediaProbe
 from huey.media.speech_pipeline import prepare_audio_for_transcription
 
 

--- a/tests/test_system_checks_module.py
+++ b/tests/test_system_checks_module.py
@@ -95,6 +95,7 @@ def test_check_os_support_accepts_supported_macos_version(monkeypatch, caplog):
     assert supported is True
     assert "Unsupported macOS version" not in caplog.text
 
+
 def test_check_os_support_warns_for_non_debian_linux(monkeypatch, caplog):
     monkeypatch.setattr(
         system_checks,
@@ -386,9 +387,9 @@ def test_system_check_uses_windows_tool_requirements(monkeypatch):
     monkeypatch.setattr(
         system_checks.shutil,
         "which",
-        lambda tool: f"C:/Tools/{tool}.exe"
-        if tool in {"git", "python", "pwsh"}
-        else None,
+        lambda tool: (
+            f"C:/Tools/{tool}.exe" if tool in {"git", "python", "pwsh"} else None
+        ),
     )
 
     results = system_checks.system_check()

--- a/tests/test_system_checks_module.py
+++ b/tests/test_system_checks_module.py
@@ -12,8 +12,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from huey.os.core.platform_support import HostPlatform
 from huey.os import system_checks
+from huey.os.core.platform_support import HostPlatform
 
 
 def _host(

--- a/tests/test_v120_asset_audit.py
+++ b/tests/test_v120_asset_audit.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import re
+
 from scripts.repo.audit_v120_assets import (
     build_report,
     classify_path,
     find_version_drift,
+    normalize_repository_path,
+    normalize_repository_paths,
     render_markdown,
 )
 from scripts.repo.check_canon_terms import _compile_rules
+from scripts.repo.check_repo_drift import DriftRule, should_check_rule
 
 
 def test_classification_keeps_archive_out_of_active_surface() -> None:
@@ -23,10 +28,14 @@ def test_old_active_master_plans_are_drift_but_archived_plans_are_not() -> None:
     paths = [
         "master-plan-v120.2.json",
         "master-plan-v120.1.json",
+        r".\master-plan-v120.0.json",
         "archives/master-plan-v101.1.json",
         "src/huey/memory/JSON/master-plan-v5.json",
     ]
-    assert find_version_drift(paths) == ["master-plan-v120.1.json"]
+    assert find_version_drift(paths) == [
+        "master-plan-v120.0.json",
+        "master-plan-v120.1.json",
+    ]
 
 
 def test_report_requires_the_v120_2_pair_and_lists_duplicates() -> None:
@@ -46,6 +55,31 @@ def test_report_requires_the_v120_2_pair_and_lists_duplicates() -> None:
     assert "`master-plan-v120.2.json`" in markdown
 
 
+def test_report_normalizes_and_deduplicates_cross_platform_paths() -> None:
+    report = build_report(
+        [
+            "./README.md",
+            r".\master-plan-v120.2.json",
+            r"src\huey\api.py",
+            "./src/huey/api.py",
+            "src/huey/services/api.py",
+        ]
+    )
+    assert report["tracked_path_count"] == 4
+    assert report["missing_canonical_files"] == []
+    assert report["duplicate_basename_groups"] == {
+        "api.py": ["src/huey/api.py", "src/huey/services/api.py"]
+    }
+
+
+def test_path_normalization_is_stable() -> None:
+    assert normalize_repository_path(r".\src\huey\api.py") == "src/huey/api.py"
+    assert normalize_repository_path("././README.md") == "README.md"
+    assert normalize_repository_paths(
+        ["./README.md", "README.md", r"src\huey\api.py"]
+    ) == ["README.md", "src/huey/api.py"]
+
+
 def test_canon_regexes_match_real_terms_not_literal_backslashes() -> None:
     rules = {rule.name: rule.pattern for rule in _compile_rules()}
     assert rules["huey-core-active"].search("Huey Core")
@@ -54,3 +88,19 @@ def test_canon_regexes_match_real_terms_not_literal_backslashes() -> None:
     assert rules["vague-hueybrain-node-label"].search(
         "active Huey Brain V1 execution node"
     )
+
+
+def test_asset_audit_can_name_review_paths_without_failing_drift() -> None:
+    audit_path = "scripts/repo/audit_v120_assets.py"
+    integration_rule = DriftRule(
+        name="integrations-pygpt-path",
+        pattern=re.compile(r"\bintegrations/pygpt\b"),
+        message="canonical connector",
+    )
+    other_rule = DriftRule(
+        name="repo-py-gpt-path",
+        pattern=re.compile(r"\brepo/py-gpt\b"),
+        message="stale path",
+    )
+    assert not should_check_rule(audit_path, integration_rule)
+    assert should_check_rule(audit_path, other_rule)

--- a/tests/test_v120_asset_audit.py
+++ b/tests/test_v120_asset_audit.py
@@ -12,7 +12,10 @@ from scripts.repo.audit_v120_assets import (
     render_markdown,
 )
 from scripts.repo.check_canon_terms import _compile_rules
-from scripts.repo.check_legacy_hueyos_imports import is_allowed_text_reference
+from scripts.repo.check_legacy_hueyos_imports import (
+    is_allowed_text_reference,
+    should_scan,
+)
 from scripts.repo.check_repo_drift import DriftRule, should_check_rule
 
 
@@ -115,3 +118,4 @@ def test_legacy_namespace_allowance_is_exact_and_audit_only() -> None:
     assert not is_allowed_text_reference(
         Path("scripts/new_runtime.py"), '"src/hueyos/",'
     )
+    assert not should_scan(Path("tests/test_v120_asset_audit.py"))

--- a/tests/test_v120_asset_audit.py
+++ b/tests/test_v120_asset_audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 from scripts.repo.audit_v120_assets import (
     build_report,
@@ -11,6 +12,7 @@ from scripts.repo.audit_v120_assets import (
     render_markdown,
 )
 from scripts.repo.check_canon_terms import _compile_rules
+from scripts.repo.check_legacy_hueyos_imports import is_allowed_text_reference
 from scripts.repo.check_repo_drift import DriftRule, should_check_rule
 
 
@@ -104,3 +106,12 @@ def test_asset_audit_can_name_review_paths_without_failing_drift() -> None:
     )
     assert not should_check_rule(audit_path, integration_rule)
     assert should_check_rule(audit_path, other_rule)
+
+
+def test_legacy_namespace_allowance_is_exact_and_audit_only() -> None:
+    audit_path = Path("scripts/repo/audit_v120_assets.py")
+    assert is_allowed_text_reference(audit_path, '    "src/hueyos/",')
+    assert not is_allowed_text_reference(audit_path, "import hueyos")
+    assert not is_allowed_text_reference(
+        Path("scripts/new_runtime.py"), '"src/hueyos/",'
+    )


### PR DESCRIPTION
## Outcome

Completes the practical Batch 0/1 baseline: addresses all actionable Copilot feedback from merged PR #759, repairs self-referential guardrail failures, and restores the full repository CI pipeline to green.

## Asset-audit corrections

- centralizes repository-path normalization and deduplication
- supports POSIX paths, Windows separators, repeated `./` prefixes, and surrogate-safe Git decoding
- makes canonical-file, version-drift, and duplicate-basename results deterministic
- adds cross-platform and archive-boundary regression tests
- directs superseded master plans to `docs/archive/master-plans/` instead of retaining them at repository root

## Guardrail corrections

- permits the audit tool to name `integrations/pygpt/` for classification without disabling unrelated drift rules
- permits the audit tool to name `src/hueyos/` through an exact path-and-line allowance
- keeps genuine legacy imports and active namespace drift blocked
- adds `--diff` to isort CI output for actionable future failures

## Baseline cleanup

- applies Black 26.5.1 formatting to the active files identified by CI
- applies isort 8.0.1-compatible import ordering
- excludes preserved `src/huey/memory/PY/` and upstream-derived `src/huey/connectors/pyhuey/` trees consistently from active formatting/lint scope
- keeps the formatting sweep mechanical; no runtime behavior was intentionally changed

## Validation

All current workflows pass:

- CI lint
- Python 3.13 supported test suite
- Python 3.14 experimental test suite
- CodeQL
- Bandit
- dependency security scan
- artifact/container-adjacent scan
- package smoke
- documentation
- release dry run

Eight focused local regression tests also pass, and changed Python files compile successfully.

## Review mapping

Resolves the normalization concerns in `build_report()`, `find_version_drift()`, and `duplicate_basenames()`, the UTF-8 robustness recommendation in `tracked_paths()`, and the missing Windows-style path coverage from PR #759.