### PR TITLE
ci: make Black verbose exclusion explicit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,8 @@ where = ["src"]
 [tool.black]
 target-version = ["py313"]
 line-length = 88
-extend-exclude = '''
+# Black treats multiline excludes as verbose regexes; keep the flag explicit.
+extend-exclude = '''(?x)
 ^/src/huey/
 (
   connectors/pyhuey


### PR DESCRIPTION
## Summary

Make the verbose-regex mode of Black's multiline `extend-exclude` pattern explicit.

## What changed

- add the inline `(?x)` flag to `[tool.black].extend-exclude`
- add a short configuration comment explaining why the flag is retained
- preserve the existing exclusions for:
  - `src/huey/connectors/pyhuey/`
  - `src/huey/memory/PY/`

## Why

Black already treats multiline exclusion patterns as verbose regular expressions. The explicit flag is therefore behavior-preserving, but removes ambiguity for reviewers and other tooling that may inspect the regex literally.

## Impact

No runtime behavior changes. This is a narrow CI/configuration clarification intended to keep the preserved and upstream-derived trees outside the active Black formatting scope.

## Validation

- branch is one commit ahead of `main` and not behind
- diff is limited to `pyproject.toml`
- change consists of two additions and one replacement

## Review focus

Confirm that the explicit verbose-regex flag makes the exclusion intent clear without changing the matched paths.