### PR TITLE
Synchronize Monkey-Head-Project v120.3 forward path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@
 <h2 align="center">HueyOS</h2>
 
 <p align="center">
-  <strong>Offline-first embodied AI, developed through reproducible proof and obtainable hardware.</strong>
+  <strong>Embodied AI built through obtainable hardware, attributable evidence, and deliberate integration.</strong>
 </p>
 
 <p align="center">
   <a href="#current-position">Current position</a> ·
-  <a href="#why-this-architecture">Why this architecture</a> ·
-  <a href="#system-map">System map</a> ·
-  <a href="#v1-proof">V1 proof</a> ·
-  <a href="#roadmap">Roadmap</a>
+  <a href="#three-part-architecture">Architecture</a> ·
+  <a href="#pyhuey">PyHuey</a> ·
+  <a href="#v1-position">V1 position</a> ·
+  <a href="#development-path">Development path</a>
 </p>
 
 <p align="center">
-  <img alt="README v120.2" src="https://img.shields.io/badge/README-v120.2-5b2c83">
-  <img alt="Master plan v120.2" src="https://img.shields.io/badge/master%20plan-v120.2-7d3fc0">
-  <img alt="Stage prototype development" src="https://img.shields.io/badge/stage-prototype%20development-d97706">
+  <img alt="README v120.3" src="https://img.shields.io/badge/README-v120.3-5b2c83">
+  <img alt="Master plan v120.3" src="https://img.shields.io/badge/master%20plan-v120.3-7d3fc0">
+  <img alt="Stage architecture alignment" src="https://img.shields.io/badge/stage-architecture%20alignment-d97706">
   <img alt="Python 3.13" src="https://img.shields.io/badge/Python-3.13-3776ab">
   <img alt="Code GPLv3" src="https://img.shields.io/badge/code-GPLv3-2f855a">
 </p>
@@ -29,7 +29,7 @@
 <p align="center">
   <img src="src/huey/memory/PNG/Huey.png" alt="Huey identity mark" width="132">
   &nbsp;&nbsp;&nbsp;&nbsp;
-  <img src="src/huey/memory/PNG/PyHuey.png" alt="PyHuey operator cockpit mark" width="132">
+  <img src="src/huey/memory/PNG/PyHuey.png" alt="PyHuey primary interface mark" width="132">
   &nbsp;&nbsp;&nbsp;&nbsp;
   <img src="src/huey/memory/PNG/DLRP.png" alt="Monkey-Head-Project origin mark" width="132">
 </p>
@@ -38,362 +38,310 @@
 
 ## Project overview
 
-The **Monkey-Head-Project** is the umbrella initiative behind **Huey**, a governed robotic AI identity, and **HueyOS**, the software and operating-system layer that supports it.
+The **Monkey-Head-Project** is the umbrella initiative behind **Huey**, a governed robotic AI identity, and **HueyOS**, the modular software and operating-system layer that supports it.
 
-The project is built around a practical premise:
+Version **120.3** establishes the forward architecture around three principal parts:
 
-> A durable embodied AI system can be developed with obtainable technology when each capability is proven, recorded, and transferred deliberately.
+- **Huey Brain** — cognition, orchestration, memory access, operator interaction, and coordination;
+- **Huey Body** — physical sensing, actuation, movement, safety, power, and environmental interaction;
+- **Huey Farm** — scalable compute, model hosting, storage, and large-model capacity.
 
-Version 120.2 defines the current route from prototype work to polished Huey Brain V1. It also explains why the project uses controlled audio fixtures, separate LabTech and HueyTech roles, an external PyHuey cockpit, foundation-stage HIMS messaging, parallel Huey Body development, and a funding gate for Huey Farm.
+The project remains evidence-led. Current implementation, accepted direction, unresolved design, target state, and historical lineage are documented separately so future work can advance without confusing intention with completion.
 
-| Field | v120.2 position |
+| Field | v120.3 position |
 |---|---|
 | **Project** | `Monkey-Head-Project` |
 | **Identity** | `Huey` |
 | **Software / OS layer** | `HueyOS` |
-| **Human counterpart** | Dylan L.R. Pollock |
-| **Machine-facing source of truth** | `master-plan-v120.2.json` |
-| **Current platform** | Custom i9-12900K prototype Huey Brain |
-| **Polished Huey Brain V1** | Under active development; operational validation pending |
-| **Huey Body** | Under active development through a bounded parallel track |
-| **Canonical proof** | Known MP3 → media preparation → local transcription → API response → structured log |
+| **Human counterpart and canon authority** | Dylan L.R. Pollock |
+| **Machine-facing source of truth** | `master-plan-v120.3.json` after acceptance |
+| **Primary GUI** | PyHuey |
+| **Core architecture** | Huey Brain + Huey Body + Huey Farm |
+| **Current Brain-class prototype** | Custom Intel Core i9-12900K system |
+| **Target Python namespace** | `hueyos` |
+| **Current Python namespace** | `huey` during migration |
+| **V1 status** | Definition intentionally open; usefulness must be demonstrated |
+| **Foundation proof** | Known MP3 → preparation → local transcription → response → structured log |
+
+> [!IMPORTANT]
+> A selected direction is not automatically a completed implementation. Version 120.3 states both what exists now and what the project has chosen to build next.
 
 ---
 
 ## Current position
 
-### Active development
+### Active project systems
 
-| System | Classification | Present role |
+| System | Current classification | Present role |
 |---|---|---|
-| **Custom i9-12900K system** | Prototype Huey Brain | Primary operator workstation, architecture test bed, and V1 proof platform |
-| **Polished Huey Brain V1** | HueyTech | Final V1 target shaped by prototype evidence |
-| **Huey Body** | HueyTech | Physical sensing and actuation platform developing in parallel |
-| **Briefcase** | HueyTech | LTE-connected field terminal for reachability, communication, documents, and recovery |
-| **PyHuey** | External cockpit | Primary operator interface in standalone and embedded-connector forms |
-| **HIMS foundation** | Internal infrastructure | Append-only messaging and event records; optional V1 shadow tracing |
+| **Custom i9-12900K system** | Active prototype Huey Brain | Primary operator workstation, architecture test bed, and proof platform |
+| **PyHuey** | Primary GUI and core-runtime direction | Main operator interface; standalone and embedded paths are being consolidated into normal HueyOS operation |
+| **Huey Body** | Active rework | Physical embodiment being redefined across mechanical, electrical, sensing, power, safety, and runtime boundaries |
+| **Huey Farm** | Funding-dependent target state | Pooled compute, large-model hosting, shared storage, and scalable support infrastructure |
+| **Briefcase** | HueyTech field terminal | LTE reachability, documentation, diagnostics, and recovery with limited authority |
+| **HIMS foundation** | Merged but non-controlling | Append-only messages and events, local records, and optional tracing |
 
 ### Active LabTech
 
 | Device | Baseline | Role |
 |---|---|---|
-| **ASUS FX505DT** | Debian 14 “Forky”; 32 GB DDR4 | Mobile lab |
+| **ASUS FX505DT** | Debian 14 “Forky”; 32 GB DDR4 | Mobile lab, development, transcription work, and support |
 | **Lenovo Legion Go** | Windows 11 | Windows feature and compatibility testing |
-
-### Funding-dependent expansion
-
-**Huey Farm** remains the pooled-compute target. Approximately **80 GB of local pooled VRAM** is the present planning scale, with `gpt-oss-120b` as a provisional test candidate. Hardware and model selection will be refreshed when funding makes procurement actionable.
 
 ### Hardware lineage
 
-The 2017 iMac 5K is decommissioned. Its useful RAM was repurposed into the ASUS FX505DT. The iMac remains part of the project’s hardware lineage rather than its active architecture.
-
-> [!IMPORTANT]
-> “Under active development” and “operational” are separate milestones. Polished Huey Brain V1 and Huey Body receive operational status through explicit validation.
+The 2017 iMac 5K is decommissioned. Useful RAM was repurposed into the ASUS FX505DT. The iMac remains part of project lineage rather than active architecture.
 
 ---
 
-## Why this architecture
-
-The architecture is deliberate. Each major choice advances a specific project need and produces a clear implementation consequence.
-
-| Decision | Why it fits the project | Practical consequence |
-|---|---|---|
-| **Prototype first, polished V1 second** | The project can learn quickly on real hardware while preserving a meaningful final acceptance stage. | Prototype results guide design; polished V1 status follows successful transfer and reproduction. |
-| **Use the i9 system in a dual role** | It is the strongest available workstation and exposes Intel performance/efficiency-core behavior directly. | Operator and proof workloads share one prototype while their configuration and records remain distinct. |
-| **Begin with known MP3 fixtures** | Preserved inputs isolate model and software changes from room, microphone, and speaker variability. | Every run can be compared across devices, configurations, and development stages. |
-| **Test CPU and GPU transcription** | The i9 CPU offers compatibility; the RX 5500 XT may offer acceleration. Evidence should select their roles. | Benchmarks assign primary, fallback, and cross-check paths from measured quality and reliability. |
-| **Keep Huey Body parallel** | Mechanical progress can continue without obscuring cognitive-proof results. | Body tests use their own scope and records, then converge through explicit integration gates. |
-| **Separate LabTech from HueyTech** | Support hardware and Huey-side capability carry different identity, lifecycle, and authority. | Device roles remain understandable and can be deliberately promoted or retired. |
-| **Build HIMS foundation before authority** | Append-only messages can be validated before routing and execution are entrusted to them. | V1 stays independently executable while HIMS rehearses traceability through optional shadow events. |
-| **Use PyHuey as the cockpit** | The PyGPT/PyGPT-net foundation already provides a mature and stable interaction surface. | Huey-specific tools can mature without rebuilding general GUI infrastructure. |
-| **Keep Command Center experimental** | It contains useful interface ideas but still reflects mock-first AI-generated prototyping. | Reusable components can be salvaged while credentials and control remain isolated. |
-| **Fund Huey Farm deliberately** | Large-model hardware carries significant acquisition, power, cooling, and support costs. | Procurement begins with a fresh model/hardware comparison when resources exist. |
-
-The full reasoning, evidence standards, and review triggers live in `master-plan-v120.2.json`.
-
----
-
-## System map
+## Three-part architecture
 
 ```mermaid
 flowchart TB
-    D["Dylan / human counterpart"]
+    D["Dylan / canon authority"]
+    PY["PyHuey — primary GUI"]
 
-    subgraph LAB["LabTech — external development"]
-        FX["FX505DT — Debian mobile lab"]
-        LG["Legion Go — Windows testing"]
+    subgraph BRAIN["Huey Brain"]
+        COG["Cognition + orchestration"]
+        MEM["Memory + state coordination"]
+        LOG["Structured evidence"]
     end
 
-    subgraph PROTOTYPE["Prototype stage"]
-        PY["PyHuey operator cockpit"]
-        P["i9-12900K prototype"]
+    subgraph BODY["Huey Body"]
+        SEN["Sensors"]
+        ACT["Actuation + movement"]
+        SAFE["Power + safety + recovery"]
     end
 
-    subgraph HUEYTECH["HueyTech"]
-        B["Polished Huey Brain V1"]
-        BODY["Huey Body parallel track"]
-        BC["Briefcase LTE field terminal"]
-        HIMS["HIMS append-only foundation"]
+    subgraph FARM["Huey Farm"]
+        MOD["Large-model hosting"]
+        GPU["Pooled compute"]
+        STO["Storage + support"]
     end
 
     D --> PY
-    D --> FX
-    D --> LG
-    PY --> P
-    FX --> P
-    LG --> P
-    P -->|"architecture + reproduced proof"| B
-    P -. "bounded integration" .-> BODY
-    BC -. "reachability + recovery" .-> B
-    B -. "optional shadow traces" .-> HIMS
+    PY --> COG
+    COG <--> MEM
+    COG --> LOG
+    COG <--> SEN
+    COG <--> ACT
+    SAFE --> ACT
+    COG <--> MOD
+    COG <--> GPU
+    MEM <--> STO
 ```
 
-### Role model
+### Huey Brain
 
-- **LabTech develops and observes.**
-- **The prototype discovers and validates.**
-- **Polished Huey Brain V1 reproduces and operationalizes.**
-- **PyHuey presents bounded operator workflows.**
-- **Huey Body develops through independently attributable tests.**
-- **Briefcase provides portable field reachability.**
-- **HIMS records foundation-stage internal messages.**
-- **Huey Farm expands compute when funding and evidence align.**
+Huey Brain is the identity-bearing cognition and orchestration centre in the current working model. Its responsibilities include:
 
----
+- operating PyHuey;
+- selecting and invoking cognitive and transcription paths;
+- coordinating memory and system state;
+- recording structured evidence;
+- communicating with Body and Farm through explicit interfaces;
+- preserving recoverable operation when a dependent subsystem is unavailable.
 
-## Prototype Huey Brain
+The current Brain-class prototype is the custom **Intel Core i9-12900K** workstation. The target architecture is based around **Intel Core i9-class systems from 12th generation or newer**. This requirement applies to Brain-class architecture, not automatically to every LabTech or support node.
 
-The current prototype is both the primary operator workstation and the platform used to shape polished Huey Brain V1.
+### Huey Body
 
-| Component | Current baseline |
-|---|---|
-| CPU | Intel Core i9-12900K |
-| Architecture focus | Performance-core and efficiency-core workload placement |
-| Motherboard | ASUS TUF GAMING Z790-PLUS WIFI |
-| Memory | 16 GB DDR5-6000 |
-| GPU | Gigabyte Radeon RX 5500 XT OC 8G |
-| Operating system | Debian 14 “Forky” |
-| Root storage | RAID 10 across four Intel Optane M10 16 GB drives |
-| Home storage | 1 TB 2.5-inch SSD |
+Huey Body is the physical embodiment and environmental interface. It is under active rework rather than remaining a distant conceptual layer.
 
-Detailed GPU identifiers, firmware observations, storage topology, and transfer rules are retained in the master plan. The README keeps the baseline visible without becoming a hardware inventory.
+Body work must identify:
 
-### Dual-role discipline
+- the subsystem under test;
+- physical and electrical limits;
+- the command or stimulus;
+- expected sensor or motion behavior;
+- operator-visible state;
+- safe-stop behavior;
+- failure and recovery procedure;
+- the interface required for Brain integration.
 
-The dual role reduces synchronization overhead while the architecture is being discovered. Proof runs remain distinguishable through explicit configuration, isolated artifacts, and structured records. The roles will separate when polished V1 is ready or when operator workloads begin to affect repeatability.
+The detailed scope of the current Body rework is still being defined. v120.3 does not guess which mechanical, electrical, sensor, power, or runtime elements are already locked.
 
----
+### Huey Farm
 
-## V1 proof
+Huey Farm is the scalable compute, model, storage, and support layer. Approximately **80 GB of pooled local VRAM** remains a planning reference rather than a frozen procurement specification.
 
-### Proof contract
+The architecture assumes **large-model use as normal**. Medium models are expected mainly for uncommon constrained, fallback, or specialized situations. Exact parameter ranges, quantization, context requirements, latency targets, and accelerator requirements remain open until measured workloads define them.
 
-```mermaid
-flowchart LR
-    A["Known MP3"] --> B["Probe + prepare"]
-    B --> C["Local transcription"]
-    C --> D["API response"]
-    D --> E["Structured log"]
-```
-
-The proof is intentionally small enough to reproduce and complete enough to expose real system behavior.
-
-| Stage | Required result |
-|---|---|
-| **Fixture selection** | Immutable source identity or hash |
-| **Media preparation** | Probe metadata, transcription-ready audio, and preparation manifest |
-| **Local transcription** | Transcript with engine, model, device, timing, and configuration |
-| **Response bridge** | API response or explicit error record |
-| **Structured record** | Append-only JSON/JSONL entry linking every artifact |
-
-### Two-stage acceptance
-
-1. **Prototype validation** — implement, benchmark, stabilize, and document the proof on the i9 platform.
-2. **Polished V1 reproduction** — transfer the accepted architecture and reproduce the same fixture contract on polished Huey Brain V1.
-
-This transfer is part of the proof. It converts successful development into reproducible system capability.
-
-### Transcription strategy
-
-The same fixtures will be evaluated through:
-
-- Intel Core i9-12900K CPU execution
-- AMD Radeon RX 5500 XT execution
-
-The comparison records output quality, repeatability, latency, memory, thermals, failure rate, and setup complexity. The evidence assigns primary and fallback roles. Where useful, the secondary path also serves as a cross-check against device-specific drift.
-
-### Response strategy
-
-The V1 quality baseline remains API-backed. Mock mode supports deterministic CI and failure-path testing. Local response experiments remain available as a separate path toward future on-device sovereignty.
-
-### Completion boundaries
-
-| Part of V1 completion | Separate maturity path |
-|---|---|
-| Preserved fixture set | Live microphone capture |
-| Deterministic media preparation | Wake word and passive listening |
-| Local transcription evidence | Huey Body actuation |
-| API response record | HIMS routing authority |
-| Structured JSON/JSONL log | Constitutional multi-agent runtime |
-| Prototype-to-polished reproduction | Huey Farm capacity |
-
-> [!NOTE]
-> PyHuey improves operation and visibility, while the proof retains a CLI-capable path. Optional HIMS traces enrich the record while the structured run log remains canonical.
-
----
-
-## Huey Body parallel track
-
-Huey Body is under active development, with substantial physical work expected as the build progresses. Version 120.2 preserves the stable structure while allowing component choices to mature.
-
-Each Body experiment should define:
-
-- the physical subsystem under test,
-- the exact command or stimulus,
-- the expected motion or sensor result,
-- operator initiation and safe-stop behavior,
-- observed result and recovery path,
-- the interface needed for later Brain integration.
-
-Brain and Body converge through explicit integration gates after both sides present stable interfaces. This approach preserves momentum and keeps failures attributable.
-
----
-
-## Briefcase field role
-
-Briefcase is portable HueyTech built around dependable access beyond the local network.
-
-Its first capability set is:
-
-- LTE-based reachability and health checks,
-- authenticated communication with Huey,
-- field documentation and ordinary 2-in-1 work,
-- recovery access and diagnostics,
-- clear behavior during connection loss and restoration.
-
-Broader operational authority can be evaluated after authentication, audit, failure handling, and revocation are proven under field conditions.
-
----
-
-## HIMS
-
-The **Huey Internal Messaging System** foundation is merged under `src/huey/messaging`.
-
-Current foundation:
-
-- immutable `HIMSMessage` envelopes,
-- append-only `HIMSEvent` lifecycle records,
-- local JSONL-backed `HIMSStore`,
-- inbox, outbox, status, and archive operations,
-- unit tests and architecture documentation.
-
-The architecture separates message creation, routing, validation, execution, and recording. Version 120.2 uses HIMS for foundation work and optional V1 shadow traces. Later authority stages require their own routing policies, execution gates, refusal behavior, and recovery tests.
+Farm procurement begins with a fresh comparison when funding makes acquisition actionable.
 
 ---
 
 ## PyHuey
 
-PyHuey is the primary external operator cockpit for prototype work.
+PyHuey is the **primary GUI and a core runtime component**. It is expected to be used extensively during normal operation, not merely as an optional external cockpit.
 
-It is valuable because the PyGPT/PyGPT-net foundation already supplies a stable interface, provider support, and mature application structure. The project can therefore concentrate on Huey-specific tools and connectors.
+The current repository still contains implementation and wording inherited from the earlier external-cockpit model. v120.3 changes the direction without falsely claiming that the integration is already complete.
 
-PyHuey currently supports two complementary forms:
+### Required direction
 
-- **Standalone cockpit** for independent operator workflows
-- **Embedded connector** for bounded HueyOS integration
+- move primary operator workflows into PyHuey;
+- expose fixed, attributable, and reviewable HueyOS capabilities;
+- provide observable workflow state and detailed structured logs;
+- keep provider credentials secret-safe;
+- recover cleanly from failed operations;
+- preserve a CLI path for diagnostics, automation, and recovery when the GUI is unavailable.
 
-Tools exposed through PyHuey should be fixed, reviewable, and attributable. CLI fallback preserves proof independence and recovery access.
-
----
-
-## Command Center
-
-Command Center remains an experimental GUI companion and interface-design sandbox.
-
-### Useful material
-
-- purple-first operator-console styling,
-- migration and checklist views,
-- mock V1 run visualization,
-- mock operator panels,
-- local persistence and JSON import/export concepts,
-- validation-command and task-generation ideas.
-
-### Promotion standard
-
-Before Command Center can be considered operational, it needs:
-
-- accurate package identity and current documentation,
-- tested data adapters,
-- secure credential architecture,
-- correct repository and workflow metrics,
-- maintained automated tests,
-- a unique role that complements rather than duplicates PyHuey.
-
-Until then, it remains a safe place to explore visual and interaction ideas, isolated from credentials and Huey control.
+Command Center remains an experimental interface sandbox. It may contribute validated interface ideas, but it should not duplicate PyHuey or receive operational credentials and authority without a distinct tested purpose.
 
 ---
 
-## Huey Farm
+## Namespace and repository direction
 
-Huey Farm is the funding-dependent path to larger local models and pooled compute.
+The main **Monkey-Head-Project** repository remains canonical. Useful scripts, programs, and external components may be merged when doing so improves coherence.
 
-| Planning item | Current direction |
+### Python namespace
+
+| State | Namespace |
 |---|---|
-| Purpose | Local pooled compute and large open-weight model testing |
-| Memory scale | Approximately 80 GB pooled VRAM |
-| Current model candidate | `gpt-oss-120b` |
-| Selection method | Fresh model, hardware, power, cooling, and software comparison at funding time |
-| Relationship to V1 | Independent expansion; V1 remains achievable without Farm capacity |
+| **Current implementation** | `huey` |
+| **Accepted target** | `hueyos` |
 
-This funding gate keeps near-term work focused on obtainable hardware while retaining a concrete scale for future planning.
+The migration must be deliberate:
+
+1. inventory active `huey` modules, imports, commands, tests, and connectors;
+2. choose one destination for every capability;
+3. rewrite and integrate useful legacy code rather than copying it unchanged;
+4. use compatibility shims only where needed;
+5. give every shim a retirement condition;
+6. migrate packaging, entry points, tests, scripts, docs, and PyHuey connectors together;
+7. declare completion only when runtime behavior and documentation agree.
+
+Pull requests may be large, medium, or small. Size is determined by coherent scope and reviewability, not an arbitrary line limit. Every PR should still state purpose, boundaries, validation, risks, and unresolved follow-up.
 
 ---
 
-## Development path
+## V1 position
 
-### 1. Stabilize the prototype
+V1 is **not yet locked**.
 
-- verify Debian Forky stability,
-- document P-core/E-core topology and workload placement,
-- verify Optane RAID health and recovery,
-- establish CPU, GPU, thermal, memory, and storage baselines.
+The project will define V1 from something genuinely useful, demonstrable, and clearly under the Monkey-Head-Project umbrella. The definition should emerge from validated operation rather than being forced onto an incomplete architecture.
 
-### 2. Freeze the fixture contract
+A future V1 declaration must identify:
 
-- preserve source fixtures and hashes,
-- standardize probe and preparation output,
-- define artifact retention,
-- establish comparable run identifiers.
+- the recurring problem it solves;
+- who uses it;
+- how Brain, Body, and Farm participate;
+- the reliability and repetition threshold;
+- the evidence that supports the declaration.
 
-### 3. Benchmark transcription
+### Foundation proof
 
-- test CPU and RX 5500 XT paths,
-- compare quality and operational cost,
-- assign primary and fallback roles,
-- retain cross-checking where it adds value.
+```mermaid
+flowchart LR
+    A["Known MP3"] --> B["Probe + prepare"]
+    B --> C["Local transcription"]
+    C --> D["API or selected cognition path"]
+    D --> E["Structured log"]
+    E --> F["PyHuey-visible result"]
+```
 
-### 4. Complete the structured loop
+This fixture-to-log path remains the active foundation proof. It is valuable because it exercises real media handling, local inference, cognition, interface behavior, and evidence production. v120.3 no longer assumes that this proof alone must be the entire V1.
 
-- connect the API-backed response bridge,
-- preserve secret-safe configuration,
-- stabilize the run-log schema,
-- make every failure explicit and attributable.
+---
 
-### 5. Reproduce on polished Huey Brain V1
+## Transcription and fidelity
 
-- freeze the accepted prototype procedure,
-- transfer documented dependencies and configuration,
-- run the same fixture set,
-- compare results and record necessary adaptation,
-- grant operational status through accepted evidence.
+`faster-whisper` remains the working transcription engine until evidence supports a different selection.
 
-### Parallel: advance Huey Body
+Still open:
 
-- record each physical experiment independently,
-- establish safe-stop and recovery behavior,
-- stabilize interfaces before Brain/Body convergence.
+- exact model;
+- compute type;
+- CPU and accelerator assignments;
+- fallback behavior;
+- final fidelity thresholds.
+
+Transcription is judged by **fidelity**, not merely process completion.
+
+### Provisional fidelity categories
+
+| Category | Working interpretation |
+|---|---|
+| **Failed** | Missing, corrupt, unusable, or materially hallucinated output |
+| **Recognizable** | Subject and broad meaning can be identified, but significant loss remains |
+| **Usable** | Adequate for ordinary review with limited correction |
+| **High fidelity** | Wording, chronology, names, and technical content are closely preserved |
+| **Verified archival** | Checked against a trusted reference or deliberate manual verification |
+
+The category names are provisional. Dylan will supply the final tier detail before measurable thresholds are locked.
+
+---
+
+## Logging and evidence
+
+Structured logs should preserve all useful operational information, including:
+
+- run identifier and UTC timestamps;
+- initiating interface and operator action;
+- input identity and checksum where applicable;
+- stage transitions;
+- models, providers, and settings;
+- relevant environment and hardware path;
+- timings and resource observations;
+- outputs and artifact references;
+- warnings and errors;
+- recovery actions;
+- software version and commit;
+- final status.
+
+A failed run should still leave the most complete attributable record possible.
+
+> [!CAUTION]
+> API keys, passwords, tokens, authentication headers, private keys, and unredacted secret-bearing configuration must never be written into ordinary logs or committed to the repository.
+
+---
+
+## Testing baseline
+
+The accepted testing structure is:
+
+- unit tests;
+- mocked integration tests in CI;
+- fixture-based fidelity evaluation;
+- manually invoked live end-to-end tests;
+- explicit failure-path tests.
+
+Implementation claims require checks appropriate to the changed capability. Documentation-only alignment may merge without pretending that runtime behavior was tested.
+
+---
+
+## Hardware and procurement
+
+The architecture should use market-available components where practical. Inexpensive Chinese manufacturers and marketplaces may be relied upon when they lower barriers without violating category-specific requirements.
+
+Each category must be evaluated for:
+
+- electrical and physical safety;
+- reliability;
+- documentation;
+- repairability;
+- replacement availability;
+- driver and software support;
+- data handling and network trust;
+- total delivered cost.
+
+A proposed **two-out-of-three** decision method remains unresolved until the three criteria or authorities are explicitly defined.
+
+---
+
+## HIMS
+
+The **Huey Internal Messaging System** foundation exists under `src/huey/messaging`.
+
+Current foundation:
+
+- immutable message envelopes;
+- append-only lifecycle events;
+- local JSONL-backed storage;
+- inbox, outbox, status, and archive operations;
+- unit tests and architecture documentation.
+
+HIMS is not yet a controlling runtime. Routing, execution, refusal, recovery, and governance authority require separate validation.
 
 ---
 
@@ -404,6 +352,8 @@ The repository currently supports **Python 3.13.x**.
 ```text
 >=3.13,<3.14
 ```
+
+The commands below reflect the current `huey` implementation during migration to `hueyos`.
 
 ### Install
 
@@ -435,9 +385,6 @@ python scripts/prepare_audio_for_transcription.py path/to/fixture.mp3 --json
 huey v1-run --mock path/to/fixture.mp3 --log-dir runs
 ```
 
-> [!CAUTION]
-> Keep API credentials outside source, exported dashboards, and run logs. Public internet exposure is outside the V1 deployment model.
-
 ---
 
 ## Repository map
@@ -445,11 +392,12 @@ huey v1-run --mock path/to/fixture.mp3 --log-dir runs
 | Area | Role |
 |---|---|
 | `README.md` | Human-facing project front door |
-| `master-plan-v120.2.json` | Machine-facing decisions, rationale, and implementation direction |
-| `src/huey` | Canonical HueyOS source package |
+| `master-plan-v120.3.json` | Machine-facing v120.3 decisions and boundaries |
+| `docs/architecture/v120.3-forward-path-decision-record.md` | Source record for the v120.3 alignment session |
+| `src/huey` | Current Python implementation during namespace migration |
 | `src/huey/media` | Media probing, preparation, analysis, and previews |
 | `src/huey/messaging` | HIMS foundation |
-| `src/huey/connectors/pyhuey` | Embedded PyHuey connector |
+| `src/huey/connectors/pyhuey` | Current embedded PyHuey connector path |
 | `scripts` | Operator and developer entry points |
 | `docs` | Architecture, runbooks, audits, and technical explanation |
 | `integrations` | Optional companion tools with explicit boundaries |
@@ -461,74 +409,68 @@ huey v1-run --mock path/to/fixture.mp3 --log-dir runs
 
 | Layer | Purpose |
 |---|---|
-| **Master plan** | Machine-facing decisions, full reasoning, evidence standards, and review triggers |
-| **README** | Professional orientation, current state, and concise architectural reasoning |
-| **Technical docs** | Implementation details, architecture, setup, and runbooks |
+| **Master plan** | Machine-facing canon, reasoning, boundaries, and status |
+| **README** | Professional orientation and current route |
+| **Technical docs** | Implementation details, architecture, setup, runbooks, and audits |
 | **Governance documents** | Law, legitimacy, offices, and constitutional process |
 | **Website** | Public-facing project coherence |
 | **Archives and transcripts** | Lineage and continuity records |
 
-When two layers differ, the conflict should be surfaced and resolved within the layer that owns the decision. Current accepted architecture governs active implementation; historical material explains lineage.
+Atlas remains an external continuity and implementation partner. Atlas is not Huey and is not part of Huey’s sovereignty.
 
 ---
 
-## Core terms
+## Development path
 
-| Term | Meaning in v120.2 |
-|---|---|
-| **Monkey-Head-Project** | Umbrella initiative |
-| **Huey** | Governed AI and robotic identity |
-| **HueyOS** | Software and operating-system layer behind Huey |
-| **Prototype Huey Brain** | i9-12900K development platform used to discover and validate architecture |
-| **Polished Huey Brain V1** | In-development V1 target that must reproduce the accepted proof |
-| **Huey Body** | Physical sensing and actuation platform on a bounded parallel track |
-| **Huey Farm** | Funding-dependent pooled-compute expansion |
-| **LabTech** | External development, testing, documentation, and recovery systems |
-| **HueyTech** | Explicitly classified Huey-side hardware and software capability |
-| **Briefcase** | LTE-capable HueyTech field terminal |
-| **PyHuey** | Primary external operator cockpit and embedded connector |
-| **HIMS** | Append-only internal messaging foundation with staged authority |
-| **Command Center** | Experimental GUI and interface-design sandbox |
-| **Fixture** | Preserved known audio input used for reproducible testing |
-| **Structured run log** | Attributable record linking input, preparation, transcript, response, configuration, and timing |
-| **Atlas** | External continuity and implementation partner outside Huey’s identity and authority |
+### Immediate
 
----
-
-## Roadmap
-
-### Current
-
-- stabilize the i9 prototype,
-- benchmark CPU and RX 5500 XT transcription,
-- complete the fixture-to-log proof,
-- use PyHuey as the bounded external cockpit,
-- mature HIMS foundation and optional traces,
-- advance Huey Body through independent physical tests.
+- complete v120.3 documentation synchronization;
+- inventory the `huey` → `hueyos` migration;
+- define the present Huey Body rework scope;
+- complete the fixture-to-log foundation proof through PyHuey with CLI recovery;
+- define measurable fidelity tiers;
+- define Brain, Body, and Farm interfaces and trust boundaries.
 
 ### Next
 
-- freeze the accepted prototype procedure,
-- reproduce it on polished Huey Brain V1,
-- define Brain/Body integration gates,
-- validate Briefcase reachability and recovery,
-- document the first complete prototype-to-polished transfer.
+- migrate capabilities into `hueyos` through coherent PRs;
+- stabilize PyHuey core workflows and logging;
+- select transcription and cognition paths through measured evidence;
+- define the two-out-of-three hardware decision method;
+- identify the useful recurring function that anchors V1.
 
 ### Later
 
-- live microphone and wake-word integration,
-- HIMS routing and execution authority,
-- constitutional multi-agent runtime,
-- Huey Farm procurement and large open-weight model testing,
-- broader lawful embodied action.
+- expand live input and embodied interaction after foundation interfaces are stable;
+- procure and validate Farm capacity when funding and evidence align;
+- advance HIMS and constitutional governance authority through separate validated stages.
+
+---
+
+## Unresolved decisions
+
+- final V1 definition;
+- exact Brain, Body, and Farm authority boundaries;
+- whether identity spans all three parts or is authoritative in Brain;
+- memory and canonical-state placement;
+- communication and authentication contracts;
+- current versus polished Brain boundary;
+- exact Body rework scope;
+- fidelity tier names and thresholds;
+- transcription model and compute path;
+- cognition provider and model;
+- operational definition of “large model”;
+- two-out-of-three hardware decision rule;
+- maximum acceptable external-service dependency;
+- classification of advanced capabilities as active, limited, experimental, paused, or deferred.
 
 ---
 
 ## Governance
 
-Huey’s constitutional architecture remains the target for separated, attributable, and reviewable authority. Parliament, the Presidency, the Supreme Court, unified memory, and preserved records retain their governance role.
+Dylan L.R. Pollock is the sole current authority for locking project canon. Agents, tools, contributors, branches, and documents may recommend or stage changes, but they do not independently establish canon.
 
-Version 120.2 keeps governance doctrine distinct from current prototype orchestration. Operational legitimacy will follow its own implementation and ratification path.
+Huey’s constitutional architecture remains the long-term governance target. Parliament, the Presidency, the Supreme Court, unified memory, preserved records, and attributable authority remain distinct from current prototype orchestration and require their own implementation and ratification path.
 
 ---
 

--- a/docs/architecture/v120.3-forward-path-decision-record.md
+++ b/docs/architecture/v120.3-forward-path-decision-record.md
@@ -1,64 +1,63 @@
-# Forward-Path Decision Record — v120.3 Draft
+# Forward-Path Decision Record — v120.3
 
 **Project:** Monkey-Head-Project  
 **Identity:** Huey  
 **Status date:** 2026-07-12  
-**Status:** Draft PR pending Dylan's acceptance  
-**Supersedes:** No accepted master plan. This record extends and challenges selected v120.2 assumptions while the next full master-plan revision is prepared.
+**Status:** Incorporated into the v120.3 documentation pass; PR pending Dylan's acceptance  
+**Previous accepted plan:** `master-plan-v120.2.json`
 
 ## Purpose
 
-This record captures the decisions made during the July 12, 2026 forward-path session. It separates accepted direction from provisional choices and unresolved questions so implementation can move without converting exploratory discussion into canon.
+This record preserves the decisions and open questions from the July 12, 2026 forward-path session that produced the full v120.3 pass.
 
-Only Dylan L.R. Pollock may lock project canon. Recommendations, generated documents, branches, and pull requests remain proposals until Dylan accepts them.
+It is a source record, not an independent canon layer. The synchronized human-facing and machine-facing documents are:
+
+- `README.md`
+- `master-plan-v120.3.json`
+
+Only Dylan L.R. Pollock may lock project canon. A branch, document, tool, agent, or pull request remains proposed until Dylan accepts it.
 
 ## Three-part architecture
 
 The Monkey-Head-Project is organized around three principal parts:
 
-1. **Huey Brain** — cognition, orchestration, memory access, operator interaction, model execution, and coordination.
-2. **Huey Body** — physical embodiment, sensing, actuation, power, safety, movement, and environmental interaction.
-3. **Huey Farm** — pooled compute, model hosting, storage, large-model capacity, and scalable support infrastructure.
+1. **Huey Brain** — cognition, orchestration, memory access, operator interaction, model execution, evidence, and coordination.
+2. **Huey Body** — embodiment, sensing, actuation, movement, power, safety, and environmental interaction.
+3. **Huey Farm** — pooled compute, model hosting, shared storage, large-model capacity, and scalable support infrastructure.
 
-These are parts of one project under the Monkey-Head-Project umbrella. Their exact ownership boundaries, trust relationships, communication contracts, and failure behavior remain to be specified.
+Their detailed ownership boundaries, trust relationships, communication contracts, and degraded-operation behavior remain to be defined.
 
 ## Accepted direction
 
 ### PyHuey
 
 - PyHuey GUI is the primary user interface.
-- PyHuey is a core runtime component and is expected to be used extensively.
+- PyHuey is a core runtime component intended for extensive normal use.
 - PyHuey is not merely an optional external cockpit.
-- A recovery-capable CLI path may still exist, but it does not replace PyHuey's primary role.
+- A recovery-capable CLI may remain for diagnostics, automation, and operation when the GUI is unavailable.
 
-This direction conflicts with v120.2 language that describes PyHuey mainly as an external cockpit. The next README and master-plan synchronization pass must correct that wording deliberately.
-
-### Canonical code namespace
-
-- Active HueyOS Python implementation should converge on the `hueyos` namespace.
-- Existing `huey` and `hueyos` implementations should not remain as competing canonical packages.
-- Useful legacy material should be rewritten, merged, or adapted into the chosen architecture.
-- Compatibility layers may exist temporarily, but must have explicit migration and retirement conditions.
-
-### Repository and change management
+### Repository and namespace
 
 - The main Monkey-Head-Project repository remains canonical.
-- Other components, scripts, and branches may be merged into the main repository where that improves coherence.
-- Pull requests may be large, medium, or small. Scope should be determined by coherence and reviewability rather than an arbitrary size limit.
-- Each PR must still state its purpose, boundaries, validation, and unresolved risks.
+- Coherent scripts, programs, and external components may be merged into it.
+- The current Python implementation remains under `huey` during migration.
+- The target canonical namespace is `hueyos`.
+- Useful legacy material should be rewritten and merged deliberately.
+- Competing canonical implementations should not survive the migration.
+- Compatibility shims require explicit retirement conditions.
 
-### Versioning
+### Pull requests and versioning
 
+- Pull requests may be large, medium, or small.
+- Scope is determined by coherence and reviewability rather than an arbitrary line limit.
+- Each PR should state purpose, boundaries, validation, risks, and unresolved follow-up.
 - The project continues to use internal project version numbering.
-- This record uses `v120.3` as a draft alignment revision.
-- A full master-plan v120.3 is not declared complete by this record alone.
 
 ### Logging and failure evidence
 
 - Structured logs should preserve all useful operational information.
-- Logs should include inputs, outputs, models, settings, timing, hardware context, software version, stage transitions, warnings, failures, recovery actions, and artifact references where available.
-- Failure records should be as detailed and attributable as practical.
-- Secrets, credentials, tokens, authentication headers, and private keys must never be written into ordinary logs.
+- Failed runs should still leave detailed attributable records.
+- Secrets, credentials, tokens, authentication headers, private keys, and unredacted secret-bearing configuration must never enter ordinary logs.
 
 ### Testing
 
@@ -73,121 +72,119 @@ The accepted baseline is:
 ### Authority
 
 - Dylan L.R. Pollock is the sole current authority for locking canon.
-- Agents, tools, contributors, and documentation may recommend or stage changes.
-- A decision becomes canonical only when Dylan explicitly accepts it or merges it into the designated canonical record.
+- Agents, tools, contributors, documents, and branches may recommend or stage changes.
+- Canon is established only through Dylan's explicit acceptance or intentional merge into the designated canonical record.
 
-## Active hardware and model direction
+## Hardware and model direction
 
 ### Compute architecture
 
-- Huey architecture should be designed around Intel Core i9-class systems from 12th generation or newer.
-- This is an architectural baseline, not a claim that every support node requires an i9.
-- The exact role of the current prototype versus a polished Huey Brain remains to be locked.
+- Brain-class architecture is based around Intel Core i9 systems from 12th generation or newer.
+- This does not imply that every LabTech or support node requires an i9.
+- The exact boundary between the current prototype and a polished Huey Brain remains open.
 
 ### Model sizing
 
-- Assume large-model use as the normal design target.
-- Medium models are expected only in uncommon fallback, constrained, or specialized situations.
-- Exact parameter ranges, quantization, context requirements, latency targets, and local-versus-API placement remain unresolved.
+- Large-model use is the normal design assumption.
+- Medium models are reserved mainly for uncommon constrained, fallback, or specialized situations.
+- Exact parameter ranges, quantization, context requirements, latency targets, local-versus-API placement, and accelerator memory remain unresolved.
 
 ### Procurement
 
-- Prefer components that are available in the general market.
+- Prefer market-available components.
 - Inexpensive Chinese hardware and supply channels may be used where they provide practical access and acceptable value.
-- Procurement still requires category-specific standards for reliability, documentation, safety, repairability, data handling, and replacement availability.
+- Each hardware category still requires safety, reliability, documentation, repairability, replacement, software-support, data-handling, and total-cost review.
+- Dylan indicated a two-out-of-three decision method, but the three criteria or authorities remain undefined.
 
-## Active Body direction
+## Huey Body
 
-- Huey Body is being reworked.
-- Body work is no longer described only as a distant deferred concept.
-- The present phase of the rework—conceptual, mechanical, electrical, sensor, power, or runtime integration—still requires a dedicated definition.
-- Brain and Body integration must remain bounded by explicit interfaces, safe-stop behavior, and recoverable failure modes.
+- Huey Body is under active rework.
+- It is no longer described only as a distant deferred concept.
+- The exact mechanical, electrical, sensor, power, safety, and runtime scope still requires dedicated definition.
+- Brain and Body integration requires explicit interfaces, safe-stop behavior, operator-visible state, and recoverable failure modes.
 
 ## V1 position
 
-V1 is intentionally not locked yet.
+V1 is intentionally not locked.
 
 The working standard is that V1 must be:
 
 - genuinely useful;
-- clearly under the Monkey-Head-Project umbrella;
-- demonstrable through real operation rather than description alone;
-- defined from the system that is successfully built and validated, not forced prematurely from an incomplete architecture.
+- clearly within the Monkey-Head-Project umbrella;
+- demonstrable through real operation;
+- repeatable enough for its declared purpose;
+- attributable through structured evidence.
+
+The known-MP3-to-structured-log path remains an active foundation proof. v120.3 does not automatically declare that proof to be the entire V1.
 
 Still unresolved:
 
-- who the primary user is;
-- which recurring problem V1 solves;
-- whether V1 requires Brain only, Brain plus Body, or participation from all three parts;
-- what reliability and repetition threshold earns V1 status;
-- whether the current fixture-to-log proof is the V1 itself, a prerequisite, or one subsystem proof among several.
+- the recurring problem V1 solves;
+- who uses it and how often;
+- whether V1 is Brain-only or requires Body or Farm participation;
+- the repetition and reliability threshold;
+- whether the foundation proof is V1, a prerequisite, or one subsystem proof.
 
-## Transcription direction
+## Transcription and fidelity
 
-- `faster-whisper` remains the working transcription engine until evidence supports a different choice.
-- The exact model, compute type, accelerator path, CPU fallback, and fidelity threshold remain open.
-- Transcription must be judged by fidelity, not merely successful execution.
+- `faster-whisper` remains the working engine until evidence supports a different selection.
+- Model, compute type, accelerator path, CPU fallback, and final thresholds remain open.
+- Transcription is judged by fidelity rather than process completion alone.
+- Fidelity will be expressed through categories or tiers.
 
-## Fidelity tiers
+The v120.3 pass uses provisional categories only:
 
-Fidelity will be evaluated through categories or tiers rather than a single vague pass/fail label.
+- failed;
+- recognizable;
+- usable;
+- high fidelity;
+- verified archival.
 
-The final tier names and thresholds are pending Dylan's additional detail. A future definition should account for:
+Dylan will provide the final category detail and thresholds.
 
-- missing content;
-- hallucinated content;
-- wording preservation;
-- names and technical terms;
-- chronology and speaker order;
-- semantic meaning;
-- archival suitability;
-- manual or reference-backed verification.
+## Provider direction
 
-## Provider and cognition path
+- Select API or local cognition providers according to practical fit.
+- Do not bind the architecture prematurely to one provider.
+- Selection must consider capability, quality, cost, privacy, availability, context size, latency, replaceability, and the path toward local sovereignty.
 
-- The API or local cognition provider should be selected according to practical fit.
-- The architecture should not be prematurely bound to a provider without evidence.
-- Provider choice must eventually account for capability, cost, privacy, availability, context size, latency, model quality, and long-term replaceability.
+## Initial implementation limits
 
-## Initial implementation limitations
-
-Until the unresolved architecture is locked, implementation should follow these limits:
-
-1. Maintain one active implementation per capability wherever practical.
-2. Keep experimental systems clearly identified and isolated from canonical runtime behavior.
+1. Maintain one active canonical implementation per capability wherever practical.
+2. Keep experimental systems clearly identified and isolated from normal authority.
 3. Preserve lineage without presenting obsolete code as operational.
-4. Do not merge legacy scripts unchanged merely to retain them; rewrite and integrate them deliberately.
-5. Keep logs exhaustive but secret-safe.
+4. Rewrite and integrate legacy code rather than merging it unchanged.
+5. Keep exhaustive logs secret-safe.
 6. Do not introduce unexplained hardware dependencies.
-7. Require safe-stop and recovery behavior for Body-facing work.
-8. Require explicit interfaces between Brain, Body, and Farm.
-9. Avoid locking V1 completion criteria before usefulness and system participation are defined.
-10. Treat merged documentation as accepted direction only when Dylan intentionally approves it.
+7. Require safe-stop and recovery for Body-facing work.
+8. Require authenticated and observable interfaces between Brain, Body, and Farm.
+9. Separate current reality, accepted direction, unresolved design, and target state.
+10. Do not finalize V1 until usefulness and system participation are defined.
 
-## Unresolved decisions
+## Full-pass result
 
-The next alignment work must answer:
+This source record has now been incorporated into:
 
-1. What exact capabilities and authority belong to Brain, Body, and Farm?
-2. Is Huey one identity spanning all three parts, or is the Brain the identity-bearing authority with Body and Farm as subordinate systems?
-3. Where do memory, models, logs, and canonical state reside?
-4. How do the three parts authenticate, communicate, degrade, disconnect, and recover?
-5. Does HueyOS run across all three parts or primarily orchestrate them from the Brain?
-6. What is the current Brain, and what is the polished target Brain?
-7. Which hardware decisions require two-of-three agreement, and what are the three decision authorities or criteria?
-8. Which Body subsystems are currently being reworked?
-9. What are the final fidelity tiers and measurable thresholds?
-10. What useful recurring function should anchor the eventual V1 declaration?
-11. Which capabilities are active, limited, experimental, paused, or deferred?
-12. What maximum dependency on external services is acceptable?
+- a rewritten v120.3 `README.md`;
+- a new `master-plan-v120.3.json`;
+- a revised Brain / Body / Farm system map;
+- corrected PyHuey core-runtime wording;
+- explicit current `huey` versus target `hueyos` namespace status;
+- a usefulness-led V1 position;
+- provisional fidelity categories;
+- logging, testing, procurement, migration, and canon-authority limits.
 
-## Required synchronization after acceptance
+## Unresolved decisions carried forward
 
-Once Dylan accepts this direction, the next documentation pass should:
-
-- produce a full `master-plan-v120.3.json` that inherits v120.2 lineage and incorporates these decisions;
-- update `README.md` so PyHuey is described as primary GUI and core runtime rather than mainly external tooling;
-- revise the system map around Brain, Body, and Farm;
-- replace premature V1 completion boundaries with an explicit discovery-and-validation position;
-- document the `hueyos` namespace migration plan;
-- define fidelity tiers and hardware-decision rules after Dylan supplies the remaining detail.
+1. Exact Brain, Body, and Farm authority boundaries.
+2. Whether Huey identity spans all three parts or is authoritative in Brain.
+3. Memory, model, log, and canonical-state placement.
+4. Communication, authentication, disconnection, degradation, and recovery contracts.
+5. Whether HueyOS runs across all three parts or orchestrates them primarily from Brain.
+6. Current versus polished Brain boundary.
+7. The three elements in the two-out-of-three hardware rule.
+8. Exact Huey Body rework scope.
+9. Final fidelity tiers and measurable thresholds.
+10. The recurring useful function that anchors V1.
+11. Final active, limited, experimental, paused, and deferred capability categories.
+12. Maximum acceptable dependency on external services.

--- a/docs/architecture/v120.3-forward-path-decision-record.md
+++ b/docs/architecture/v120.3-forward-path-decision-record.md
@@ -1,0 +1,193 @@
+# Forward-Path Decision Record — v120.3 Draft
+
+**Project:** Monkey-Head-Project  
+**Identity:** Huey  
+**Status date:** 2026-07-12  
+**Status:** Draft PR pending Dylan's acceptance  
+**Supersedes:** No accepted master plan. This record extends and challenges selected v120.2 assumptions while the next full master-plan revision is prepared.
+
+## Purpose
+
+This record captures the decisions made during the July 12, 2026 forward-path session. It separates accepted direction from provisional choices and unresolved questions so implementation can move without converting exploratory discussion into canon.
+
+Only Dylan L.R. Pollock may lock project canon. Recommendations, generated documents, branches, and pull requests remain proposals until Dylan accepts them.
+
+## Three-part architecture
+
+The Monkey-Head-Project is organized around three principal parts:
+
+1. **Huey Brain** — cognition, orchestration, memory access, operator interaction, model execution, and coordination.
+2. **Huey Body** — physical embodiment, sensing, actuation, power, safety, movement, and environmental interaction.
+3. **Huey Farm** — pooled compute, model hosting, storage, large-model capacity, and scalable support infrastructure.
+
+These are parts of one project under the Monkey-Head-Project umbrella. Their exact ownership boundaries, trust relationships, communication contracts, and failure behavior remain to be specified.
+
+## Accepted direction
+
+### PyHuey
+
+- PyHuey GUI is the primary user interface.
+- PyHuey is a core runtime component and is expected to be used extensively.
+- PyHuey is not merely an optional external cockpit.
+- A recovery-capable CLI path may still exist, but it does not replace PyHuey's primary role.
+
+This direction conflicts with v120.2 language that describes PyHuey mainly as an external cockpit. The next README and master-plan synchronization pass must correct that wording deliberately.
+
+### Canonical code namespace
+
+- Active HueyOS Python implementation should converge on the `hueyos` namespace.
+- Existing `huey` and `hueyos` implementations should not remain as competing canonical packages.
+- Useful legacy material should be rewritten, merged, or adapted into the chosen architecture.
+- Compatibility layers may exist temporarily, but must have explicit migration and retirement conditions.
+
+### Repository and change management
+
+- The main Monkey-Head-Project repository remains canonical.
+- Other components, scripts, and branches may be merged into the main repository where that improves coherence.
+- Pull requests may be large, medium, or small. Scope should be determined by coherence and reviewability rather than an arbitrary size limit.
+- Each PR must still state its purpose, boundaries, validation, and unresolved risks.
+
+### Versioning
+
+- The project continues to use internal project version numbering.
+- This record uses `v120.3` as a draft alignment revision.
+- A full master-plan v120.3 is not declared complete by this record alone.
+
+### Logging and failure evidence
+
+- Structured logs should preserve all useful operational information.
+- Logs should include inputs, outputs, models, settings, timing, hardware context, software version, stage transitions, warnings, failures, recovery actions, and artifact references where available.
+- Failure records should be as detailed and attributable as practical.
+- Secrets, credentials, tokens, authentication headers, and private keys must never be written into ordinary logs.
+
+### Testing
+
+The accepted baseline is:
+
+- unit tests;
+- mocked integration tests in CI;
+- fixture-based fidelity evaluation;
+- manually invoked live end-to-end tests;
+- explicit failure-path tests.
+
+### Authority
+
+- Dylan L.R. Pollock is the sole current authority for locking canon.
+- Agents, tools, contributors, and documentation may recommend or stage changes.
+- A decision becomes canonical only when Dylan explicitly accepts it or merges it into the designated canonical record.
+
+## Active hardware and model direction
+
+### Compute architecture
+
+- Huey architecture should be designed around Intel Core i9-class systems from 12th generation or newer.
+- This is an architectural baseline, not a claim that every support node requires an i9.
+- The exact role of the current prototype versus a polished Huey Brain remains to be locked.
+
+### Model sizing
+
+- Assume large-model use as the normal design target.
+- Medium models are expected only in uncommon fallback, constrained, or specialized situations.
+- Exact parameter ranges, quantization, context requirements, latency targets, and local-versus-API placement remain unresolved.
+
+### Procurement
+
+- Prefer components that are available in the general market.
+- Inexpensive Chinese hardware and supply channels may be used where they provide practical access and acceptable value.
+- Procurement still requires category-specific standards for reliability, documentation, safety, repairability, data handling, and replacement availability.
+
+## Active Body direction
+
+- Huey Body is being reworked.
+- Body work is no longer described only as a distant deferred concept.
+- The present phase of the rework—conceptual, mechanical, electrical, sensor, power, or runtime integration—still requires a dedicated definition.
+- Brain and Body integration must remain bounded by explicit interfaces, safe-stop behavior, and recoverable failure modes.
+
+## V1 position
+
+V1 is intentionally not locked yet.
+
+The working standard is that V1 must be:
+
+- genuinely useful;
+- clearly under the Monkey-Head-Project umbrella;
+- demonstrable through real operation rather than description alone;
+- defined from the system that is successfully built and validated, not forced prematurely from an incomplete architecture.
+
+Still unresolved:
+
+- who the primary user is;
+- which recurring problem V1 solves;
+- whether V1 requires Brain only, Brain plus Body, or participation from all three parts;
+- what reliability and repetition threshold earns V1 status;
+- whether the current fixture-to-log proof is the V1 itself, a prerequisite, or one subsystem proof among several.
+
+## Transcription direction
+
+- `faster-whisper` remains the working transcription engine until evidence supports a different choice.
+- The exact model, compute type, accelerator path, CPU fallback, and fidelity threshold remain open.
+- Transcription must be judged by fidelity, not merely successful execution.
+
+## Fidelity tiers
+
+Fidelity will be evaluated through categories or tiers rather than a single vague pass/fail label.
+
+The final tier names and thresholds are pending Dylan's additional detail. A future definition should account for:
+
+- missing content;
+- hallucinated content;
+- wording preservation;
+- names and technical terms;
+- chronology and speaker order;
+- semantic meaning;
+- archival suitability;
+- manual or reference-backed verification.
+
+## Provider and cognition path
+
+- The API or local cognition provider should be selected according to practical fit.
+- The architecture should not be prematurely bound to a provider without evidence.
+- Provider choice must eventually account for capability, cost, privacy, availability, context size, latency, model quality, and long-term replaceability.
+
+## Initial implementation limitations
+
+Until the unresolved architecture is locked, implementation should follow these limits:
+
+1. Maintain one active implementation per capability wherever practical.
+2. Keep experimental systems clearly identified and isolated from canonical runtime behavior.
+3. Preserve lineage without presenting obsolete code as operational.
+4. Do not merge legacy scripts unchanged merely to retain them; rewrite and integrate them deliberately.
+5. Keep logs exhaustive but secret-safe.
+6. Do not introduce unexplained hardware dependencies.
+7. Require safe-stop and recovery behavior for Body-facing work.
+8. Require explicit interfaces between Brain, Body, and Farm.
+9. Avoid locking V1 completion criteria before usefulness and system participation are defined.
+10. Treat merged documentation as accepted direction only when Dylan intentionally approves it.
+
+## Unresolved decisions
+
+The next alignment work must answer:
+
+1. What exact capabilities and authority belong to Brain, Body, and Farm?
+2. Is Huey one identity spanning all three parts, or is the Brain the identity-bearing authority with Body and Farm as subordinate systems?
+3. Where do memory, models, logs, and canonical state reside?
+4. How do the three parts authenticate, communicate, degrade, disconnect, and recover?
+5. Does HueyOS run across all three parts or primarily orchestrate them from the Brain?
+6. What is the current Brain, and what is the polished target Brain?
+7. Which hardware decisions require two-of-three agreement, and what are the three decision authorities or criteria?
+8. Which Body subsystems are currently being reworked?
+9. What are the final fidelity tiers and measurable thresholds?
+10. What useful recurring function should anchor the eventual V1 declaration?
+11. Which capabilities are active, limited, experimental, paused, or deferred?
+12. What maximum dependency on external services is acceptable?
+
+## Required synchronization after acceptance
+
+Once Dylan accepts this direction, the next documentation pass should:
+
+- produce a full `master-plan-v120.3.json` that inherits v120.2 lineage and incorporates these decisions;
+- update `README.md` so PyHuey is described as primary GUI and core runtime rather than mainly external tooling;
+- revise the system map around Brain, Body, and Farm;
+- replace premature V1 completion boundaries with an explicit discovery-and-validation position;
+- document the `hueyos` namespace migration plan;
+- define fidelity tiers and hardware-decision rules after Dylan supplies the remaining detail.

--- a/master-plan-v120.3.json
+++ b/master-plan-v120.3.json
@@ -1,0 +1,411 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "project": "Monkey-Head-Project",
+  "ai_identity": "Huey",
+  "version": "v120.3",
+  "schema_version": 120.3,
+  "schema_contract_version": "master_plan_schema_v120.3",
+  "document_kind": "machine_facing_master_plan",
+  "status_date": "2026-07-12",
+  "created_by": "Dylan L.R. Pollock with Atlas continuity support",
+  "supersedes": "master-plan-v120.2.json",
+  "status": "proposed_in_pr",
+  "description": "Master Plan v120.3 reorganizes the active direction around Huey Brain, Huey Body, and Huey Farm; establishes PyHuey as the primary GUI and a core runtime component; adopts hueyos as the target canonical Python namespace; keeps V1 definition open until a genuinely useful system is demonstrated; and introduces explicit limits for fidelity, logging, testing, procurement, migration, and canon authority.",
+  "source_basis": {
+    "primary_previous_master_plan": "master-plan-v120.2.json",
+    "forward_path_record": "docs/architecture/v120.3-forward-path-decision-record.md",
+    "current_session_date": "2026-07-12",
+    "explicit_decisions": [
+      "The project is organized around Huey Brain, Huey Body, and Huey Farm.",
+      "PyHuey GUI is the primary interface and a core runtime component intended for extensive use.",
+      "The target canonical Python namespace is hueyos; useful huey and legacy material is to be rewritten and merged deliberately.",
+      "The main Monkey-Head-Project repository remains canonical and may absorb coherent external components.",
+      "Project releases continue to use internal version numbering.",
+      "Structured records should preserve all useful operational information while excluding secrets.",
+      "Transcription is judged by fidelity and will use categories or tiers.",
+      "Testing includes unit tests, mocked integration tests in CI, fixture fidelity evaluation, manual live end-to-end tests, and detailed failure-path tests.",
+      "The architecture assumes large-model use normally and medium-model use only in uncommon constrained or specialized cases.",
+      "Hardware architecture is based around Intel Core i9-class systems from 12th generation or newer.",
+      "Market-available components are preferred; inexpensive Chinese hardware and supply channels may be used when category-specific standards are met.",
+      "Huey Body is under active rework.",
+      "Only Dylan L.R. Pollock may lock project canon."
+    ],
+    "source_priority": [
+      "Dylan's explicit current-session decisions",
+      "newest accepted machine-facing master plan",
+      "merged repository and implementation state",
+      "README and technical documentation",
+      "older plans, transcripts, and archives as lineage"
+    ],
+    "inheritance_policy": "Carry forward v120.2 implementation evidence and lineage unless v120.3 explicitly changes the direction. Do not present target-state decisions as already implemented."
+  },
+  "truth_model": {
+    "current_reality": "Observed hardware, merged code, working commands, and directly verified behavior.",
+    "accepted_direction": "Architecture Dylan has selected for implementation, even when migration is incomplete.",
+    "provisional_choice": "A working selection that remains replaceable through evidence.",
+    "unresolved": "A decision intentionally left open pending additional detail or testing.",
+    "target_state": "A longer-term capability whose implementation depends on resources, maturity, or later validation.",
+    "historical_lineage": "Earlier systems and decisions retained for continuity without overriding current direction."
+  },
+  "canon": {
+    "authority": "Dylan L.R. Pollock",
+    "rule": "No agent, tool, contributor, generated document, branch, or pull request may independently lock canon.",
+    "acceptance_mechanisms": [
+      "Dylan explicitly states acceptance",
+      "Dylan intentionally merges a designated canonical update"
+    ],
+    "machine_facing_source": "master-plan-v120.3.json after acceptance",
+    "human_facing_source": "README.md aligned to v120.3",
+    "conflict_rule": "Current explicit decisions override older documentation; implementation reality must still be labelled separately from accepted direction."
+  },
+  "three_part_architecture": {
+    "decision": "Organize the system around Huey Brain, Huey Body, and Huey Farm.",
+    "huey_brain": {
+      "role": "Identity-bearing cognition and orchestration centre.",
+      "responsibilities": [
+        "PyHuey operator interaction",
+        "cognition and model selection",
+        "workflow orchestration",
+        "memory access and state coordination",
+        "structured evidence and audit records",
+        "coordination with Body and Farm"
+      ],
+      "current_platform": {
+        "status": "active_prototype",
+        "system": "Custom Intel Core i9-12900K workstation",
+        "purpose": "Primary operator workstation, architecture test bed, and proof platform",
+        "note": "The exact boundary between the current prototype and a polished Huey Brain remains open."
+      },
+      "target_hardware_rule": "Brain architecture is based around Intel Core i9-class processors from 12th generation or newer."
+    },
+    "huey_body": {
+      "role": "Physical embodiment and environmental interface.",
+      "responsibilities": [
+        "sensing",
+        "actuation",
+        "movement",
+        "power and cooling integration",
+        "physical safety",
+        "recoverable interaction with the environment"
+      ],
+      "status": "active_rework",
+      "current_boundary": "The exact mechanical, electrical, sensor, power, and runtime scope will be documented as the rework is clarified.",
+      "integration_rule": "Brain and Body integration requires explicit interfaces, operator-visible state, safe-stop behavior, and recovery procedures."
+    },
+    "huey_farm": {
+      "role": "Scalable compute, model, storage, and support infrastructure.",
+      "responsibilities": [
+        "large-model hosting",
+        "pooled accelerator capacity",
+        "shared storage and artifacts",
+        "compute expansion",
+        "backup and recovery support where explicitly assigned"
+      ],
+      "status": "target_state_funding_dependent",
+      "planning_scale": "Approximately 80 GB pooled local VRAM remains a planning reference, not a locked procurement specification.",
+      "procurement_rule": "Refresh model, accelerator, power, cooling, software, and cost comparisons when funding makes acquisition actionable."
+    },
+    "unresolved_boundaries": [
+      "Whether Huey identity spans all three parts or is embodied authoritatively by Brain",
+      "Where canonical memory, models, logs, and state reside",
+      "Communication and authentication protocols",
+      "Disconnected and degraded operation",
+      "Farm authority versus service-only behavior",
+      "Whether HueyOS is installed across all three parts or orchestrates them primarily from Brain"
+    ]
+  },
+  "pyhuey": {
+    "accepted_role": "Primary GUI and core runtime component",
+    "use_expectation": "Extensive normal operation rather than optional demonstration use",
+    "current_reality": [
+      "PyHuey exists as a standalone application and an embedded connector path.",
+      "The current Monkey-Head-Project implementation still contains external-cockpit wording and incomplete integration assumptions from v120.2."
+    ],
+    "direction": [
+      "Move primary operator workflows into PyHuey.",
+      "Expose fixed, attributable, reviewable HueyOS capabilities through PyHuey.",
+      "Retain a recovery-capable CLI for diagnostics, automation, and operation when the GUI is unavailable.",
+      "Avoid duplicating PyHuey with Command Center unless Command Center develops a distinct validated role."
+    ],
+    "acceptance_evidence": [
+      "Reliable launch and shutdown",
+      "Observable workflow state",
+      "Secret-safe provider configuration",
+      "Detailed structured logs",
+      "Recoverable errors",
+      "Tests for core operator workflows"
+    ]
+  },
+  "namespace_and_repository": {
+    "canonical_repository": "DylanLRPollock/Monkey-Head-Project",
+    "repository_rule": "The main repository remains canonical and may merge coherent external scripts, programs, and components.",
+    "current_python_namespace": "huey",
+    "target_python_namespace": "hueyos",
+    "migration_status": "accepted_direction_not_complete",
+    "migration_rules": [
+      "Inventory every active huey package and import path before moving it.",
+      "Choose one destination for each capability; do not preserve competing canonical implementations.",
+      "Rewrite and integrate useful legacy code rather than copying it unchanged.",
+      "Use compatibility shims only when required and give each shim an explicit retirement condition.",
+      "Update tests, scripts, entry points, docs, packaging metadata, and PyHuey connectors together.",
+      "Do not claim the hueyos migration is complete until imports, commands, tests, and documentation agree."
+    ],
+    "pull_request_policy": {
+      "size": "large_medium_or_small",
+      "selection_rule": "Use the largest coherent scope that remains understandable and reviewable.",
+      "required_content": [
+        "purpose",
+        "boundaries",
+        "validation",
+        "known risks",
+        "unresolved follow-up"
+      ]
+    }
+  },
+  "hardware_direction": {
+    "architecture_baseline": "Intel Core i9-class, 12th generation or newer",
+    "scope": "Primary Brain-class architecture; support nodes do not automatically require the same class.",
+    "model_assumption": {
+      "normal": "large models",
+      "rare": "medium models for constrained, fallback, or specialized use",
+      "unresolved": [
+        "parameter ranges",
+        "quantization policy",
+        "minimum context size",
+        "latency targets",
+        "local versus API placement",
+        "minimum accelerator memory"
+      ]
+    },
+    "procurement": {
+      "market_rule": "Prefer parts and systems available through ordinary market channels.",
+      "cost_rule": "Chinese manufacturers and marketplaces may be relied upon for inexpensive components when practical.",
+      "category_checks": [
+        "electrical and physical safety",
+        "reliability",
+        "documentation",
+        "repairability",
+        "replacement availability",
+        "driver and software support",
+        "data handling and network trust",
+        "total delivered cost"
+      ],
+      "two_of_three_rule": {
+        "status": "unresolved",
+        "note": "Dylan indicated a two-out-of-three approach but the three criteria or authorities still require definition."
+      }
+    }
+  },
+  "v1_position": {
+    "status": "definition_open",
+    "decision": "Do not lock V1 prematurely. Define it from a system that proves genuinely useful operation under the Monkey-Head-Project umbrella.",
+    "minimum_characteristics": [
+      "useful",
+      "demonstrable",
+      "repeatable enough for its declared purpose",
+      "attributable through structured evidence",
+      "clearly part of the Monkey-Head-Project"
+    ],
+    "foundation_proof": {
+      "path": "known MP3 fixture -> media preparation -> local transcription -> API-backed response -> structured log",
+      "status": "active_foundation_proof",
+      "interpretation": "This remains valuable and should be completed, but v120.3 does not automatically declare it to be the whole of V1."
+    },
+    "open_questions": [
+      "Which recurring problem V1 solves",
+      "Who uses it and how often",
+      "Whether V1 is Brain-only or requires Body or Farm participation",
+      "What repetition and reliability thresholds earn the declaration",
+      "Whether the foundation proof is V1, a prerequisite, or one subsystem proof"
+    ]
+  },
+  "transcription_and_fidelity": {
+    "working_engine": "faster-whisper",
+    "engine_status": "provisional_until_evidence_selects_or_replaces_it",
+    "selection_open": [
+      "model",
+      "compute type",
+      "CPU path",
+      "accelerator path",
+      "fallback behavior"
+    ],
+    "primary_quality_rule": "Judge transcription by fidelity, not by successful process completion alone.",
+    "tier_framework": {
+      "status": "framework_accepted_thresholds_open",
+      "dimensions": [
+        "missing content",
+        "hallucinated content",
+        "wording preservation",
+        "names and technical terms",
+        "chronology",
+        "speaker order",
+        "semantic meaning",
+        "archival suitability",
+        "manual or reference-backed verification"
+      ],
+      "provisional_categories": [
+        "failed",
+        "recognizable",
+        "usable",
+        "high_fidelity",
+        "verified_archival"
+      ],
+      "rule": "Category names may be retained or replaced after Dylan supplies the intended tier details; numeric thresholds are not locked in v120.3."
+    }
+  },
+  "cognition_provider": {
+    "status": "fit_based_selection",
+    "rule": "Use the API or local provider that best fits the task and architecture; do not bind the system prematurely to one provider.",
+    "selection_criteria": [
+      "capability",
+      "quality",
+      "cost",
+      "privacy",
+      "availability",
+      "context size",
+      "latency",
+      "replaceability",
+      "local sovereignty path"
+    ]
+  },
+  "logging": {
+    "rule": "Preserve all useful operational information while excluding secrets and unnecessary private data.",
+    "required_fields": [
+      "run identifier",
+      "UTC timestamps",
+      "initiating interface and operator action",
+      "input identity and checksum where applicable",
+      "stage transitions",
+      "models and providers",
+      "configuration and relevant environment",
+      "hardware and device path",
+      "timing and resource observations",
+      "outputs and artifact references",
+      "warnings",
+      "errors and stack context",
+      "recovery actions",
+      "software version and commit",
+      "final status"
+    ],
+    "prohibited_fields": [
+      "API keys",
+      "tokens",
+      "passwords",
+      "private keys",
+      "authentication headers",
+      "unredacted secret-bearing configuration"
+    ],
+    "failure_rule": "A failed run should still leave the most complete attributable record possible."
+  },
+  "testing": {
+    "baseline": [
+      "unit tests",
+      "mocked integration tests in CI",
+      "fixture-based fidelity evaluation",
+      "manual live end-to-end tests",
+      "explicit failure-path tests"
+    ],
+    "failure_detail": "Tests should expose stage, input, environment, expected behavior, observed behavior, error context, and recovery result where applicable.",
+    "release_rule": "Documentation-only alignment may merge without runtime tests; implementation claims require checks appropriate to the changed capability."
+  },
+  "implementation_limits": [
+    "Maintain one active canonical implementation per capability wherever practical.",
+    "Mark experimental systems clearly and isolate them from normal authority.",
+    "Preserve lineage without presenting obsolete code as operational.",
+    "Rewrite and merge legacy code deliberately rather than importing it unchanged.",
+    "Keep exhaustive logs secret-safe.",
+    "Do not introduce unexplained hardware dependencies.",
+    "Require explicit interfaces, safe-stop, and recovery for Body-facing work.",
+    "Require authenticated and observable interfaces between Brain, Body, and Farm.",
+    "Keep current reality separate from accepted direction and target state.",
+    "Do not finalize V1 until usefulness and participation are defined."
+  ],
+  "active_labtech": [
+    {
+      "name": "ASUS FX505DT",
+      "classification": "LabTech",
+      "baseline": "Debian 14 Forky; 32 GB DDR4",
+      "role": "Mobile lab, development, transcription experimentation, and support"
+    },
+    {
+      "name": "Lenovo Legion Go",
+      "classification": "LabTech",
+      "baseline": "Windows 11",
+      "role": "Windows feature and compatibility testing"
+    },
+    {
+      "name": "Briefcase",
+      "classification": "HueyTech",
+      "role": "LTE-capable field terminal for reachability, documentation, diagnostics, and recovery",
+      "authority": "Limited until authentication, audit, failure handling, and revocation are proven"
+    }
+  ],
+  "hims": {
+    "current_reality": "The append-only HIMS foundation exists under src/huey/messaging.",
+    "current_role": "Foundation-stage messages, events, local records, and optional tracing.",
+    "authority_status": "not_controlling_runtime",
+    "future_rule": "Routing, execution, refusal, recovery, and governance authority require separate explicit validation."
+  },
+  "command_center": {
+    "status": "experimental_interface_sandbox",
+    "rule": "May contribute validated interface concepts, but must not duplicate PyHuey or receive credentials and control authority without a distinct tested role."
+  },
+  "documentation_layers": {
+    "master_plan": "Machine-facing canon, reasoning, boundaries, and status.",
+    "readme": "Professional human-facing orientation and current route.",
+    "technical_docs": "Implementation detail, setup, architecture, runbooks, and audits.",
+    "governance": "Constitution, legitimacy, offices, and lawful authority.",
+    "website": "Public-facing coherence layer.",
+    "archives": "Lineage and continuity records that do not automatically override current decisions."
+  },
+  "work_program": {
+    "immediate": [
+      "Complete v120.3 documentation synchronization.",
+      "Inventory the huey to hueyos namespace migration.",
+      "Define the present Huey Body rework scope.",
+      "Complete the fixture-to-log foundation proof through PyHuey with CLI recovery.",
+      "Define fidelity tiers with measurable acceptance evidence.",
+      "Define Brain, Body, and Farm interfaces and trust boundaries."
+    ],
+    "next": [
+      "Migrate capabilities into hueyos in coherent PRs.",
+      "Stabilize PyHuey core workflows and logging.",
+      "Choose transcription and cognition paths from measured evidence.",
+      "Define the two-of-three hardware decision method.",
+      "Determine the useful recurring function that anchors V1."
+    ],
+    "later": [
+      "Expand live input and embodied interaction after foundation interfaces are stable.",
+      "Procure and validate Farm capacity when funding and evidence align.",
+      "Advance HIMS and constitutional governance authority through separate validated stages."
+    ]
+  },
+  "unresolved_decisions": [
+    "Final V1 definition",
+    "Exact Brain, Body, and Farm authority boundaries",
+    "Identity distribution across the three parts",
+    "Memory and canonical-state placement",
+    "Communication and authentication contracts",
+    "Current versus polished Brain boundary",
+    "Exact Body rework scope",
+    "Fidelity tier names and thresholds",
+    "Transcription model and compute path",
+    "Cognition provider and model",
+    "Large-model operational definition",
+    "Two-of-three hardware decision rule",
+    "Maximum acceptable external-service dependency",
+    "Capabilities classified as active, limited, experimental, paused, or deferred"
+  ],
+  "change_log_v120_3": [
+    "Reframed the architecture around Brain, Body, and Farm.",
+    "Promoted PyHuey from external cockpit language to primary GUI and core runtime direction.",
+    "Selected hueyos as the target namespace while preserving the truth that src/huey remains current implementation.",
+    "Changed V1 from a prematurely fixed fixture proof to a usefulness-led declaration that remains open.",
+    "Retained the fixture-to-log path as an active foundation proof.",
+    "Added large-model-first and i9 12th-generation-or-newer architecture direction.",
+    "Added market and Chinese procurement posture with category-specific safeguards.",
+    "Reopened Huey Body as an active rework with bounded safety and integration requirements.",
+    "Expanded logging, testing, fidelity, PR-scope, and canon-authority rules.",
+    "Separated accepted direction from current implementation and unresolved decisions."
+  ]
+}


### PR DESCRIPTION
## What changed

This PR now contains the full v120.3 documentation pass:

- adds `master-plan-v120.3.json` as the proposed machine-facing plan
- rewrites `README.md` to align with v120.3
- retains and updates the forward-path decision record as the session source document
- reorganizes the architecture around **Huey Brain**, **Huey Body**, and **Huey Farm**
- establishes **PyHuey** as the primary GUI and a core runtime component
- adopts `hueyos` as the target canonical Python namespace while accurately recording that `src/huey` remains the current implementation
- keeps the final V1 definition open until the project demonstrates a genuinely useful, attributable, repeatable system
- retains the known-MP3-to-structured-log path as an active foundation proof rather than automatically declaring it to be the whole of V1
- records the i